### PR TITLE
Update source/administration/backups.txt

### DIFF
--- a/source/administration/backups.txt
+++ b/source/administration/backups.txt
@@ -599,11 +599,7 @@ is true:
 - The backup can run and complete without affecting the performance of
   the cluster.
 
-.. note:: If you use :program:`mongodump` without specifying the a database or
-   collection, the output will contain both the collection data and the
-   sharding config metadata from the :ref:`config servers <sharding-config-server>`.
-
-   You cannot use the :option:`--oplog <mongodump --oplog>` option for
+.. note::You cannot use the :option:`--oplog <mongodump --oplog>` option for
    :program:`mongodump` when dumping from a :program:`mongos`. This option is only
    available when running directly against a :term:`replica set` member.
 


### PR DESCRIPTION
 If you use :program:`mongodump` without specifying the a database or
   collection, the output will contain both the collection data and the
   sharding config metadata from the :ref:`config servers <sharding-config-server>`.

It is from version 2.2 now
