### PR TITLE
Implement custom 404 (and 401,403,410) pages for docs site

### DIFF
--- a/source/.htaccess
+++ b/source/.htaccess
@@ -1,0 +1,5 @@
+# Note: this must be manually copied, sphinx does not process it
+ErrorDocument 401 /manual/meta/401.html
+ErrorDocument 403 /manual/meta/403.html
+ErrorDocument 404 /manual/meta/404.html
+ErrorDocument 410 /manual/meta/410.html

--- a/source/meta/401.txt
+++ b/source/meta/401.txt
@@ -1,0 +1,7 @@
+:orphan:
+
+=======================
+Authentication Required
+=======================
+
+You must log in to access the URL you requested.

--- a/source/meta/403.txt
+++ b/source/meta/403.txt
@@ -1,0 +1,7 @@
+:orphan:
+
+=============
+Access Denied
+=============
+
+You do not have access to the URL you requested.

--- a/source/meta/404.txt
+++ b/source/meta/404.txt
@@ -1,0 +1,7 @@
+:orphan:
+
+==============
+File not found
+==============
+
+The URL you requested does not exist or has been removed.

--- a/source/meta/410.txt
+++ b/source/meta/410.txt
@@ -1,0 +1,7 @@
+:orphan:
+
+============
+File Deleted
+============
+
+The URL you requested has been deleted.

--- a/themes/mongodb/layout.html
+++ b/themes/mongodb/layout.html
@@ -222,21 +222,25 @@
     </div>
 {%- endblock %}
 
-{%- block analytics%}
+{%- block analytics %}
 <script type="text/javascript">
-var _gaq = _gaq || [];
-_gaq.push(['_setAccount', 'UA-7301842-8']);
-_gaq.push(['_setDomainName', 'mongodb.org']);
-_gaq.push(['_trackPageview']);
-(function() {
-var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-var s = document.getElementsByTagName('script')[0];
-s.parentNode.insertBefore(ga, s);
-})();
+	var _gaq = _gaq || [];
+	_gaq.push(['_setAccount', 'UA-7301842-8']);
+	_gaq.push(['_setDomainName', 'mongodb.org']);
+	{%- if (pagename == "meta/401") or (pagename == "meta/403") or (pagename == "meta/404") or (pagename == "meta/410") %}
+	_gaq.push(['_trackPageview', '/manual/{{pagename}}.html?page=' + document.location.pathname + document.location.search + '&from=' + document.referrer]);
+	{%- else %}
+	_gaq.push(['_trackPageview']);
+	{%- endif %}
+
+	(function() {
+		var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+		ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+		var s = document.getElementsByTagName('script')[0];
+		s.parentNode.insertBefore(ga, s);
+		})();
 </script>
 {%- endblock %}
-
 {%- block marketo %}
 <script type="text/javascript">
 document.write(unescape("%3Cscript src='" + document.location.protocol + "//munchkin.marketo.net/munchkin.js' type='text/javascript'%3E%3C/script%3E"));


### PR DESCRIPTION
Created four custom error pages (meta/401.txt, meta/403.txt, meta/404.txt and meta/410.txt).
Modified layout.html to alter the Google Analytics trackPageView line depending on whether it's an error page or normal page being generated.
