### PR TITLE
Fixed a typo in the command to concat key and pem

### DIFF
--- a/source/administration/ssl.txt
+++ b/source/administration/ssl.txt
@@ -60,7 +60,7 @@ and the ``.pem`` certificate, use the following command:
 
 .. code-block:: sh
 
-   cat mongodb-cert.crt mongodb-cert.pem > mongodb.pem
+   cat mongodb-cert.key mongodb-cert.pem > mongodb.pem
 
 Clients
 -------


### PR DESCRIPTION
Was a .crt (doesn't pop up anywhere else), but I guess it is .key
