### PR TITLE
Edits for style: remove doublings of words across a number of files.

### DIFF
--- a/source/administration/backups.txt
+++ b/source/administration/backups.txt
@@ -660,7 +660,7 @@ This procedure describes both approaches:
    only need to back up one config server, as they all have replicas of
    the same information.
 
-   Issue this command against one of the the config server itself or the
+   Issue this command against one of the config server itself or the
    :program:`mongos`:
 
    .. code-block:: sh

--- a/source/administration/indexes.txt
+++ b/source/administration/indexes.txt
@@ -238,7 +238,7 @@ To return a list of all indexes on a collection, use the, use the
 :method:`db.collection.getIndexes()` method or a similar
 :api:`method for your driver <>`.
 
-For example, to view all indexes on the the ``people`` collection:
+For example, to view all indexes on the ``people`` collection:
 
 .. code-block:: javascript
 

--- a/source/administration/security.txt
+++ b/source/administration/security.txt
@@ -352,7 +352,7 @@ HTTP Status Interface
 The HTTP status interface provides a web-based interface that includes
 a variety of operational data, logs, and status reports regarding the
 :program:`mongod` or :program:`mongos` instance. The HTTP interface is
-always available on the the port numbered ``1000`` greater than the
+always available on the port numbered ``1000`` greater than the
 primary :program:`mongod` port. By default this is ``28017``, but is
 indirectly set using the :setting:`port` option which allows you to
 configure the primary :program:`mongod` port.

--- a/source/administration/sharding.txt
+++ b/source/administration/sharding.txt
@@ -417,7 +417,7 @@ list of databases with sharding enabled:
       { "_id" : "animals", "partitioned" : true, "primary" : "m0.example.net:30001" }
       { "_id" : "farms", "partitioned" : false, "primary" : "m1.example2.net:27017" }
 
-   Then sharding is only enabled for the the ``animals`` database.
+   Then sharding is only enabled for the ``animals`` database.
 
 List Shards
 ~~~~~~~~~~~

--- a/source/core/sharding.txt
+++ b/source/core/sharding.txt
@@ -419,7 +419,7 @@ possible. Operations have the following targeting characteristics:
   stores this data.
 
   For queries that include the shard key, :program:`mongos` can target
-  the query at a specific shard or set set of shards, if the portion
+  the query at a specific shard or set of shards, if the portion
   of the shard key included in the query is a *prefix* of the shard
   key. For example, if the shard key is:
 

--- a/source/faq/developers.txt
+++ b/source/faq/developers.txt
@@ -178,7 +178,7 @@ storage utilization for these collections:
   that would have occupied space in another portion of the document. 
   
   You can store any value in the ``_id`` field, but because this value
-  serves as a a primary key for documents in the collection, it must
+  serves as a primary key for documents in the collection, it must
   uniquely identify them. If the field's value is not unique, then it
   cannot serve as a primary key as there would be collisions in
   collection.

--- a/source/reference/command/cloneCollectionAsCapped.txt
+++ b/source/reference/command/cloneCollectionAsCapped.txt
@@ -30,7 +30,7 @@ cloneCollectionAsCapped
    - MongoDB will transverse the documents in the original collection
      in :term:`natural order <natural order>` as they're loaded. 
 
-   - If the ``capped size`` specified for the new collection collection is
+   - If the ``capped size`` specified for the new collection is
      smaller than the size of the original uncapped collection, then
      MongoDB will begin overwriting earlier documents in 
      insertion order, which is *first in, first out* (e.g "FIFO").

--- a/source/reference/command/compact.txt
+++ b/source/reference/command/compact.txt
@@ -106,7 +106,7 @@ compact
 
    - :dbcommand:`compact` blocks all other activity. In MongoDB 2.2,
      :dbcommand:`compact` blocks activities only for its database. You
-     may view the intermediate progress either by viewing the the
+     may view the intermediate progress either by viewing the
      :program:`mongod` log file, or by running the
      :method:`db.currentOp()` in another shell instance.
 

