### PR TITLE
Update source/faq/concurrency.txt

### DIFF
--- a/source/faq/concurrency.txt
+++ b/source/faq/concurrency.txt
@@ -233,9 +233,9 @@ secondaries, in a two phases:
 What kind of concurrency does MongoDB provide for JavaScript operations?
 ------------------------------------------------------------------------
 
-A single :program:`mongod` can only *single* JavaScript operation at
-once. Therefore, operations that rely on JavaScript cannot run
-concurrently; however, the :program:`mongod` can often run other
+A single :program:`mongod` can only run a *single* JavaScript
+operation at once. Therefore, operations that rely on JavaScript cannot
+run concurrently; however, the :program:`mongod` can often run other
 database operations concurrently with the JavaScript execution. This
 limitation with JavaScript affects the following operations:
 


### PR DESCRIPTION
Simple typo - word missing in the JS operations paragraph
