### PR TITLE
Fixed example for size alloc in capped collections

### DIFF
--- a/source/reference/method/db.createCollection.txt
+++ b/source/reference/method/db.createCollection.txt
@@ -49,10 +49,10 @@ db.createCollection()
 
    .. code-block:: javascript
 
-      db.createCollection("log", { capped : true, size : 536870912, max : 5000 } )
+      db.createCollection("log", { capped : true, size : 5242880, max : 5000 } )
 
    This command creates a collection named log with a maximum size of
-   5 megabytes (512 kilobytes) or a maximum of 5000 documents.
+   5 megabytes (5*1024*1024 bytes) or a maximum of 5000 documents.
 
    The following command simply pre-allocates a 2 gigabyte, uncapped,
    collection named ``people``:


### PR DESCRIPTION
DOCS ticket: https://jira.mongodb.org/browse/DOCS-758
