### PR TITLE
Update replica config to max priority of 100.0

### DIFF
--- a/source/reference/replica-configuration.txt
+++ b/source/reference/replica-configuration.txt
@@ -120,7 +120,7 @@ Configuration Variables
 
    *Optional*.
 
-   **Type**: Number, between 0 and 1000 including decimals.
+   **Type**: Number, between 0 and 100.0 including decimals.
 
    **Default**: 1
 


### PR DESCRIPTION
From 2.2

```
{
    "errmsg" : "exception: bad config for member[1] priorities must be between 0.0 and 100.0",
    "code" : 13135,
    "ok" : 0
}
```
