### PR TITLE
Update source/release-notes/2.4-upgrade.txt

### DIFF
--- a/source/release-notes/2.4-upgrade.txt
+++ b/source/release-notes/2.4-upgrade.txt
@@ -47,10 +47,10 @@ procedure.
    :term:`sharded cluster`, as described in
    :ref:`sharding-balancing-disable-temporally`.
 
-#. Ensure there are no MongoDB processes running 2.0 still active in the
-   sharded cluster. The automated upgrade process checks this, but
-   network availability can prevent a definitive check. Wait 5 minutes
-   after stopping version 2.0 :program:`mongos` processes to confirm
+#. Ensure there are no version 2.0 :program:`mongod` or :program:`mongos`
+   processes still active in the sharded cluster. The automated upgrade process checks this, but
+   network availability can prevent a definitive check.  Wait 5 minutes
+   after stopping or upgrading version 2.0 :program:`mongos` processes to confirm
    that none are still active.
 
 #. Start a single 2.4 :program:`mongos` process with


### PR DESCRIPTION
QA testing by mike - he seemed to think this was confusing as written and implied that only mongos processes needed to be upgraded
