### PR TITLE
Wrong --host example

### DIFF
--- a/source/reference/mongoimport.txt
+++ b/source/reference/mongoimport.txt
@@ -64,7 +64,7 @@ Options
 
    .. code-block:: sh
 
-      --host repl0 mongo0.example.net,mongo0.example.net,27018,mongo1.example.net,mongo2.example.net
+      --host repl0/mongo0.example.net,mongo0.example.net,27018,mongo1.example.net,mongo2.example.net
 
    You can always connect directly to a single MongoDB instance by
    specifying the host and port number directly.


### PR DESCRIPTION
The example on how to use a replica set was missing a slash.
