### PR TITLE
added quotes around strings

### DIFF
--- a/source/tutorial/change-hostnames-in-a-replica-set.txt
+++ b/source/tutorial/change-hostnames-in-a-replica-set.txt
@@ -130,7 +130,7 @@ This procedure uses the above :ref:`assumptions <procedure-assumption-change-hos
 
          cfg = rs.conf()
 
-         cfg.members[1].host = mongodb1.example.net:27017
+         cfg.members[1].host = "mongodb1.example.net:27017"
 
          rs.reconfig(cfg)
 
@@ -162,7 +162,7 @@ This procedure uses the above :ref:`assumptions <procedure-assumption-change-hos
 
       cfg = rs.conf()
 
-      cfg.members[0].host = mongodb0.example.net:27017
+      cfg.members[0].host = "mongodb0.example.net:27017"
 
       rs.reconfigure(cfg)
 


### PR DESCRIPTION
The "Change Hostnames" doc was also missing quotes around two strings. I have added the quotes.
