### PR TITLE
Remove incorrect instruction to run 'yum update'

### DIFF
--- a/source/tutorial/install-mongodb-on-redhat-centos-or-fedora-linux.txt
+++ b/source/tutorial/install-mongodb-on-redhat-centos-or-fedora-linux.txt
@@ -110,13 +110,6 @@ production deployments, place the following configuration in
    gpgcheck=0
    enabled=1
 
-After saving the new ``.repo`` files, users of both platforms should
-issue the following command to update the local package database:
-
-.. code-block:: sh
-
-   yum update
-
 Installing Packages
 ~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
yum update installs available updates for all packages on the
system (not what we intend to advise here).  In reference to the
comment 'add instructions for yum update' removed in 5038c710:
this step is not necessary for yum, which will pull from the
available repositories during the next step (yum install).
