### PR TITLE
Fix misspellings of "pipeline" on "Aggregation Framework" page

### DIFF
--- a/source/applications/aggregation.txt
+++ b/source/applications/aggregation.txt
@@ -55,7 +55,7 @@ documents.
 All pipeline operators process a stream of documents and the
 pipeline behaves as if the operation scans a :term:`collection` and
 passes all matching documents into the "top" of the pipeline.
-Each operator in the pipleine transforms each document as it passes
+Each operator in the pipeline transforms each document as it passes
 through the pipeline.
 
 .. note::
@@ -201,7 +201,7 @@ to scan only the matching documents in a collection.
 .. operator in front of the :agg:pipeline:`$project`.
 
 In future versions there may be an optimization phase in the
-pipleine that reorders the operations to increase performance without
+pipeline that reorders the operations to increase performance without
 affecting the result. However, at this time place
 :agg:pipeline:`$match` operators at the beginning of the pipeline when
 possible.


### PR DESCRIPTION
Fix misspellings of "pipeline" on "Aggregation Framework" page
