### PR TITLE
Procedure for Testing Replica Set is Wrong

### DIFF
--- a/source/tutorial/deploy-replica-set.txt
+++ b/source/tutorial/deploy-replica-set.txt
@@ -112,7 +112,7 @@ The examples in this procedure create a new replica set named ``rs0``.
 
    .. code-block:: javascript
 
-      rs.initiate()
+      rs.initiate( { _id:"rs0", "members": [ { _id:0, "host":"localhost:27017" } ] } )
 
 #. Display the current :doc:`replica configuration </reference/replica-configuration>`:
 


### PR DESCRIPTION
If you don't specify your member host name in rs.initiate(), rs.add("localhost:27018") will fail.

...host in repl set member names except when using it for all members" on subsequent rs.add()
