### PR TITLE
production: fix background in search box

### DIFF
--- a/themes/mongodb/static/mongodb-docs.css_t
+++ b/themes/mongodb/static/mongodb-docs.css_t
@@ -648,3 +648,5 @@ div#etp ul li {display:inline;list-style-type:none;font-size:13px;color:#C48C55;
 div#etp ul li a {color:#AA814D}
 div#etp ul li:before {content:"|";padding-right:1em;color:#c48c55}
 div#etp ul li:first-child:before {content:"";}
+
+input.gsc-input {background:none;}


### PR DESCRIPTION
the <input> field somehow got a background set which obscured the google cse logo, so set background: none on the input field.
