### PR TITLE
note on dbpath when installing as Windows Service

### DIFF
--- a/source/tutorial/install-mongodb-on-windows.txt
+++ b/source/tutorial/install-mongodb-on-windows.txt
@@ -250,6 +250,16 @@ Run all of the following commands in :guilabel:`Command Shell` with
    :setting:`logpath` setting or the :option:`--logpath <mongod --logpath>`
    run-time option.
 
+.. note::
+
+   If you had specified alternate path for \data\db, please provide dbpath option when installing
+
+   .. code-block:: powershell
+
+      C:\mongodb\bin\mongod.exe --config C:\mongodb\mongod.cfg --dbpath d:\test\mongodb\data --install 
+  
+  else you may see error in starting service like "System error 1067 has occurred"
+  
    .. TODO fix --install link once mongod.exe manual page exists.
 
 #. To run the MongoDB Service:


### PR DESCRIPTION
If user has choose alternative location for dbpath, same should be provided while installing as windows service, a note about same was added as nothing found currently mentioning about same
