### PR TITLE
add sitemap index for root docs directory

### DIFF
--- a/draft/sitemap.xml
+++ b/draft/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap>
+<loc>http://docs.mongodb.org/manual/sitemap.xml.gz</loc>
+</sitemap>
+<sitemap>
+<loc>http://docs.mongodb.org/ecosystem/sitemap.xml.gz</loc>
+</sitemap>
+</sitemapindex>


### PR DESCRIPTION
This needs to be placed in / on docs.mongodb.org 
Should not need to be updated though we may add an entry for forked archive versions of the manual.
