### PR TITLE
Monitoring section additions

### DIFF
--- a/source/administration/monitoring.txt
+++ b/source/administration/monitoring.txt
@@ -144,6 +144,49 @@ this includes a count of the objects in the collection, the size of
 the collection, the amount of disk space used by the collection, and
 information about the indexes.
 
+3rd Party Tools
+~~~~~~~~~~~~~~~
+
+There are a number of plugins and monitoring tools to help you monitor MongoDB. 
+
+Self Hosted Monitoring Tools
+````````````````````````````
+
+These are monitoring tools that you must install, configure and maintain
+on your own servers, usually open source.
+
+============================================================  =======================================================================================  ======================================
+ **Tool**                                                     **Plugin**                                                                                **Description**
+------------------------------------------------------------  ---------------------------------------------------------------------------------------  --------------------------------------
+ `Ganglia <http://sourceforge.net/apps/trac/ganglia/wiki>`_    `mongodb-ganglia <https://github.com/quiiver/mongodb-ganglia>`_                          Shell script to report operations per second, memory usage, btree statistics, master/slave status and current connections.
+ `Ganglia <http://sourceforge.net/apps/trac/ganglia/wiki>`_    `gmond_python_modules <https://github.com/ganglia/gmond_python_modules>`_                Parses output from the :dbcommand:`serverStatus` and :dbcommand:`replSetGetStatus` commands.
+ `Motop <https://github.com/tart/motop>`_                                                                                                               Realtime monitoring tool for several MongoDB servers. Shows current operations ordered by durations every second.
+ `mtop <https://github.com/beaufour/mtop>`_                                                                                                             A top like tool.          
+ `Munin <http://munin-monitoring.org/>`_                       `mongo-munin <https://github.com/erh/mongo-munin>`_                                      Retrieves server statistics.
+ `Munin <http://munin-monitoring.org/>`_                       `mongomon <https://github.com/pcdummy/mongomon>`_                                        Retrieves collection statistics (sizes, index sizes, and each (configured) collection count for one DB).
+ `Munin <http://munin-monitoring.org/>`_                       `munin-plugins Ubuntu PPA <https://launchpad.net/~chris-lea/+archive/munin-plugins>`_    Some additional munin plugins not in the main distribution. 
+ `Nagios <http://www.nagios.org/>`_                            `nagios-plugin-mongodb <https://github.com/mzupan/nagios-plugin-mongodb>`_               Monitors availability, resource utilization, health, performance and other important metrics.
+ `Zabbix <http://www.zabbix.com/>`_                            `mikoomi-mongodb <https://code.google.com/p/mikoomi/wiki/03>`_                           A simple Nagios check script.
+============================================================  =======================================================================================  ======================================
+
+Hosted (SaaS) Monitoring Tools
+``````````````````````````````
+
+These are monitoring tools provided as a hosted service, usually on a 
+subscription billing basis.
+
+==================================================  ===========
+ **Name**                                            **Notes**
+--------------------------------------------------  -----------
+ `Scout <http://scoutapp.com>`_                      Several plugins including: `MongoDB Monitoring <https://scoutapp.com/plugin_urls/391-mongodb-monitoring>`_, `MongoDB Slow Queries <http://scoutapp.com/plugin_urls/291-mongodb-slow-queries>`_ and `MongoDB Replica Set Monitoring <http://scoutapp.com/plugin_urls/2251-mongodb-replica-set-monitoring>`_.
+ `Server Density <http://www.serverdensity.com>`_    `Dashboard for MongoDB <http://www.serverdensity.com/mongodb-monitoring/>`_, MongoDB specific alerts, replication failover timeline and iPhone, iPad and Android mobile apps.
+==================================================  ===========
+
+Other Tools
+```````````
+
+- `dex <https://github.com/mongolab/dex>`_: Index and query analyzer for MongoDB: compares MongoDB log files and index entries to make index recommendations.
+
 Diagnosing Performance Issues
 -----------------------------
 


### PR DESCRIPTION
Added 3 additional sections to the Monitoring Tools section to migrate links from http://www.mongodb.org/display/DOCS/Monitoring+and+Diagnostics for several 3rd party tools: self hosted monitoring tools, hosted monitoring tools and other tools.

I'm unsure about the table formatting in the doc source because the rest of the doc has line wrapping but the table structure seems to require it be on a single line.
