### PR TITLE
Tad Marshall claims traceExceptions is plural.

### DIFF
--- a/source/reference/command/setParameter.txt
+++ b/source/reference/command/setParameter.txt
@@ -30,7 +30,7 @@ setParameter
    :option boolean notablescan: If ``true``, queries that do not
                                 using an index will fail.
 
-   :option boolean traceException: If ``true``, :program:`mongod` will
+   :option boolean traceExceptions: If ``true``, :program:`mongod` will
                                    log full stack traces on assertions
                                    or errors. This parameter is only
                                    available in version 2.1 and later.


### PR DESCRIPTION
See SERVER-6978.