--- a/source/reference/command/convertToCapped.txt
+++ b/source/reference/command/convertToCapped.txt
@@ -25,7 +25,7 @@ convertToCapped
    command exhibit the following behavior:
 
    - MongoDB transverses the documents in the original collection in
-     :term:`natural order` and loads the documents into  into a new
+     :term:`natural order` and loads the documents into a new
      capped collection.
 
    - If the ``capped size`` specified for the capped collection is

--- a/source/reference/command/copydb.txt
+++ b/source/reference/command/copydb.txt
@@ -32,7 +32,7 @@ copydb
    You can omit the ``fromhost`` argument, to copy one database to
    another database within a single MongoDB instance.
 
-   You must run this command on the the destination, or the ``todb``
+   You must run this command on the destination, or the ``todb``
    server.
 
    Be aware of the following behaviors:

--- a/source/reference/config-database.txt
+++ b/source/reference/config-database.txt
@@ -35,7 +35,7 @@ Collections
 .. data:: chunks
 
    The :data:`chunks` collection stores a document for each chunk in
-   in the cluster.  Consider the following example of a document for a
+   the cluster.  Consider the following example of a document for a
    chunk named ``records.pets-animal_\"cat\"``:
 
    .. code-block:: javascript

--- a/source/reference/glossary.txt
+++ b/source/reference/glossary.txt
@@ -9,7 +9,7 @@ Glossary
 
    BSON
       A serialization format used to store documents and make remote
-      procedure calls in MongoDB. "BSON" is a a portmanteau of the words
+      procedure calls in MongoDB. "BSON" is a portmanteau of the words
       "binary" and "JSON". Think of BSON as a binary representation
       of JSON (JavaScript Object Notation) documents. For a detailed spec,
       see `bsonspec.org <http://bsonspec.org/>`_.
@@ -174,7 +174,7 @@ Glossary
 
    box
       MongoDB's :term:`geospatial` indexes and querying system
-      allow you to to build queries around rectangles on two-dimensional
+      allow you to build queries around rectangles on two-dimensional
       coordinate systems. These queries use the :operator:`$box`
       operator to define a shape using the lower-left
       and the upper-right coordinates.
@@ -385,7 +385,7 @@ Glossary
    haystack index
       In the context of :term:`geospatial` queries, haystack indexes
       enhance searches by creating "bucket" of objects grouped by a second
-      criterion. For example, you might want want all geographical searches
+      criterion. For example, you might want all geographical searches
       to also include the type of location being searched for. In this case,
       you can create a haystack index that includes a document's position
       and type:

--- a/source/reference/method/ObjectId.valueOf.txt
+++ b/source/reference/method/ObjectId.valueOf.txt
@@ -12,7 +12,7 @@ ObjectId.valueOf()
 
    .. versionchanged:: 2.2
       In previous versions :method:`ObjectId.valueOf()` returns the
-      the ``ObjectId()`` object.
+      ``ObjectId()`` object.
 
    In the following example, call the :method:`valueOf()
    <ObjectId.valueOf()>` method on an ObjectId

--- a/source/reference/method/db.collection.stats.txt
+++ b/source/reference/method/db.collection.stats.txt
@@ -15,7 +15,7 @@ db.collection.stats()
 
    This function provides a wrapper around the database command
    :dbcommand:`collStats`. The ``scale`` option allows you to
-   configure how the :program:`mongo` shell scales the the sizes
+   configure how the :program:`mongo` shell scales the sizes
    of things in the output. For example, specify a ``scale``
    value of ``1024`` to display kilobytes rather than bytes.
 

--- a/source/reference/method/db.collection.update.txt
+++ b/source/reference/method/db.collection.update.txt
@@ -173,7 +173,7 @@ db.collection.update()
    - To update a document or to insert a new document if no
      document matches the query criteria, call the
      :method:`update() <db.collection.update()>` and specify the
