### PR TITLE
Typo fixed in DOCS

### DIFF
--- a/source/tutorial/write-a-tumblelog-application-with-django-mongodb-engine.txt
+++ b/source/tutorial/write-a-tumblelog-application-with-django-mongodb-engine.txt
@@ -247,7 +247,7 @@ to add the views:
            context_object_name="posts_list"),
            name="home"
        ),
-       url(r'^post/(?P<slug>[a-zA-Z0-9-]+)/$', PostDetailView.as_view(
+       url(r'^post/(?P<slug>[a-zA-Z0-9-]+)/$', DetailView.as_view(
            queryset=Post.objects.all(),
            context_object_name="post"),
            name="post"


### PR DESCRIPTION
There is no such a class called 'PostDetailView'
It's actually 'DetailView'
Fixed: "PostDetailView" => "DetailView"
