### PR TITLE
Update source/tutorial/install-mongodb-on-red-hat-centos-or-fedora-linux...

### DIFF
--- a/source/tutorial/install-mongodb-on-red-hat-centos-or-fedora-linux.txt
+++ b/source/tutorial/install-mongodb-on-red-hat-centos-or-fedora-linux.txt
@@ -12,7 +12,7 @@ This tutorial outlines the basic installation process for deploying
 and related systems. This procedure uses ``.rpm`` packages as the
 basis of the installation. 10gen publishes packages of the MongoDB
 releases as ``.rpm`` packages for easy installation and management for
-users of Debian systems. While some of these distributions include
+users of Centos, Fedora and RHEL systems. While some of these distributions include
 their own MongoDB packages, the 10gen packages are generally more up
 to date.
 


### PR DESCRIPTION
Removing copy/pasted reference to Debian and replace it with reference to RPM based system.
