### PR TITLE
DOCS-979 updated after finding a comment from Randall

### DIFF
--- a/source/reference/current-op.txt
+++ b/source/reference/current-op.txt
@@ -99,8 +99,10 @@ depending on the kind of operation and its state.
 
 .. data:: currentOp.active
 
-   A boolean value, that is ``true`` if the operation is currently running
+   A boolean value, that is ``true`` if the operation has started
    or ``false`` if the operation is queued and waiting for a lock to run.
+   :data:`~currentOp.active` may be ``true`` even if the operation has
+   yielded to another operation.
 
 .. data:: currentOp.secs_running
 


### PR DESCRIPTION
Randall commented in email:

_active is probably more correctly thought of as _started -- things remain active (currently) even when they're yielded. At least in my limited test and understanding of the execution logic. _active only goes back to false during a reset/when the op is done.

I checked in the source and _active will only be set to false
if the op has not started or the op has completed, otherwise it
is always true even if the op has yielded to another op.
