### PR TITLE
printJson actually doesn't work

### DIFF
--- a/source/reference/mongo.txt
+++ b/source/reference/mongo.txt
@@ -255,7 +255,7 @@ the :option:`--eval <mongo --eval>` option, use the following form:
 
 .. code-block:: sh
 
-   mongo --eval 'db.collection.find().forEach(printJson)'
+   mongo --eval 'db.collection.find().forEach(printjson)'
 
 Use single quotes (e.g. ``'``) to enclose the JavaScript, as well as
 the additional JavaScript required to generate this output.


### PR DESCRIPTION
in
  MongoDB shell version: 2.0.7-rc0 (winXP)
"printJson" causes:
  ReferenceError: printJson is not defined (shell eval):1
"printjson" works fine
