### PR TITLE
Update source/reference/operator/mod.txt

### DIFF
--- a/source/reference/operator/mod.txt
+++ b/source/reference/operator/mod.txt
@@ -18,7 +18,7 @@ $mod
       db.inventory.find( { qty: { $mod: [ 4, 0 ] } } )
    
    This query will select all documents in the ``inventory`` collection
-   where the ``qty`` field value modulo ``4`` equals ``3``, such as
+   where the ``qty`` field value modulo ``4`` equals ``0``, such as
    documents with ``qty`` value equal to ``0`` or ``12``.
    
    In some cases, you can query using the :operator:`$mod` operator
@@ -27,14 +27,14 @@ $mod
    
    .. code-block:: javascript
    
-      db.inventory.find( { qty: { $mod: [ 4, 3 ] } } )
+      db.inventory.find( { qty: { $mod: [ 4, 0 ] } } )
    
    The above query is less expensive than the following query which
    uses the :operator:`$where` operator:
      
    .. code-block:: javascript
    
-      db.inventory.find( { $where: "this.qty % 4 == 3" } )
+      db.inventory.find( { $where: "this.qty % 4 == 0" } )
       
    .. seealso::
    


### PR DESCRIPTION
Fixed modulo math error in the docs. Then made all modulo expressions consistent: x % 4 = 0
