### PR TITLE
DOCS394 add example output to mongotop, also some typo and rephrasing cleanup

### DIFF
--- a/source/reference/mongotop.txt
+++ b/source/reference/mongotop.txt
@@ -11,7 +11,7 @@ Synopsis
 
 :program:`mongotop` provides a method to track the amount of time a
 MongoDB instance spends reading and writing data. :program:`mongotop`
-provides statistics on the per-collection level. By default,
+provides statistics on a per-collection level. By default,
 :program:`mongotop` returns values every second.
 
 .. seealso::
@@ -51,7 +51,7 @@ Options
 
 .. option:: --version
 
-   Returns the version of the :program:`mongotop` utility.
+   Print the version of the :program:`mongotop` utility and exit.
 
 .. option:: --host <hostname><:port>
 
@@ -103,7 +103,7 @@ Options
 
 .. option:: <sleeptime>
 
-   The final argument the length of time, in seconds, that
+   The final argument is the length of time, in seconds, that
    :program:`mongotop` waits in between calls. By default
    :program:`mongotop` returns data every second.
 
@@ -163,8 +163,8 @@ Usage
 -----
 
 By default :program:`mongotop` connects to the MongoDB instance
-ruining on the localhost port 27017; however, you can optionally
-connect :program:`mongotop` to connect to remote :program:`mongod`
+running on the localhost port 27017. However, :program:`mongotop` can optionally
+connect to remote :program:`mongod`
 instances. See the :ref:`mongotop options <mongotop-options>` for more
 information.
 
@@ -175,6 +175,26 @@ return every 15 seconds.
 .. code-block:: sh
 
    mongotop 15
+   
+Resulting in the following output:
+   
+.. code-block:: sh
+	connected to: 127.0.0.1
+	
+								ns       total        read       write		2012-08-13T15:45:40
+			test.system.namespaces         0ms         0ms         0ms
+			  local.system.replset         0ms         0ms         0ms
+			  local.system.indexes         0ms         0ms         0ms
+			  admin.system.indexes         0ms         0ms         0ms
+							admin.         0ms         0ms         0ms
+	
+								ns       total        read       write		2012-08-13T15:45:55
+			test.system.namespaces         0ms         0ms         0ms
+			  local.system.replset         0ms         0ms         0ms
+			  local.system.indexes         0ms         0ms         0ms
+			  admin.system.indexes         0ms         0ms         0ms
+							admin.         0ms         0ms         0ms
+
 
 Use the following command to return a :program:`mongotop` report every 5
 minutes:
@@ -182,3 +202,17 @@ minutes:
 .. code-block:: sh
 
    mongotop 300
+   
+Use the following command to report on per-database locks: 
+
+.. code-block:: sh
+
+   mongotop --locks
+
+								db       total        read       write		2012-08-13T16:33:34
+							 local         0ms         0ms         0ms
+							 admin         0ms         0ms         0ms
+								 .         0ms         0ms         0ms
+
+
+


### PR DESCRIPTION
Added sample output per DOCS394 but think that realistic output would be better.
Also fixed some typos and altered some phrasing.
--version prints version and exits
