### PR TITLE
temporarily store journaling faq as note in storage faq

### DIFF
--- a/source/faq/storage.txt
+++ b/source/faq/storage.txt
@@ -101,3 +101,55 @@ active document in memory.
 
 For best performance, the majority of your *active* set should fit in
 RAM.
+
+
+.. todo The following "journal FAQ" content is from the wiki and must be added
+   to the manual, perhaps on this page.
+
+.. If I am using replication, can some members use journaling and others
+   not?
+   --------------------------------------------------------------------------
+
+.. Yes. It is OK to use journaling on some replica set members and not
+   others.
+
+.. Can I use the journaling feature to perform safe hot backups?
+   -------------------------------------------------------------
+
+.. Yes, see :doc:`/administration/backups`.
+
+.. 32 bit nuances?
+   ---------------
+
+.. There is extra memory mapped file activity with journaling. This will
+   further constrain the limited db size of 32 bit builds. Thus, for now
+   journaling by default is disabled on 32 bit systems.
+
+.. When did the --journal option change from --dur?
+   ------------------------------------------------
+
+.. In 1.8 the option was renamed to --journal, but the old name is still
+   accepted for backwards compatibility; please change to --journal if
+   you are using the old option.
+
+.. Will the journal replay have problems if entries are incomplete (like
+   the failure happened in the middle of one)?
+   -----------------------------------------------------------------------------------------------------------------
+
+.. Each journal (group) write is consistent and won't be replayed during
+   recovery unless it is complete.
+
+.. How many times is data written to disk when replication and
+   journaling are both on?
+   -----------------------------------------------------------------------------------
+
+.. In v1.8, for an insert, four times. The object is written to the main
+   collection and also the oplog collection. Both of those writes are
+   also journaled as a single mini-transaction in the journal files in
+   /data/db/journal.
+
+.. The above applies to collection data and inserts which is the worst
+   case scenario. Index updates are written to the index and the
+   journal, but not the oplog, so they should be 2X today not 4X.
+   Likewise updates with things like $set, $addToSet, $inc, etc. are
+   compactly logged all around so those are generally small.


### PR DESCRIPTION
Ready for Merge. This stores the journaling faq info in a note in the storage faq doc. 
I've filed DOCS-904: "Add Journaling FAQ Content to the Manual"
