### PR TITLE
Flask-mongoengine fix for Tumblelog/Flask/MongoEngine tutorial

### DIFF
--- a/source/tutorial/write-a-tumblelog-application-with-flask-mongoengine.txt
+++ b/source/tutorial/write-a-tumblelog-application-with-flask-mongoengine.txt
@@ -160,7 +160,7 @@ Install the Flask_ extension and add the configuration. Update
    from flask.ext.mongoengine import MongoEngine
 
    app = Flask(__name__)
-   app.config["MONGODB_DB"] = "my_tumble_log"
+   app.config["MONGODB_SETTINGS"] = {'DB': "my_tumble_log"}
    app.config["SECRET_KEY"] = "KeepThisS3cr3t"
 
    db = MongoEngine(app)


### PR DESCRIPTION
Updated app.config to reflect changes in flask-mongoengine; it now expects a "MONGODB_SETTINGS" dict (https://github.com/MongoEngine/flask-mongoengine/commit/352670e2ec80a2c2846a757214a0c3dfe0fa6eb4).

While there is a fallback, I suspect it may be broken, and the new way is just better.
