### PR TITLE
Update source/includes/fact-replica-set-sync-from-is-temporary.rst

### DIFF
--- a/source/includes/fact-replica-set-sync-from-is-temporary.rst
+++ b/source/includes/fact-replica-set-sync-from-is-temporary.rst
@@ -6,7 +6,7 @@ temporary override of default behavior. If:
 - the connection to the sync target closes, or 
 
 - the sync target falls more than 30 seconds behind another member of
-  the replica set;
+  the replica set (v2.4 only)
 
 then, the :program:`mongod` instant will revert to the default sync
 logic and target.


### PR DESCRIPTION
The last of these options is v2.4 only.  Not 100% sure how to report this in the "right" way, but we should note it.
