### PR TITLE
typo edit run

### DIFF
--- a/source/administration/sharding.txt
+++ b/source/administration/sharding.txt
@@ -311,7 +311,7 @@ The procedure to remove a shard is as follows:
 
    .. code-block:: javascript
 
-      db.runCommand( { removeshard: "mongodb0" } )
+      db.runCommand( { removeShard: "mongodb0" } )
 
    This operation will return the following response immediately:
 
@@ -377,7 +377,7 @@ The procedure to remove a shard is as follows:
 
    .. code-block:: javascript
 
-      db.runCommand( { removeshard: "mongodb0" } )
+      db.runCommand( { removeShard: "mongodb0" } )
 
    When successful, this command will return a document like this:
 

--- a/source/applications/map-reduce.txt
+++ b/source/applications/map-reduce.txt
@@ -197,7 +197,7 @@ map-reduce:
                           }
                         );
 
-.. _map-reduce-temporay-collection:
+.. _map-reduce-temporary-collection:
 
 Temporary Collection
 --------------------

--- a/source/applications/replication.txt
+++ b/source/applications/replication.txt
@@ -67,7 +67,7 @@ for a replica set. Use the :data:`settings.getLastErrorDefaults` setting
 in the :doc:`replica set configuration
 </reference/replica-configuration>`. The following sequence of commands
 creates a configuration that waits for the write operation to complete
-on a majority of the set members beforBe returning:
+on a majority of the set members before returning:
 
 .. code-block:: javascript
 

