### PR TITLE
collection-statistics  fixed binary prefix

### DIFF
--- a/source/reference/collection-statistics.txt
+++ b/source/reference/collection-statistics.txt
@@ -24,7 +24,7 @@ You may also use the literal command format:
 Replace ``collection`` in both examples with the name of the
 collection you want statistics for. By default, the return values will
 appear in terms of bytes. You can, however, enter a ``scale``
-argument. For example, you can convert the return values to kilobytes
+argument. For example, you can convert the return values to kibibytes
 like so:
 
 .. code-block:: javascript


### PR DESCRIPTION
1 kilobyte is 1000 byte
1 kibibyte is 1024 byte
1 kg is 1000g and not 1024g

https://en.wikipedia.org/wiki/Kibibyte
