### PR TITLE
Correcting description of two monitoring third party tools

### DIFF
--- a/source/administration/monitoring.txt
+++ b/source/administration/monitoring.txt
@@ -164,7 +164,7 @@ on your own servers, usually open source.
      - **Description**
    * - `Ganglia <http://sourceforge.net/apps/trac/ganglia/wiki>`_
      - `mongodb-ganglia <https://github.com/quiiver/mongodb-ganglia>`_
-     - Shell script to report operations per second, memory usage, btree statistics, master/slave status and current connections.
+     - Python script to report operations per second, memory usage, btree statistics, master/slave status and current connections.
    * - Ganglia
      - `gmond_python_modules <https://github.com/ganglia/gmond_python_modules>`_
      - Parses output from the :dbcommand:`serverStatus` and :dbcommand:`replSetGetStatus` commands.
@@ -185,7 +185,7 @@ on your own servers, usually open source.
      - Some additional munin plugins not in the main distribution.
    * - `Nagios <http://www.nagios.org/>`_
      - `nagios-plugin-mongodb <https://github.com/mzupan/nagios-plugin-mongodb>`_
-     - A simple Nagios check script.
+     - A simple Nagios check script, written in Python.
    * - `Zabbix <http://www.zabbix.com/>`_
      - `mikoomi-mongodb <https://code.google.com/p/mikoomi/wiki/03>`_
      - Monitors availability, resource utilization, health, performance and other important metrics.


### PR DESCRIPTION
I changed the description of `mongodb-ganglia` from `Shell` to `Python` as it's a bit misleading.

For `nagios-plugin-mongodb`, I added the language it's written it.

Both information are important for sysadmins looking for tools in a specific language to reduce dependencies on the monitoring server.
