### PR TITLE
added to pre-splits entry in glossary

### DIFF
--- a/source/reference/glossary.txt
+++ b/source/reference/glossary.txt
@@ -512,8 +512,8 @@ Glossary
       MongoDB will return from the documents in the result set.
 
    pre-splitting
-      Pre-splitting is a command run prior to data insertion that
-      specifies the shard key values on which to split up chunks.
+      Pre-splitting is an action you can perform prior to data insertion
+      that specifies the shard key values on which to split chunks.
       When deploying a :term:`shard cluster`, it is sometimes necessary
       to expedite the initial distribution of documents among shards by
       manually dividing the collection into chunks. In this case, you


### PR DESCRIPTION
I liked this sentence from Jenna's write-up on pre-splits. It seemed it belonged in the glossary, not the FAQ.
