### PR TITLE
Fix a typo in the ensureIndex reference.

### DIFF
--- a/source/reference/method/db.collection.ensureIndex.txt
+++ b/source/reference/method/db.collection.ensureIndex.txt
@@ -1,5 +1,5 @@
 =============================
-db.collection.ensureIndexes()
+db.collection.ensureIndex()
 =============================
 
 .. default-domain:: mongodb


### PR DESCRIPTION
The ensureIndex reference uses the name "ensureIndexes", which does not exist.
