### PR TITLE
typo revisited: there is only one procedure in this topic

### DIFF
--- a/source/tutorial/convert-standalone-to-replica-set.txt
+++ b/source/tutorial/convert-standalone-to-replica-set.txt
@@ -23,7 +23,7 @@ administration </replication>`, see:
 Procedure
 ---------
 
-These procedures assume you have a :term:`standalone` instance of MongoDB
+This procedure assumes you have a :term:`standalone` instance of MongoDB
 installed. If you have not already installed MongoDB, see the
 :ref:`installation tutorials <tutorials-installation>`.
 


### PR DESCRIPTION
Changed an intro sentence from "these procs" to "this proc" as the topic has just one proc
