### PR TITLE
DOCS-605 Clarify flask tumblelog tutorial

### DIFF
--- a/source/tutorial/write-a-tumblelog-application-with-flask-mongoengine.txt
+++ b/source/tutorial/write-a-tumblelog-application-with-flask-mongoengine.txt
@@ -306,7 +306,8 @@ Add :file:`views.py` and create a *posts* blueprint_:
    posts.add_url_rule('/<slug>/', view_func=DetailView.as_view('detail'))
 
 Now in :file:`__init__.py` register the blueprint, avoiding a circular
-dependency by registering the blueprints in a method. Add the following code:
+dependency by registering the blueprints in a method. Add the following code
+inline (not in the main block):
 
 .. code-block:: python
 
@@ -997,3 +998,9 @@ Now you have a fully fledged tumbleblog using Flask and MongoEngine!
 
 .. image:: .static/flask-mongoengine-tumblelog.png
    :align: center
+
+Having issues?
+--------------
+The source code is available on Github: `source code`_
+
+.. _source code: https://github.com/rozza/flask-tumblelog


### PR DESCRIPTION
Clarified the location of `register_blueprints`
