### PR TITLE
Added an example for an aggregate key as this was not clear.

### DIFF
--- a/source/reference/aggregation.txt
+++ b/source/reference/aggregation.txt
@@ -423,6 +423,10 @@ The current pipeline operators are:
    a single field from the documents in the pipeline, a previously computed
    value, or an aggregate key made up from several incoming fields.
 
+   .. note::
+
+      An aggregate key takes the format: ``{myKeyName: { author:true, myOtherField:true , YetAnotherField:true}}``.
+
    Every group expression must specify an ``_id`` field.
    You may specify the ``_id`` field as a dotted
    field path reference, a document with multiple fields enclosed in


### PR DESCRIPTION
Grouping over multiple fields is a clear use case for many people but this is not shown in any examples here and the format required for the aggregate key is inconsistent (you do not specify $name but simply name) so adding an example would probably save a few people some frustration, esp. those not coming from a background of using the previous collection.group method.
