### PR TITLE
Update source/reference/command/compact.txt

### DIFF
--- a/source/reference/command/compact.txt
+++ b/source/reference/command/compact.txt
@@ -165,13 +165,13 @@ compact
        ``force:true`` above for information regarding compacting the
        primary.
 
-     - If you run :dbcommand:`compact` on a secondary, the secondary
-       will enter a "recovering" state to prevent clients from
+   .. warning:: If you run :dbcommand:`compact` on a secondary, the 
+       secondary will enter a "RECOVERING" state to prevent clients from
        sending read operations during compaction. Once the compaction
-       finishes the secondary will automatically return to secondary
-       state.
+       finishes the secondary will automatically return to "SECONDARY"
+       state.  See :status:`members.state` for more information on states.
 
-       You may refer to the "`partial script for automating step down
+     - You may refer to the "`partial script for automating step down
        and compaction  <https://github.com/mongodb/mongo-snippets/blob/master/js/compact-example.js>`_")
        for an example.
 


### PR DESCRIPTION
Changed the note about the status change for a compact to be a warning 
and altered the case of the states to make it more in line with what 
is actually displayed in rs.status() and added a link to the state 
definitions for more info.
