### PR TITLE
SERVER-6131 Correct description of behavior when $unwind is applied to a...

### DIFF
--- a/source/reference/aggregation.txt
+++ b/source/reference/aggregation.txt
@@ -406,8 +406,9 @@ The current pipeline operators are:
         not an array, :mongodb:func:`aggregate()` generates an error.
 
       - If you specify a target field for :pipeline:`$unwind` that
-        holds an empty array (``[]``), then the document passes
-        through unchanged.
+        holds an empty array (``[]``), then that field is removed
+        from the result while all other fields are passed through
+        unchanged.
 
 .. pipeline:: $group
 


### PR DESCRIPTION
...n empty array.  (The specified field is dropped from the result.)
