### PR TITLE
fix multiple broken URLs to wiki, github and gnu.org

### DIFF
--- a/source/about.txt
+++ b/source/about.txt
@@ -16,7 +16,7 @@ pages <>` for more information about MongoDB:
 
 - :wiki:`Introduction`
 - :wiki:`Philosophy`
-- :wiki:`Features`
+.. - :wiki:`Features`
 - :wiki:`About`
 
 If you want to download MongoDB, see the `downloads page

--- a/source/applications/database-references.txt
+++ b/source/applications/database-references.txt
@@ -173,8 +173,8 @@ Support
    for interacting with DBRefs.
 
 **Ruby**
-   The Ruby Driver supports DBRefs using the :api:`DBRef class </ruby/current/classes/XGen/Mongo/Driver/DBRef.html>`
-   and the :api:`deference method <ruby/current/classes/XGen/Mongo/Driver/DB.html#M000236>`.
+   The Ruby Driver supports DBRefs using the :api:`DBRef class </ruby/current/BSON/DBRef.html>`
+   and the :api:`deference method </ruby/current/Mongo/DB.html#dereference>`.
 
 Use
 ~~~

--- a/source/applications/drivers.txt
+++ b/source/applications/drivers.txt
@@ -16,7 +16,7 @@ information about the MongoDB wiki :wiki:`drivers <Drivers>` page:
 - PHP (:wiki:`wiki <PHP+Language+Center>`, `docs <http://php.net/mongo/>`_)
 - Perl (:wiki:`wiki <Perl+Language+Center>`, :api:`docs <perl/current/>`)
 - Java (:wiki:`wiki <Java+Language+Center>`, :api:`docs <java/current>`)
-- Scala (:wiki:`wiki <Scaa+Language+Center>`, :api:`docs <scala/casbah/current/>`)
+- Scala (:wiki:`wiki <Scala+Language+Center>`, :api:`docs <scala/casbah/current/>`)
 - C# (:wiki:`wiki <CSharp+Language+Center>`, :api:`docs <csharp/current/>`)
 - C (:wiki:`wiki <C+Language+Center>`, :api:`docs <c/current/>`)
 - C++ (`wiki <http://mongodb.org/pages/viewpage.action?pageId=133409>`_, :api:`docs <cplusplus/current/>`)

--- a/source/index.txt
+++ b/source/index.txt
@@ -136,7 +136,7 @@ MongoDB. The following pages from the wiki are especially useful:
         - :wiki:`Quickstart`
         - :wiki:`Introduction`
         - :wiki:`Downloads`
-        - :wiki:`Features`
+..        - :wiki:`Features`
         - :wiki:`SQL to MongoDB Mapping <SQL+to+Mongo+Mapping+Chart>`
 
    - :wiki:`Developer Documentation <Developer+Zone>`
@@ -165,7 +165,7 @@ MongoDB. The following pages from the wiki are especially useful:
 
        - :wiki:`Components`
        - :wiki:`Journaling`
-       - :wiki:`Production Notes`
+       - :wiki:`Production Notes <Production+Notes>`
        - :wiki:`Replication`
        - :wiki:`Sharding`
        - :wiki:`Monitoring and Diagnostics <Monitoring+and+Diagnostics>`

--- a/source/reference/glossary.txt
+++ b/source/reference/glossary.txt
@@ -273,7 +273,7 @@ Glossary
    index
       A data structure that optimizes queries.
 
-      .. seealso:: The ":wiki:`Indexing`" wiki page.
+      .. seealso:: The ":wiki:`Indexes`" wiki page.
 
       .. STUB ":doc:`/core/indexing`"
 
@@ -284,7 +284,7 @@ Glossary
    compound index
       An :term:`index` consisting of two or more keys.
 
-      .. seealso:: The ":wiki:`Indexing`" wiki page.
+      .. seealso:: The ":wiki:`Indexes`" wiki page.
 
       .. STUB ":doc:`/core/indexing`"
 

--- a/source/tutorial/deploy-replica-set.txt
+++ b/source/tutorial/deploy-replica-set.txt
@@ -118,11 +118,11 @@ See the documentation of the following shell functions for more
 information: :func:`rs.initiate()`, :func:`rs.conf()`,
 :func:`rs.reconfig()` and :func:`rs.add()`.
 
-.. [#screen] `GNU Screen <http://www.gnu.org/screen/>`_ is packaged as
+.. [#screen] `GNU Screen <http://www.gnu.org/software/screen/>`_ is packaged as
    ``screen`` on Debian-based, Fedira/Red Hat-based, and Arch Linux.
 
 .. seealso:: You may also consider the "`simple setup script
-   <https://github.com/mongodb/mongo-snippets/blob/master/replication/simple-setup.Pu>`_"
+   <https://github.com/mongodb/mongo-snippets/blob/master/replication/simple-setup.py>`_"
    as an example of a basic automatically configured replica set.
 
 Production Replica Set


### PR DESCRIPTION
several link fixes, primarily typos in links to wiki pages or renames due to wiki pages renames.
Commented out links to "Features" in wiki, could not find relevant replacement page.
corrected link to github and gnu.org
