### PR TITLE
DOCS-527 improve mongo man page documentation, add .dbshell .mongorc.js

### DIFF
--- a/source/reference/mongo.txt
+++ b/source/reference/mongo.txt
@@ -1,14 +1,15 @@
-.. _mongo:
-
-.. meta::
-   :description: The mongo shell man page
-   :keywords: man page, mongo, javascript, shell
-   
-.. default-domain:: mongodb
-
 ================
 mongo
 ================
+.. only:: html
+
+	.. meta::
+			:description: The mongo command man page.
+			:keywords: mongo, mongodb, man page, mongo process, mongo shell
+         
+.. default-domain:: mongodb
+
+.. _mongo:
 
 Synopsis
 --------
@@ -19,10 +20,10 @@ Description
 -----------
 
 :program:`mongo` is an interactive JavaScript shell interface to
-MongoDB. :program:`mongo` provides a powerful interface
+MongoDB. The :program:`mongo` command provides a powerful interface
 for systems administrators as well as a way to test queries and
 operations directly with the database. To increase the flexibility of
-:program:`mongo`, the shell provides a fully functional JavaScript
+the :program:`mongo` command, the shell provides a fully functional JavaScript
 environment. This document addresses the basic invocation of the
 :program:`mongo` shell and an overview of its usage.
 
@@ -37,60 +38,63 @@ Options
 
 .. cmdoption:: --shell
 
-   If you invoke the :program:`mongo` and specify a :term:`JavaScript`
-   file as an argument, or ":option:`mongo --eval`" the
-   :option:`--shell` option provides the user with a shell prompt after the
-   file finishes executing.
+   Enables the shell interface after a :term:`JavaScript` file is evaluated. 
+   If you invoke the :program:`mongo` command and specify a JavaScript
+   file as an argument, or use :option:`mongo --eval` to specify 
+   JavaScript on the command line, the :option:`mongo --shell` option 
+   provides the user with a shell prompt after the file finishes 
+   executing.
 
 .. cmdoption:: --nodb
 
-   Use this option to prevent the shell from connecting to any
-   database instance.
+	Prevents the shell from connecting to any database instances.
 
 .. cmdoption:: --norc
 
-   By default :program:`mongo` runs the ``~/.mongorc.js`` file when it
-   starts. Use this option to prevent the shell from sourcing this
-   file on start up.
-
+   Prevents the shell from sourcing and evaluating
+   :file:`~/.mongorc.js` on startup.
+   
 .. cmdoption:: --quiet
 
    Silences output from the shell during the connection process.
 
 .. cmdoption:: --port <PORT>
 
-   Specify the port where the :program:`mongod` or :program:`mongos`
+   Specifies the port where the :program:`mongod` or :program:`mongos`
    instance is listening. Unless specified :program:`mongo` connects
    to :program:`mongod` instances on port 27017, which is the default
    :program:`mongod` port.
 
 .. cmdoption:: --host <HOSTNAME>
 
-   Specific the host where the :program:`mongod` or :program:`mongos` is running to
+   specifies the host where the :program:`mongod` or :program:`mongos` is running to
    connect to as ``<HOSTNAME>``. By default :program:`mongo` will attempt
-   to connect to MongoDB process running on the localhost.
+   to connect to a MongoDB process running on the localhost.
 
 .. cmdoption:: --eval <JAVASCRIPT>
 
-   Evaluates a JavaScript specified as an argument to this
+   Evaluates a JavaScript expression specified as an argument to this
    option. :program:`mongo` does not load its own environment when evaluating
    code: as a result many options of the shell environment are not
    available.
 
 .. cmdoption:: --username <USERNAME>, -u <USERNAME>
 
-   Specify a username to authenticate to the MongoDB instance, if your
-   database requires authentication. Use in conjunction with the
+   Specifies a username to authenticate to the MongoDB instance.
+   Use in conjunction with the
    :option:`mongo --password` option to supply a password.
+   If you specify a username and password but the default database
+   or the specified database do not require authentication, 
+   :program:`mongo` will exit with an exception.
 
 .. cmdoption:: --password <password>, -p <password>
 
-   Specify a password to authenticate to the MongoDB instance, if your
-   database requires authentication. Use in conjunction with the
+   Specifies a password to authenticate to the MongoDB instance. 
+   Use in conjunction with the
    :option:`mongo --username` option to supply a username. If you
    specify a :option:`--username <mongo --username>` without the
    :option:`mongo --password` option, :program:`mongo` will prompt for a
-   password interactively.
+   password interactively if authentication is required.
 
 .. cmdoption:: --help,  -h
 
@@ -114,7 +118,7 @@ Options
 
 .. cmdoption:: <db address>
 
-   Specify the "database address" of the database to connect to. For
+   Specifies the "database address" of the database to connect to. For
    example: ::
 
         mongo admin
@@ -133,8 +137,9 @@ Options
 
 .. cmdoption:: <file.js>
 
-   Optionally, specify a JavaScript file as the final argument to the
-   shell. The shell will run the file and then exit. Use the
+   Specifies a JavaScript file to run and then exit. 
+   Must be the last option specified.
+   Use the
    :option:`mongo --shell` option to return to a shell after the file
    finishes running.
 
@@ -224,21 +229,21 @@ Environment
 
 .. envvar:: EDITOR
 
-	Specify the path to an editor to use with the `edit` shell command.
+	Specifies the path to an editor to use with the `edit` shell command.
 	A JavaScript variable `EDITOR` will override the value of 
 	:envvar:`EDITOR`.
 
 .. envvar:: HOME
 
-	Specify the path to the home directory where `.mongorc.js` will be
-	read from and `.dbshell` will be written to.
+	specifies the path to the home directory where :file:`.mongorc.js` will be
+	read from and :file:`.dbshell` will be written to.
 
 .. envvar:: HOMEDRIVE
 
-	Specify the Windows path to the home directory where `.mongorc.js` will be
-	read from and `.dbshell` will be written to.
+	specifies the Windows path to the home directory where :file:`.mongorc.js` will be
+	read from and :file:`.dbshell` will be written to.
 
 .. envvar:: HOMEPATH
 
-	Specify the Windows path to the home directory where `.mongorc.js` will be
-	read from and `.dbshell` will be written to.
+	specifies the Windows path to the home directory where :file:`.mongorc.js` will be
+	read from and :file:`.dbshell` will be written to.


### PR DESCRIPTION
Additions: file section on .dbshell .mongorc.js /tmp/mongo_edit, environment variables section, rewrote other parts to fix verb tenses, misc formatting cleanup.
