### PR TITLE
Fix two small typos in Operator Reference

### DIFF
--- a/source/reference/operator/and.txt
+++ b/source/reference/operator/and.txt
@@ -40,10 +40,10 @@ $and
       db.inventory.find( { price: 1.99, qty: { $lt: 20 } , sale: true } )
    
    If, however, a query requires an ``AND`` operation on the same field
-   such as ``{ $price: { $ne: 1.99 } } AND { price: { $exists: true }
+   such as ``{ price: { $ne: 1.99 } } AND { price: { $exists: true }
    }``, then either use the :operator:`$and` operator for the two
    separate expressions or combine the operator expressions for the
-   field ``{ $price: { $ne: 1.99, $exists: true } }``.
+   field ``{ price: { $ne: 1.99, $exists: true } }``.
 
    Consider the following examples:
     


### PR DESCRIPTION
Fix two $and examples where a field name is inappropriately prefixed by a dollar sign.
