### PR TITLE
DOCS-617 minor edits to ensure <argument> have <> and spelling

### DIFF
--- a/draft/applications/create.txt
+++ b/draft/applications/create.txt
@@ -6,8 +6,8 @@ Create
 
 Of the four basic database operations (i.e. CRUD), *create* operations
 are those that add new records or :term:`documents <document>` to a
-:term:`collection` in MongoDB. For general information related to
-document creation and other write operations, see
+:term:`collection` in MongoDB. For general information about write
+operations and the factors that affect their performance, see
 :ref:`/core/write-operations`; for documentation of the other CRUD
 operations, see the :doc:`/crud` page.
 
@@ -48,8 +48,8 @@ Insert
 ------
 
 The :method:`insert() <db.collection.insert()>` is the primary method
-used to create documents into a MongoDB collection, and has the
-following syntax:
+to insert a document or documents into a MongoDB collection, and has
+the following syntax:
 
 .. code-block:: javascript
 
@@ -271,8 +271,8 @@ separate database call to check for the existence of a record before
 performing either an update or an insert operation. Typically update
 operations :doc:`update </applications/update>` existing documents, but
 in MongoDB, the :method:`update() <db.collection.update()>` operation
-can accept an ``upsert`` option as an argument. Upserts are a hybrid
-operation that use the ``query`` argument to determine the write
+can accept an ``<upsert>`` option as an argument. Upserts are a hybrid
+operation that use the ``<query>`` argument to determine the write
 operation:
 
 - If the query returns a result, the upsert updates the matching
@@ -476,13 +476,14 @@ Save
 ----
 
 The :method:`save() <db.collection.save()>` method is a specialized
-upsert that use the ``_id`` field in document argument to determine
-whether to perform an insert or an update:
+upsert that use the ``_id`` field in the ``<document>`` argument to
+determine whether to perform an insert or an update:
 
-- If the document does not contain the ``_id`` field or contains an
-  ``_id`` field with a value not in the collection, the :method:`save()
-  <db.collection.save()>` method performs an insert of the document.
-
+- If the ``<document>`` argument does not contain the ``_id`` field or
+  contains an ``_id`` field with a value not in the collection, the
+  :method:`save() <db.collection.save()>` method performs an insert of
+  the document.
+  
 - Otherwise, the :method:`save() <db.collection.save()>` method
   performs an update.
 
@@ -496,7 +497,7 @@ following syntax:
 Consider the following examples that illustrate the use of the
 :method:`save() <db.collection.save()>` method to perform inserts:
 
-- If the ``document`` does not contain the ``_id`` field, the
+- If the ``<document>`` does not contain the ``_id`` field, the
   :method:`save() <db.collection.save()>` method performs an insert.
   Refer to the :ref:`insert <crud-create-insert>` section for details
   of the insert operation of a document without an ``_id`` field.
@@ -520,7 +521,7 @@ Consider the following examples that illustrate the use of the
                 ]
      } )
 
-- If the ``document`` contains an ``_id`` field but has a value not
+- If the ``<document>`` contains an ``_id`` field but has a value not
   found in the collection, the :method:`save() <db.collection.save()>`
   method performs an insert. Refer to the :ref:`insert
   <crud-create-insert>` section for details of the insert operation.

--- a/draft/applications/read.txt
+++ b/draft/applications/read.txt
@@ -7,7 +7,7 @@ Read
 Of the four basic database operations (i.e. CRUD), read operation are
 those that retrieve records or or :term:`documents <document>` from a
 :term:`collection` in MongoDB. For general information about read
-operations and the factors that affect their performanace, see
+operations and the factors that affect their performance, see
 :ref:`/core/read-operations`; for documentation of the other CRUD
 operations, see the :doc:`/crud` page.
 
@@ -188,12 +188,14 @@ Consider the following examples that illustrate the use of the
                                                } } } )
 
 - If there is a ``<projection>`` argument, the :method:`find()
-  <db.collection.find()>` method returns only those fields as
-  specified in the projection to include or exclude:
+  <db.collection.find()>` method returns only those fields as specified
+  in the ``<projection>`` argument to include or exclude:
 
   .. note:: The ``_id`` field is implicitly included in the
-    projection, and in projections that explicitly include fields,
-    ``_id`` is the only field that you can explicitly exclude.
+    ``<projection>`` argument. In projections that explicitly include
+    fields, ``_id`` is the only field that you can explicitly exclude.
+    Otherwise, you cannot mix include field and exclude field
+    specifications.
 
   - The following operation finds all documents in the ``csbios``
     collection and returns only the ``name`` field, the ``contribs``
@@ -210,11 +212,6 @@ Consider the following examples that illustrate the use of the
     .. code-block:: javascript
 
        db.csbios.find( { }, { name: 1, contribs: 1, _id: 0 } )
-
-    .. note::
-
-       The ``projection`` argument cannot contain both include and
-       exclude specifications *except* for the exclusion of the ``_id``.
 
   - The following operation finds the documents in the ``csbios``
     collection where the ``contribs`` field contains the element
@@ -285,7 +282,7 @@ Except for the return value, :method:`findOne()
 examples that illustrate the use of the :method:`findOne()
 <db.collection.findOne()>` method:
 
-- If there is no ``query`` argument, the :method:`findOne()
+- If there is no ``<query>`` argument, the :method:`findOne()
   <db.collection.findOne()>` method selects just one document from a
   collection.
 
@@ -296,9 +293,9 @@ examples that illustrate the use of the :method:`findOne()
 
        db.csbios.findOne()
 
-- If there is a ``query`` argument, the :method:`findOne()
+- If there is a ``<query>`` argument, the :method:`findOne()
   <db.collection.findOne()>` method selects the first document from a
-  collection that meets the ``query`` argument:
+  collection that meets the ``<query>`` argument:
 
   - The following operation returns the first matching document from
     the ``csbios`` collection where either the field ``first`` in the
@@ -311,8 +308,9 @@ examples that illustrate the use of the :method:`findOne()
                                    { birth: { $lt: new Date('01/01/1945') } }
                                  ] } )
 
-- You can pass a projection to :method:`findOne()
-  <db.collection.findOne()>` to control the fields included in the result set:
+- You can pass a ``<projection>`` argument to :method:`findOne()
+  <db.collection.findOne()>` to control the fields included in the
+  result set:
 
   - The following operation finds a document in the ``csbios``
     collection and returns only the ``name`` field, the ``contribs``


### PR DESCRIPTION
Last changes for the time being.  I think CRUD can be tech-reviewed.
