### PR TITLE
DOCS-338: Clarification that elemMatch projection only returns first match found (per SERVER-2238)

### DIFF
--- a/source/reference/operator/elemMatch.txt
+++ b/source/reference/operator/elemMatch.txt
@@ -20,7 +20,7 @@ $elemMatch (query)
    returns all documents in ``collection`` where the array ``array``
    satisfies all of the conditions in the :operator:`$elemMatch`
    expression, or where the value of ``value1`` is 1 and the value of
-   ``value2`` is greater than 1. Matching arrays must have one element
+   ``value2`` is greater than 1. Matching arrays must have at least one element
    that matches all specified criteria. Therefore, the following
    document would not match the above query:
 

--- a/source/reference/projection/elemMatch.txt
+++ b/source/reference/projection/elemMatch.txt
@@ -22,7 +22,7 @@ $elemMatch (projection)
 
          {
           _id: ObjectId(),
-          zipcode: 63109
+          zipcode: 63109,
           dependents: [
                        { name: "john", school: 102, age: 10 },
                        { name: "jess", school: 102, age: 11 },
@@ -41,15 +41,18 @@ $elemMatch (projection)
 
       The query would return all documents where the value of the
       ``zipcode`` field is ``63109``, while the projection excludes
-      the ``_id`` field and only includes those elements of the
-      ``dependents`` array where the ``school`` element has a valueof
+      the ``_id`` field and only includes the first matching element of
+      the ``dependents`` array where the ``school`` element has a value of
       ``102``. The documents would take the following form:
 
       .. code-block:: javascript
 
          {
           dependents: [
-                       { name: "john", school: 102, age: 10 },
-                       { name: "jess", school: 102, age: 11 }
+                       { name: "john", school: 102, age: 10 }
                       ]
          }
+
+.. note::
+
+   The $elemMatch projection will only match one array element per source document.

--- a/source/release-notes/2.2.txt
+++ b/source/release-notes/2.2.txt
@@ -303,7 +303,7 @@ New ``$elemMatch`` Projection Operator
 
 The :projection:`$elemMatch` operator allows applications to narrow
 the data returned from queries so that the query operation will only
-return matching portions of an array. See the
+return the first matching element in an array. See the
 :doc:`/reference/projection/elemMatch` documentation and the
 :issue:`SERVER-2238` and :issue:`SERVER-828` issues for more
 information.


### PR DESCRIPTION
Per Ben's comment on SERVER-2238 and confirmed behaviour in 2.2.0:
- The $elemMatch projection specifier will only match one element
