### PR TITLE
Fixing a minor typo

### DIFF
--- a/source/tutorial/install-mongodb-on-ubuntu.txt
+++ b/source/tutorial/install-mongodb-on-ubuntu.txt
@@ -115,7 +115,7 @@ Configure MongoDB
 
 These packages configure MongoDB using the ``/etc/mongodb.conf`` file
 in conjunction with the :term:`control script`.  You will find the
-control script is at ``/etc/init/mongodb.conf``.
+control script is at ``/etc/init.d/mongodb.conf``.
 
 This MongoDB instance will store its data files in the
 ``/var/lib/mongodb`` and its log files in ``/var/log/mongodb``, and


### PR DESCRIPTION
Init scripts are located at /etc/init.d/ instead of /etc/init/
