### PR TITLE
Update source/tutorial/install-mongodb-on-windows.txt

### DIFF
--- a/source/tutorial/install-mongodb-on-windows.txt
+++ b/source/tutorial/install-mongodb-on-windows.txt
@@ -269,6 +269,8 @@ Run all of the following commands in :guilabel:`Command Prompt` with
    :program:`mongod.exe` will not be able to start. The default value
    for :setting:`dbpath` is ``\data\db``.
 
+   You can also save the config for dbpath in mongod.cfg
+
 Stop or Remove the MongoDB Service
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Updating the note to install as windows service, by mentioning about adding dbpath config to mongod.cfg file itself
