### PR TITLE
Added index caveats regarding the $or operator

### DIFF
--- a/source/core/indexes.txt
+++ b/source/core/indexes.txt
@@ -796,3 +796,14 @@ Be aware of the following behaviors and limitations:
 
 - Create indexes to support queries and other operations, but do not
   maintain indexes that your MongoDB instance cannot or will not use.
+
+- When using indexes with :operator:`$or` queries, remember that
+  each clause of an :operator:`$or` query will execute in parallel.
+  These clauses can each use their own index.
+
+- When using the :operator:`$or` operator with the
+  :method:`sort() <cursor.sort()>` method in a query, the query will
+  **not** use the indexes on the :operator:`$or` fields.
+
+- You cannot use the :operator:`$or` with ``2d`` :doc:`geospatial
+  queries </core/geospatial-indexes>`.


### PR DESCRIPTION
The index documentation failed to mention the caveats, gotchas, and sinkholes when using the $or operator. I watered down the salient details from the $or documentation and added them to the "Index Behaviors and Limitations" section.
