### PR TITLE
Minor Syntax Changes

### DIFF
--- a/source/release-notes/2.4.txt
+++ b/source/release-notes/2.4.txt
@@ -73,9 +73,9 @@ support boolean text search queries:
   - Indexes and queries drop stop words (i.e. "the," "an," "a," "and,"
     etc.)
 
-  - MongoDB stores words stemmed during insertion in the index, using
-    simple suffix stemming, including support for a number of
-    languages. MongoDB automatically stems :dbcommand:`text` queries at
+  - MongoDB stores words stemmed during insertion in the index using
+    simple suffix stemming, and includes support for a number of
+    languages. MongoDB automatically stems :dbcommand:`text` queries
     before beginning the query.
 
 However, ``text`` indexes have large storage requirements and incur


### PR DESCRIPTION
Removed 'at'. Removed comma after 'index'. Changed 'including' to 'and includes'. 