-     ``upsert`` option in the the ``options`` argument, as in the
+     ``upsert`` option in the ``options`` argument, as in the
      following:
 
      .. code-block:: javascript

--- a/source/reference/method/db.stats.txt
+++ b/source/reference/method/db.stats.txt
@@ -15,7 +15,7 @@ db.stats()
 
    This function provides a wrapper around the database command
    ":dbcommand:`dbStats`". The ``scale`` option allows you to
-   configure how the :program:`mongo` shell scales the the sizes
+   configure how the :program:`mongo` shell scales the sizes
    of things in the output. For example, specify a ``scale``
    value of ``1024`` to display kilobytes rather than bytes.
 

--- a/source/reference/server-status-index.txt
+++ b/source/reference/server-status-index.txt
@@ -4,7 +4,7 @@ Server Status Output Index
 
 .. default-domain:: mongodb
 
-This document provides a quick overview and example of the the
+This document provides a quick overview and example of the
 :dbcommand:`serverStatus` command. The helper :method:`db.serverStatus()`
 in the :program:`mongo` shell provides access to this output. For full
 documentation of the content of this output, see

--- a/source/tutorial/configure-linux-iptables-firewall.txt
+++ b/source/tutorial/configure-linux-iptables-firewall.txt
@@ -41,9 +41,9 @@ required communication between your application and the appropriate
 :program:`mongod` and :program:`mongos` instances.
 
 Be aware that, by default, the default policy of ``iptables`` is to
-allow all connections and traffic unless explicitly disabled. THe
+allow all connections and traffic unless explicitly disabled. The
 configuration changes outlined in this document will create rules that
-explicitly allow traffic from specific addresses and on specific ports
+explicitly allow traffic from specific addresses and on specific
 ports, using a default policy that drops all traffic that is not
 explicitly allowed. When you have properly configured your
 ``iptables`` rules to allow only the traffic that you want to permit,
@@ -138,7 +138,7 @@ resemble the following:
 
    iptables -A INPUT -s <ip-address> -p tcp --destination-port 27019 -m state --state NEW,ESTABLISHED -j ACCEPT
 
-Replace ``<ip-address>`` with the address address of the
+Replace ``<ip-address>`` with the address of the
 :program:`mongos` instances and the shard :program:`mongod`
 instances.
 
@@ -257,7 +257,7 @@ some aspects of ``iptables`` configuration, but at the core all
 Make all ``iptables`` Rules Persistent
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default all ``iptables`` rules are are only stored in memory. When
+By default all ``iptables`` rules are only stored in memory. When
 your system restarts, your firewall rules will revert to their
 defaults. When you have tested a rule set and have guaranteed that it
 effectively controls traffic you can use the following operations to

--- a/source/tutorial/configure-windows-netsh-firewall.txt
+++ b/source/tutorial/configure-windows-netsh-firewall.txt
@@ -42,7 +42,7 @@ required communication between your application and the appropriate
 :program:`mongod.exe` and :program:`mongos.exe` instances.
 
 The configuration changes outlined in this document will create rules
-which explicitly allow traffic from specific addresses and on specific ports
+which explicitly allow traffic from specific addresses and on specific
 ports, using a default policy that drops all traffic that is not
 explicitly allowed. 
 

--- a/source/tutorial/convert-standalone-to-replica-set.txt
+++ b/source/tutorial/convert-standalone-to-replica-set.txt
@@ -12,7 +12,7 @@ standalone instance into a three-member replica set. If you're
 deploying a replica set "fresh," without any existing MongoDB data or
 instance, see :doc:`/tutorial/deploy-replica-set`.
 
