### PR TITLE
Prevent us from running rs.initiate on set members

### DIFF
--- a/source/tutorial/convert-standalone-to-replica-set.txt
+++ b/source/tutorial/convert-standalone-to-replica-set.txt
@@ -60,8 +60,8 @@ installed. If you have not already installed MongoDB, see the
    status of the replica set, use :method:`rs.status()`.
 
 #. Now add additional replica set members. On two distinct systems,
-   start two new :program:`mongod` instances, as above. Then, in the
-   :program:`mongo` shell instance connected to the first
+   start two new :program:`mongod` instances, as described in step 1.
+   Then, in the :program:`mongo` shell instance connected to the first
    :program:`mongod` instance, issue a command in the following form:
 
    .. code-block:: javascript


### PR DESCRIPTION
Or else it's very tempting to run rs.initiate()
on new replica set members, "as above".
