### PR TITLE
Edits for style and typos.

### DIFF
--- a/source/reference/mongodump.txt
+++ b/source/reference/mongodump.txt
@@ -36,7 +36,7 @@ Options
 
 .. option:: --version
 
-   Returns the version of the :program:`mongodump` utility.
+   Returns the version of the :program:`mongodump` utility and exits.
 
 .. option:: --host <hostname><:port>
 
@@ -50,9 +50,9 @@ Options
 
    To connect to a replica set, use the :option:`--host <mongodump --host>`
    argument with a setname, followed by a slash and a comma
-   separated list of host and port names. The :program:`mongodump`
+   separated list of host names and port numbers. The :program:`mongodump`
    utility will, given the seed of at least one connected set member,
-   connect to primary member of that set. this option would resemble:
+   connect to the primary member of that set. This option would resemble:
 
    .. code-block:: javascript
 
@@ -98,7 +98,7 @@ Options
    directly to local data files and copy the data without the
    :program:`mongod`. To run with :option:`--dbpath`,
    :program:`mongodump` needs to restrict access to the data
-   directory: as a result, no :program:`mongod` can be access the same
+   directory: as a result, no :program:`mongod` can access the same
    path while the process runs.
 
 .. option:: --directoryperdb
@@ -124,7 +124,7 @@ Options
    dump files. Use this option to backup or copy a smaller subset of
    your data.
 
-.. option:: --collection <collection>, -c <c>
+.. option:: --collection <collection>, -c <collection>
 
    Use the :option:`--collection` option to specify a collection for
    :program:`mongodump` to backup. If you do not specify a collection,
@@ -153,7 +153,7 @@ Options
 
    Without :option:`--oplog`, if there are write operations during the
    dump operation, the dump will not reflect a single moment in
-   time. Changes made to the  during the update process can
+   time. Changes made to the database during the update process can
    affect the output of the backup.
 
    :option:`--oplog` has no effect when running :program:`mongodump`
@@ -172,7 +172,7 @@ Options
 
    Use this option to run a repair option in addition to dumping the
    database. The repair option attempts to repair a database that may
-   be an inconsistent state as a result of an improper shutdown or
+   be in an inconsistent state as a result of an improper shutdown or
    :program:`mongod` crash.
 
 .. option:: --forceTableScan
@@ -193,9 +193,9 @@ Behavior
 --------
 
 When running :program:`mongodump` against a :program:`mongos` instance
-where :term:`shard cluster` consists of :term:`replica sets <replica
+where the :term:`shard cluster` consists of :term:`replica sets <replica
 set>`, the :term:`read preference` of the operation will prefer reads
-to :term:`secondary` members of the set.
+from :term:`secondary` members of the set.
 
 Usage
 -----


### PR DESCRIPTION
Should be straightforward, one thing to verify because I couldn't confirm elsewhere in the documentation: first graph under Behavior read:

When running mongodump against a mongos instance where shard cluster consists of replica sets, the read preference of the operation will prefer _reads to secondary_ members of the set.

I changed this to read:

When running mongodump against a mongos instance where shard cluster consists of replica sets, the read preference of the operation will prefer _reads from secondary_ members of the set.
