### PR TITLE
Change on how to do $group on compound keys

### DIFF
--- a/source/reference/aggregation/group.txt
+++ b/source/reference/aggregation/group.txt
@@ -20,7 +20,7 @@ $group (aggregation)
 
    .. code-block:: javascript
 
-      { _id : { author: 1, pageViews: 1, posted: 1 } }
+      { _id : { author: $author$, pageViews: $pageViews$, posted: $posted$ } }
 
    With the exception of the ``_id`` field, :pipeline:`$group` cannot
    output nested documents.


### PR DESCRIPTION
The currently documented example for creating a $group with compound  keys doesn't work with 2.2. The change is based on this discussion: https://groups.google.com/forum/?fromgroups=#!topic/mongodb-user/1cYch580h0w
