### PR TITLE
grammar (subject-verb agreement - number)

### DIFF
--- a/source/applications/delete.txt
+++ b/source/applications/delete.txt
@@ -72,7 +72,7 @@ whose value starts with ``G``:
 
    db.bios.remove( { 'name.first' : /^G/ } )
 
-Remove Only One Document That Match a Condition
+Remove Only One Document That Matches a Condition
 -----------------------------------------------
 
 If there is a ``<query>`` argument and you specify the ``<justOne>``


### PR DESCRIPTION
corrected subtitle "Remove Only One Document That Match a Condition" to "Remove Only One Document That Matches a Condition" (conjugation of verb "to match" should agree in number (singular) with subject "document") 
