### PR TITLE
Update source/includes/fact-replica-set-sync-from-is-temporary.rst

### DIFF
--- a/source/includes/fact-replica-set-sync-from-is-temporary.rst
+++ b/source/includes/fact-replica-set-sync-from-is-temporary.rst
@@ -1,4 +1,5 @@
 :dbcommand:`replSetSyncFrom` and :method:`rs.syncFrom()` provide a
 temporary override of default behavior. If the :program:`mongod`
-restarts or the connection to the sync target closes,
-:program:`mongod` will revert to the default sync logic and target.
+restarts, the connection to the sync target closes, or the sync target falls
+more than 30s behind another node, :program:`mongod` will revert to
+the default sync logic and target.


### PR DESCRIPTION
DOCS-1028 updated behavior of replSetSyncFrom for 2.4.
