### PR TITLE
typo correction c/mogno/mongo/

### DIFF
--- a/source/reference/commands.txt
+++ b/source/reference/commands.txt
@@ -471,7 +471,7 @@ Aggregation
    .. seealso:: ":func:`mapReduce()`" and ":term:`map-reduce`."
 
       Also, the ":wiki:`MapReduce` page, provides a greater overview
-      of MognoDB's map-reduce functionality. Consider the
+      of MongoDB's map-reduce functionality. Consider the
       ":wiki:`Simple application <Aggregation>`" support for basic
       aggregation operations and ":doc:`/applications/aggregation`"
       for a more flexible approach to data aggregation in MongoDB.

--- a/source/reference/configuration-options.txt
+++ b/source/reference/configuration-options.txt
@@ -529,7 +529,7 @@ Settings
 
    *Default:* false
 
-   When set to ``true``, :program:`mognod` returns diagnostic system
+   When set to ``true``, :program:`mongod` returns diagnostic system
    information regarding the page size, the number of physical pages,
    and the number of available physical pages to standard output.
 

--- a/source/reference/javascript.txt
+++ b/source/reference/javascript.txt
@@ -667,7 +667,7 @@ Data Aggregation
                    ``_id`` field.
 
    .. seealso:: :term:`map-reduce`, provides a greater overview
-      of MognoDB's map-reduce functionality.
+      of MongoDB's map-reduce functionality.
 
       Also consider ":doc:`/applications/aggregation`" for a more
       flexible approach to data aggregation in MongoDB, and the
@@ -2112,7 +2112,7 @@ These functions are accessible in the shell but exist to support other
 functionality in the environment. Do not call these functions
 directly.
 
-.. function:: _startMognoProgram()
+.. function:: _startMongoProgram()
 
    For internal use.
 

--- a/source/reference/mongod.txt
+++ b/source/reference/mongod.txt
@@ -178,7 +178,7 @@ Options
 .. option:: --dbpath <path>
 
    Specify a directory for the :program:`mongod` instance to store its
-   data. Typical locations include: ``/srv/mognodb``,
+   data. Typical locations include: ``/srv/mongodb``,
    ``/var/lib/mongodb`` or ``/opt/mongodb``
 
    Unless specified, :program:`mongod` will look for data files in the

--- a/source/reference/server-status.txt
+++ b/source/reference/server-status.txt
@@ -429,7 +429,7 @@ mem
 .. status:: mem.mapped
 
    The value of :status:`mem.mapped` provides the amount of mapped memory by
-   the database. Because MognoDB uses memory-mapped files, this value
+   the database. Because MongoDB uses memory-mapped files, this value
    is likely to be to be roughly equivalent to the total size of your
    database or databases.
 

--- a/source/use-cases/product-catalog.txt
+++ b/source/use-cases/product-catalog.txt
@@ -16,7 +16,7 @@ Problem
 
 Product catalogs must have the capacity to store many differed types
 of objects with different sets of attributes. These kinds of data
-collections are quite compatible with MognoDB's data model, but many
+collections are quite compatible with MongoDB's data model, but many
 important considerations and design decisions remain.
 
 Solution


### PR DESCRIPTION
There is one instance which I thought might be an intentional typo but I checked the source code and the phrase was spelled correctly in the source, misspelled in the doc.