-For more information on on :doc:`replica sets, their use, and
+For more information on :doc:`replica sets, their use, and
 administration </replication>`, see:
 
 - :doc:`/core/replication`,

--- a/source/tutorial/copy-databases-between-instances.txt
+++ b/source/tutorial/copy-databases-between-instances.txt
@@ -55,7 +55,7 @@ Considerations
   :term:`secondary` member of a replica set, with properly configured
   :term:`read preference`.
 
-- Each destination :program:`mongod` instance must must have enough
+- Each destination :program:`mongod` instance must have enough
   free disk space on the destination server for the database you are
   copying. Use the :method:`db.stats()` operation to check the size of
   the database on the source :program:`mongod` instance. For more

--- a/source/tutorial/deploy-replica-set.txt
+++ b/source/tutorial/deploy-replica-set.txt
@@ -51,7 +51,7 @@ The examples in this procedure create a new replica set named ``rs0``.
 
 1. Before creating your replica set, verify that every member can
    successfully connect to every other member. The network
-   configuration must allow all possible connections between any any
+   configuration must allow all possible connections between any
    two members. To test connectivity, see
    :ref:`replica-set-troubleshooting-check-connection`.
 
@@ -200,7 +200,7 @@ To deploy a production replica set:
 
 1. Before creating your replica set, verify that every member can
    successfully connect to every other member. The network
-   configuration must allow all possible connections between any any
+   configuration must allow all possible connections between any
    two members. To test connectivity, see
    :ref:`replica-set-troubleshooting-check-connection`.
 

--- a/source/tutorial/perform-two-phase-commits.txt
+++ b/source/tutorial/perform-two-phase-commits.txt
@@ -203,7 +203,7 @@ Set Transaction State to Committed
 ``````````````````````````````````
 
 Use the following :method:`update() <db.collection.update()>` operation
-to set the the transaction's state to ``committed``:
+to set the transaction's state to ``committed``:
 
 .. code-block:: javascript
 
@@ -368,7 +368,7 @@ following:
 Set Transaction State to Canceled
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Finally, use the following following :method:`update()
+Finally, use the following :method:`update()
 <db.collection.update()>` operation to set the transaction's state to
 ``canceled``:
 

--- a/source/use-cases/inventory-management.txt
+++ b/source/use-cases/inventory-management.txt
@@ -144,7 +144,7 @@ function operation.
 
 .. admonition:: The system does not trust that the available inventory can satisfy a request
 
-   First this operation checks to make sure that that the cart is
+   First this operation checks to make sure that the cart is
    "active" before adding a item. Then, it verifies that the available
    inventory to satisfy the request before decrementing inventory.
 

--- a/source/use-cases/metadata-and-asset-management.txt
+++ b/source/use-cases/metadata-and-asset-management.txt
@@ -435,9 +435,9 @@ site, or in an ``.rss`` or ``.atom`` feed.
 Indexing
 ````````
 
-Create an compound index the the ``{ metadata.section: 1,
-metadata.published: 1 }`` fields to support this query and sort
-operation.
+Create a compound index on the
+``{ metadata.section: 1, metadata.published: 1 }``
+fields to support this query and sort operation.
 
 .. code-block:: python
 

--- a/source/use-cases/product-catalog.txt
+++ b/source/use-cases/product-catalog.txt
@@ -185,7 +185,7 @@ Avoid Modeling Product Data
 ```````````````````````````
 
 Additionally some e-commerce solutions with relational database
-systems avoid choosing one of the the data models above, and serialize
+systems avoid choosing one of the data models above, and serialize
 all of this data into a ``BLOB`` column. While simple, the details
 become difficult to access for search and sort.
 

--- a/source/use-cases/storing-comments.txt
+++ b/source/use-cases/storing-comments.txt
@@ -578,7 +578,7 @@ logic to support this:
 This :py:meth:`update() <pymongo:pymongo.collection.Collection.update>` operation
 includes the last known number of pages in the query to prevent a race
 condition where the number of pages incriments twice, that would
-result result in a nearly or totally empty document. If another
+result in a nearly or totally empty document. If another
 process increments the number of pages, then update above does
 nothing.
 


### PR DESCRIPTION
Q: most of the doubled words were really short, am wondering if this is something I introduced with one of the earlier spell check runs, or if there's some other automated thing we're using that caused this?
