### PR TITLE
Document initial random value for ObjectId counter

### DIFF
--- a/source/core/object-id.txt
+++ b/source/core/object-id.txt
@@ -13,7 +13,7 @@ constructed using:
 - a 4-byte timestamp,
 - a 3-byte machine identifier,
 - a 2-byte process id, and
-- a 3-byte counter.
+- a 3-byte counter, starting with a random value.
 
 In MongoDB, documents stored in a collection require a unique
 :term:`_id` field that acts as a :term:`primary key`. Because


### PR DESCRIPTION
This was mentioned in the original spec, but missed being copied over to the new docs.
