### PR TITLE
Error in example code in two stage commit tutorial.

### DIFF
--- a/source/tutorial/perform-two-phase-commits.txt
+++ b/source/tutorial/perform-two-phase-commits.txt
@@ -229,8 +229,8 @@ to set remove the pending transaction from the :term:`documents
 
 .. code-block:: javascript
 
-   db.accounts.update({name: t.source}, {$pull: {pendingTransactions: ObjectId("4d7bc7a8b8a04f5126961522")}})
-   db.accounts.update({name: t.destination}, {$pull: {pendingTransactions: ObjectId("4d7bc7a8b8a04f5126961522")}})
+   db.accounts.update({name: t.source}, {$pull: {pendingTransactions: t._id}})
+   db.accounts.update({name: t.destination}, {$pull: {pendingTransactions: t._id}})
    db.accounts.find()
 
 The :method:`find() <db.collection.find()>` operation will return the


### PR DESCRIPTION
The example code for the stage "Remove Pending Transaction" includes an actual object id rather than referring to the transaction by the _id property of the variable t. This means that these lines of code will not perform as expected if copied/pasted into the CLI.
I have fixed the lines of code in question so that they refer to the object id via the variable "t" which is created in an earlier step. The code now functions as expected if copied/pasted to the CLI
