### PR TITLE
DOCS-821 default writeconcern change for mongorestore to 0 under 2.3.2

### DIFF
--- a/source/reference/mongorestore.txt
+++ b/source/reference/mongorestore.txt
@@ -190,6 +190,12 @@ Options
    database. By default, :program:`mongorestore` waits for the write
    operation to return on 1 member of the set (i.e. the
    :term:`primary`.)
+   
+   .. versionchanged:: 2.3.2
+   
+   Effective with MongoDB 2.3.2 the default :term:`write concern` used
+   by :program:`mongorestore` is now 0, disabling basic acknowledgment of
+   write operations.
 
 .. option:: --noOptionsRestore
 


### PR DESCRIPTION
The code change will ship with 2.3.2.
