### PR TITLE
DOCS-557 add note to convertToCapped

### DIFF
--- a/source/reference/command/convertToCapped.txt
+++ b/source/reference/command/convertToCapped.txt
@@ -8,7 +8,7 @@ convertToCapped
 
    The :dbcommand:`convertToCapped` command converts an existing,
    non-capped collection to a :term:`capped collection`.
-   
+
    The command has the following syntax:
 
    .. code-block:: javascript
@@ -30,6 +30,11 @@ convertToCapped
      smaller than the size of the original uncapped collection, then
      the documents will be aged out of the collection based on
      insertion order(First In, First Out).
+
+   .. note::
+
+      The :dbcommand:`convertToCapped` command is not supported in a
+      sharded cluster.
 
    .. warning::
 


### PR DESCRIPTION
A comment in the code states that the convertToCapped is not supported in sharded environments.  Scott gave the go-ahead to put the note.  Will also add reference to "cloneCollectionAsCapped" and "renameCollection".