--- a/source/core/data-modeling.txt
+++ b/source/core/data-modeling.txt
@@ -146,7 +146,7 @@ Atomicity
 
 MongoDB only provides atomic operations on the level of a single
 document. [#record-atomicity]_ As a result needs for atomic operations influence decisions
-to use embeded or referenced relationships when modeling data for
+to use embedded or referenced relationships when modeling data for
 MongoDB.
 
 Embed fields that need to be modified together atomically in the same
@@ -245,7 +245,7 @@ the size of the ``<database>.ns`` file, pass a new size to
 :option:`--nssize option \<new size MB\> <mongod --nssize>` on server
 start.
 
-.. todo make a tutoiral called "how to change size of namespace file"
+.. todo make a tutorial called "how to change size of namespace file"
 
 The :option:`--nssize <mongod --nssize>` sets the size for *new*
 ``<database>.ns`` files. For existing databases, after starting up the

--- a/source/core/write-operations.txt
+++ b/source/core/write-operations.txt
@@ -207,7 +207,7 @@ concern requirements:
        If you disable basic write operation acknowledgment but require
        journal commit acknowledgment, the journal commit prevails, and
        the driver will require that :program:`mongod`  will
-       acknowladge the replica set.
+       acknowledge the replica set.
 
   - ``1``:
 

--- a/source/reference/config-database.txt
+++ b/source/reference/config-database.txt
@@ -122,7 +122,7 @@ Collections
 
    .. data:: changelog.ns
 
-      Namespace where the change occured.
+      Namespace where the change occurred.
 
    .. data:: changelog.details
 

--- a/source/reference/method/cursor.min.txt
+++ b/source/reference/method/cursor.min.txt
@@ -27,7 +27,7 @@ cursor.min()
           *in order*. You can explicitly specify the particular index
           with the :method:`hint() <cursor.hint()>` method. Otherwise,
           MongoDB selects the index using the fields in the
-          ``indexbounds``; however, if multiple indexes exist on same
+          ``indexBounds``; however, if multiple indexes exist on same
           fields with different sort orders, the selection of the index
           may be ambiguous.
 

--- a/source/reference/mongodb-extended-json.txt
+++ b/source/reference/mongodb-extended-json.txt
@@ -25,7 +25,7 @@ MongoDB can process of these representations in REST input.
 
 Special representations of :term:`BSON data <BSON types>` in JSON
 format make it possible to render information that have no obvious
-corresponding JSON. In some cases MongoDB supports multiple equivelent
+corresponding JSON. In some cases MongoDB supports multiple equivalent
 representations of the same type information. Consider the following
 table:
 

--- a/source/reference/operator/min.txt
+++ b/source/reference/operator/min.txt
@@ -37,7 +37,7 @@ $min
 
    You can explicitly specify the corresponding index with
    :method:`cursor.hint()`. Otherwise, MongoDB selects the index using
-   the fields in the ``indexbounds``; however, if multiple indexes
+   the fields in the ``indexBounds``; however, if multiple indexes
    exist on same fields with different sort orders, the selection of
    the index may be ambiguous.
 

--- a/source/release-notes/2.4.txt
+++ b/source/release-notes/2.4.txt
@@ -328,7 +328,7 @@ indexes:
   *However*, hashed indexes may be smaller than a normal index when
   the values of the indexed field are larger than 64 bits. [#hash-size]_
 
-- it's possible to have a hashed and non-hased index on the same
+- it's possible to have a hashed and non-hashed index on the same
   field: MongoDB will use the non-hashed for range queries.
 
 .. _hashed-index-warning:

--- a/source/tutorial/backup-sharded-cluster-with-database-dumps.txt
+++ b/source/tutorial/backup-sharded-cluster-with-database-dumps.txt
@@ -28,7 +28,7 @@ In this procedure, you will stop the cluster balancer and take a backup
 up of the :term:`config database`, and then take backups of each
 shard in the cluster using :program:`mongodump` to capture the backup
 data. If you need an exact moment-in-time snapshot of the system, you will
-need to stop all application writes before taking the filesysem
+need to stop all application writes before taking the filesystem
 snapshots; otherwise the snapshot will only approximate a moment of
 time.
 
@@ -95,7 +95,7 @@ shard.
    dump to the ``/data/backup/`` directory.
 
 #. Restart all stopped replica set members of each shard as normal and
-   allow them to catch up wit hthe state of the primary.
+   allow them to catch up with the state of the primary.
 
 #. Restore the balancer with the :method:`sh.startBalancer()` method
    according to the :ref:`sharding-balancing-disable-temporally`

--- a/source/tutorial/backup-sharded-cluster-with-filesystem-snapshots.txt
+++ b/source/tutorial/backup-sharded-cluster-with-filesystem-snapshots.txt
@@ -28,7 +28,7 @@ In this procedure, you will stop the cluster balancer and take a backup
 up of the :term:`config database`, and then take backups of each
 shard in the cluster using a file-system snapshot tool. If you need an
 exact moment-in-time snapshot of the system, you will need to stop all
-application writes before taking the filesysem snapshots; otherwise
+application writes before taking the filesystem snapshots; otherwise
 the snapshot will only approximate a moment of in time.
 
 For approximate point-in-time snapshots, you can improve the quality

--- a/source/tutorial/create-tailable-cursor.txt
+++ b/source/tutorial/create-tailable-cursor.txt
@@ -11,7 +11,7 @@ By default, MongoDB will automatically close a cursor when the client
 has exhausted all results in the cursor. However, for :doc:`capped
 collections </core/capped-collections>` you may use a *Tailable
 Cursor* that remains open after the client exhausts the results in the
-initial causer. Taliable cursors are conceptually equivelent to the
+initial cursor. Tailable cursors are conceptually equivalent to the
 ``tail`` Unix command with the ``-f`` option (i.e. with "follow"
 mode.) After clients insert new additional documents into a capped
 collection, the tailable cursor will to continue to retrieve

--- a/source/tutorial/getting-started-with-the-mongo-shell.txt
+++ b/source/tutorial/getting-started-with-the-mongo-shell.txt
@@ -49,7 +49,7 @@ To start the :program:`mongo` shell and connect to your :doc:`MongoDB
    To list the available databases, use the command ``show dbs``. See
    also :ref:`mongo-shell-getSiblingDB` to access a different database
    from the current database without switching your current database
-   contentx (i.e. ``db.``.)
+   context (i.e. ``db.``.)
 
 To start the :program:`mongo` shell with other options, see
 :ref:`examples of starting up mongo <mongo-usage-examples>` and

--- a/source/tutorial/manage-the-database-profiler.txt
+++ b/source/tutorial/manage-the-database-profiler.txt
@@ -42,7 +42,7 @@ The following profiling levels are available:
 
   You can modify the threshold for "slow" operations with the
   :setting:`slowms` runtime option or the :dbcommand:`set Parameter`
-  method. See the :ref:`database-profiling-specifiy-slowms-threshold`
+  method. See the :ref:`database-profiling-specify-slowms-threshold`
   section for more information.
 
 - ``2`` - collects profiling data for all database operations.
@@ -87,7 +87,7 @@ The ``"ok" : 1`` key-value pair indicates the operation succeeded:
 To verify the new setting, see the
 :ref:`database-profiling-view-status` section.
 
-.. _database-profiling-specifiy-slowms-threshold:
+.. _database-profiling-specify-slowms-threshold:
 
 Specify the Threshold for Slow Operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/tutorial/remove-shards-from-cluster.txt
+++ b/source/tutorial/remove-shards-from-cluster.txt
@@ -57,7 +57,7 @@ begins "draining" chunks from the shard you are removing.
 
 .. code-block:: javascript
 
-   db.runCommand( { removeshard: "mongodb0" } )
+   db.runCommand( { removeShard: "mongodb0" } )
 
 This operation returns immediately, with the following response:
 
@@ -78,7 +78,7 @@ process, as follows:
 
 .. code-block:: javascript
 
-   db.runCommand( { removeshard: "mongodb0" } )
+   db.runCommand( { removeShard: "mongodb0" } )
 
 The output resembles the following document:
 
@@ -90,7 +90,7 @@ In the ``remaining`` sub document, a counter displays the remaining number
 of chunks that MongoDB must migrate to other shards and the number of
 MongoDB databases that have "primary" status on this shard.
 
-Continue checking the status of the `removeshard` command until the
+Continue checking the status of the `removeShard` command until the
 number of chunks remaining is 0. Then proceed to the next step.
 
 Move Unsharded Databases
@@ -131,7 +131,7 @@ information and finalize the removal, as follows:
 
 .. code-block:: javascript
 
-   db.runCommand( { removeshard: "mongodb0" } )
+   db.runCommand( { removeShard: "mongodb0" } )
 
 A success message appears at completion:
 


### PR DESCRIPTION
It's "equivalent" not "equivelent".
and removeShard is biCamelCase sensitive
