### PR TITLE
Remove bogus word & fix boolean value

### DIFF
--- a/source/reference/replica-configuration.txt
+++ b/source/reference/replica-configuration.txt
@@ -91,7 +91,7 @@ Configuration Variables
    - You are only using this instance to perform backups using
      :program:`mongodump`,
 
-   - this instance will receive no queries will, *and*
+   - this instance will receive no queries, *and*
 
    - index creation and maintenance overburdens the host
      system.
@@ -108,7 +108,7 @@ Configuration Variables
       member to the set.
 
       Furthermore, other secondaries cannot synchronize off of replica
-      set members where :data:`members[n].buildIndexes` is true.
+      set members where :data:`members[n].buildIndexes` is false.
 
 .. data:: members[n].hidden
 


### PR DESCRIPTION
Secondaries cannot synchronize from members where buildIndexes is _false_
