### PR TITLE
DOCS-652 add blurb in CRUD about logic behind document max size

### DIFF
--- a/source/includes/fact-document-max-size.rst
+++ b/source/includes/fact-document-max-size.rst
@@ -1,1 +1,7 @@
 MongoDB v2.2 has a 16 megabytes limit on document size.
+
+The logic behind the maximum document size is to ensure that the
+document does not require excessive amount of RAM on the machine nor
+excessive amount of bandwidth to return. MongoDB provides the GridFS
+api to handle documents larger than the maximum size. See your specific
+driver api documentation on GridFS.


### PR DESCRIPTION
last little bit from the wiki Documents page is now incorporated into CRUD
