### PR TITLE
Added a note about how to restore the backup of oplog.rs

### DIFF
--- a/source/tutorial/change-oplog-size.txt
+++ b/source/tutorial/change-oplog-size.txt
@@ -41,12 +41,12 @@ The examples in this procedure use the following configuration:
   of ``/srv/mongodb``.
 
 To change the size of the oplog for a replica set, use the following
-procedure for every member of the set that may become primary. 
- 
-1. Shut down the :program:`mongod` instance and restart it in
-   "standalone" mode running on a different port.  
+procedure for every member of the set that may become primary.
 
-   .. note:: 
+1. Shut down the :program:`mongod` instance and restart it in
+   "standalone" mode running on a different port.
+
+   .. note::
 
       Shutting down the :term:`primary` member of the set will trigger
       a failover situation and another member in the replica set will
@@ -76,6 +76,10 @@ procedure for every member of the set that may become primary.
    .. code-block:: sh
 
       mongodump --db local --collection 'oplog.rs' --port 37017
+
+   .. note::
+
+      Restore the backup using the `mongorestore` command.
 
    Connect to the instance using the :program:`mongo` shell:
 


### PR DESCRIPTION
Added a note about how to restore the backup of oplog.rs in the [Change the Size of the Oplog](http://docs.mongodb.org/manual/tutorial/change-oplog-size/) tutorial.
