### PR TITLE
DOCS-200 objcheck option for mongorestore

### DIFF
--- a/source/reference/mongorestore.txt
+++ b/source/reference/mongorestore.txt
@@ -147,8 +147,10 @@ Options
 
 .. option:: --objcheck
 
-   Forces :program:`mongorestore` to validate every object before
-   inserting it in the target database.
+   Verifies each object as a valid :term:`BSON` object before inserting
+   it into the target database. If the object is not a valid
+   :term:`BSON` object, :program:`mongorestore` will not insert the
+   object into the target database and stop processing.
 
 .. option:: --filter '<JSON>'
 


### PR DESCRIPTION
I didn't really add much to what was already there, so I'm not sure if they wanted something else.  Should we have Dan or some other developer check?
Left the BSONdump as is -- since its parent is BSONTool which has the objcheck option 
