### PR TITLE
Add an ORDER BY example that would be used in a typical GROUP BY query.

### DIFF
--- a/source/includes/table-sql-to-agg-examples.yaml
+++ b/source/includes/table-sql-to-agg-examples.yaml
@@ -71,10 +71,31 @@ mongo3: |
                           total: { $sum: "$price" } } }
            ] )
 desc4: |
+        For each unique ``cust_id``,
+        sum the ``price`` field,
+        results sorted by sum.
+sql4: |
+      .. code-block:: sql
+
+         SELECT cust_id,
+                SUM(price) AS total
+         FROM orders
+         GROUP BY cust_id
+         ORDER BY total
+mongo4: |
+        .. code-block:: javascript
+           :emphasize-lines: 2-4
+
+           db.orders.aggregate( [
+              { $group: { _id: "$cust_id",
+                          total: { $sum: "$price" } } },
+              { $sort: { total: 1 } }
+           ] )
+desc5: |
         For each unique
         ``cust_id``, ``ord_date`` grouping,
         sum the ``price`` field.
-sql4: |
+sql5: |
       .. code-block:: sql
 
          SELECT cust_id,
@@ -82,7 +103,7 @@ sql4: |
                 SUM(price) AS total
          FROM orders
          GROUP BY cust_id, ord_date
-mongo4: |
+mongo5: |
         .. code-block:: javascript
            :emphasize-lines: 2-4
 
@@ -91,18 +112,18 @@ mongo4: |
                                  ord_date: "$ord_date" },
                           total: { $sum: "$price" } } }
            ] )
-desc5: |
+desc6: |
         For ``cust_id`` with multiple records,
         return the ``cust_id`` and
         the corresponding record count.
-sql5: |
+sql6: |
       .. code-block:: sql
 
          SELECT cust_id, count(*)
          FROM orders
          GROUP BY cust_id
          HAVING count(*) > 1
-mongo5: |
+mongo6: |
         .. code-block:: javascript
            :emphasize-lines: 2-4
 
@@ -111,12 +132,12 @@ mongo5: |
                           count: { $sum: 1 } } },
               { $match: { count: { $gt: 1 } } }
            ] )
-desc6: |
+desc7: |
         For each unique ``cust_id``, ``ord_date``
         grouping, sum the ``price`` field
         and return only where the
         sum is greater than 250.
-sql6: |
+sql7: |
       .. code-block:: sql
 
          SELECT cust_id,
@@ -125,7 +146,7 @@ sql6: |
          FROM orders
          GROUP BY cust_id, ord_date
          HAVING total > 250
-mongo6: |
+mongo7: |
         .. code-block:: javascript
            :emphasize-lines: 2-5
 
@@ -135,33 +156,10 @@ mongo6: |
                           total: { $sum: "$price" } } },
               { $match: { total: { $gt: 250 } } }
            ] )
-desc7: |
-        For each unique ``cust_id``
-        with status ``A``,
-        sum the ``price`` field.
-sql7: |
-      .. code-block:: sql
-
-         SELECT cust_id,
-                SUM(price) as total
-         FROM orders
-         WHERE status = 'A'
-         GROUP BY cust_id
-mongo7: |
-        .. code-block:: javascript
-           :emphasize-lines: 2-4
-
-           db.orders.aggregate( [
-              { $match: { status: 'A' } },
-              { $group: { _id: "$cust_id",
-                          total: { $sum: "$price" } } }
-           ] )
 desc8: |
         For each unique ``cust_id``
         with status ``A``,
-        sum the ``price`` field and return
-        only where the
-        sum is greater than 250.
+        sum the ``price`` field.
 sql8: |
       .. code-block:: sql
 
@@ -170,8 +168,31 @@ sql8: |
          FROM orders
          WHERE status = 'A'
          GROUP BY cust_id
-         HAVING total > 250
 mongo8: |
+        .. code-block:: javascript
+           :emphasize-lines: 2-4
+
+           db.orders.aggregate( [
+              { $match: { status: 'A' } },
+              { $group: { _id: "$cust_id",
+                          total: { $sum: "$price" } } }
+           ] )
+desc9: |
+        For each unique ``cust_id``
+        with status ``A``,
+        sum the ``price`` field and return
+        only where the
+        sum is greater than 250.
+sql9: |
+      .. code-block:: sql
+
+         SELECT cust_id,
+                SUM(price) as total
+         FROM orders
+         WHERE status = 'A'
+         GROUP BY cust_id
+         HAVING total > 250
+mongo9: |
         .. code-block:: javascript
            :emphasize-lines: 2-5
 
@@ -181,13 +202,13 @@ mongo8: |
                           total: { $sum: "$price" } } },
               { $match: { total: { $gt: 250 } } }
            ] )
-desc9: |
+desc10: |
         For each unique ``cust_id``,
         sum the corresponding
         line item ``qty`` fields
         associated with the
         orders.
-sql9: |
+sql10: |
       .. code-block:: sql
 
          SELECT cust_id,
@@ -196,7 +217,7 @@ sql9: |
               order_lineitem li
          WHERE li.order_id = o.id
          GROUP BY cust_id
-mongo9: |
+mongo10: |
         .. code-block:: javascript
            :emphasize-lines: 2-5
 


### PR DESCRIPTION
The current SQL <-> aggregate examples are missing the very common usage of ORDER BY when combined with a GROUP BY.
