### PR TITLE
fix shell example for unique key enforcement

### DIFF
--- a/source/tutorial/enforce-unique-keys-for-sharded-collections.txt
+++ b/source/tutorial/enforce-unique-keys-for-sharded-collections.txt
@@ -152,11 +152,11 @@ To insert documents, use the following procedure in the
 
 .. code-block:: javascript
 
-   use records
+   use records;
 
-   primary_id = ObjectId()
+   var primary_id = ObjectId();
 
-   db.information.proxy({
+   db.proxy.insert({
       "_id" : primary_id
       "email" : "example@example.net"
    })


### PR DESCRIPTION
The shell example uses invalid syntax to insert a document into the `proxy` collection.
