### PR TITLE
Update source/tutorial/deploy-replica-set.txt

### DIFF
--- a/source/tutorial/deploy-replica-set.txt
+++ b/source/tutorial/deploy-replica-set.txt
@@ -27,13 +27,15 @@ deployments require no additional members or configuration.
 Requirements
 ------------
 
-A replica set requires two or more distinct systems so that each system can run its own
-instance of :program:`mongod`. This tutorial will deal with a 3 member set. For
-development systems you can run all three instances of the :program:`mongod` process on a
-local system. (e.g. a laptop) or within a virtual instance. For production
-environments, you should endeavor to maintain as much separation between the members as
-possible.  For example, when using VMs in Production, each member should live on separate
-host servers, served by redundant power circuits, and with redundant network paths.
+Most replica sets are made up of two or more :program:`mongod` instances. This tutorial
+will deal with a 3 member set specifically.  In a production environment, this would
+usually involve a deployment on 3 distinct systems so that each system can run its own
+instance of :program:`mongod`. For development systems you can run all three instances
+of the :program:`mongod` process on a local system. (e.g. a laptop) or within a virtual
+instance. For production environments, you should endeavor to maintain as much separation
+between the members as possible.  For example, when using VMs in Production, each member
+should live on separate host servers, served by redundant power circuits, and with
+redundant network paths.
 
 Procedure
 ---------


### PR DESCRIPTION
Fixed the requirements section to agree with the docs here:

http://docs.mongodb.org/manual/core/replication/

The requirement for a set is one or more, with the usual deployment of 2 or more etc.
The tutorial describes three, hence the language and it led to some confusion in the community:

http://serverfault.com/questions/462780/does-a-mongodb-replica-set-require-at-least-2-or-3-members
