### PR TITLE
Confusing wording on the ubuntu install page

### DIFF
--- a/source/tutorial/install-mongodb-on-ubuntu.txt
+++ b/source/tutorial/install-mongodb-on-ubuntu.txt
@@ -23,7 +23,7 @@ configuration and operation.
 .. note:: 
    
    If you use an older Ubuntu that does **not** use Upstart, (i.e. any
-   since version 9.10 "Karmic,") please follow the instructions on the
+   version before 9.10 "Karmic") please follow the instructions on the
    :doc:`install-mongodb-on-debian` tutorial.
 
 .. seealso:: The documentation of following related processes and


### PR DESCRIPTION
[in the first "note"]

If you use an older Ubuntu that does not use Upstart, (i.e. any since version 9.10 “Karmic,”)

should be

If you use an older Ubuntu that does not use Upstart, (i.e. any version before 9.10 “Karmic,”)
