### PR TITLE
DOCS-249-related: change to write concern glossary entry

### DIFF
--- a/source/reference/glossary.txt
+++ b/source/reference/glossary.txt
@@ -366,10 +366,6 @@ Glossary
       migration of :term:`chunks <chunk>`. Administrators must disable
       the balancer for all maintenance operations on a sharded cluster.
 
-   fsync
-      A system call that flushes all dirty, in-memory pages to disk. MongoDB
-      calls ``fsync()`` every 60 seconds.
-
    chunk
       In the context of a :term:`sharded cluster`, a chunk is a contiguous
       range of :term:`shard key` values assigned to a particular :term:`shard`.


### PR DESCRIPTION
This is related to DOCS-249 (write operations). This updates the "write concern" glossary entry and deletes the "fsync" glossary entry.
