### PR TITLE
fix reference to incorrect usage of collStats command

### DIFF
--- a/source/reference/command/collStats.txt
+++ b/source/reference/command/collStats.txt
@@ -11,9 +11,9 @@ collStats
 
    .. code-block:: javascript
 
-      { collStats: "database.collection" , scale : 1024 }
+      { collStats: "collection" , scale : 1024 }
 
-   Specify a namespace ``database.collection`` and
+   Specify the ``collection`` you want statistics for, and
    use the ``scale`` argument to scale the output. The above example
    will display values in kilobytes.
 


### PR DESCRIPTION
correct usage in http://docs.mongodb.org/manual/reference/collection-statistics/

example:

```
> db.runCommand({collStats:"foo"})
{
    "ns" : "test.foo",
    "count" : 8,
    "size" : 292,
    "avgObjSize" : 36.5,
    "storageSize" : 4096,
    "numExtents" : 1,
    "nindexes" : 1,
    "lastExtentSize" : 4096,
    "paddingFactor" : 1,
    "systemFlags" : 1,
    "userFlags" : 0,
    "totalIndexSize" : 8176,
    "indexSizes" : {
        "_id_" : 8176
    },
    "ok" : 1
}
> db.runCommand({collStats:"test.foo"})
{ "ok" : 0, "errmsg" : "ns not found" }
> 
```
