### PR TITLE
Slight change to description of $ifNull expression

### DIFF
--- a/source/reference/aggregation.txt
+++ b/source/reference/aggregation.txt
@@ -877,7 +877,7 @@ Multi-Expressions
 .. expression:: $ifNull
 
    Takes an array with two expressions. :expression:`$ifNull` returns
-   the first expression if it evaluates to a non-false
+   the first expression if it evaluates to a non-null
    value. Otherwise, :expression:`$ifNull` returns the second
    expression’s value.
 


### PR DESCRIPTION
The first argument is returned if non null, not if non false.
