### PR TITLE
Update source/faq/indexes.txt

### DIFF
--- a/source/faq/indexes.txt
+++ b/source/faq/indexes.txt
@@ -39,7 +39,7 @@ To list a collection's indexes, use the
 How do you determine the size of an index?
 ------------------------------------------
 
-To check index size, use :method:`db.collection.totalIndexSize()`.
+To check the sizes of the indexes on a collection, use :method:`db.collection.stats()`.
 
 .. todo:: FAQ How do I determine if an index fits into RAM?
 


### PR DESCRIPTION
totalIndexSizes shows the sum of index sizes on a collection, not the sizes of each individual index. Collection stats shows the index sizes broken out.
