### PR TITLE
DOCS-954 eval() helper and nolock

### DIFF
--- a/source/includes/fact-eval-lock.rst
+++ b/source/includes/fact-eval-lock.rst
@@ -1,0 +1,19 @@
+.. eval-command-nolock
+
+By default, :dbcommand:`eval` takes a global write lock before
+evaluating the JavaScript function. This means that :dbcommand:`eval`
+blocks all other read and write operations to the database while the
+:dbcommand:`eval` operation runs. Set ``nolock`` to ``true`` to ensure
+that :dbcommand:`eval` does not take this global write lock before
+evaluating the function. The flag does not impact whether the
+JavaScript code itself takes a write lock.
+
+.. eval-method-lock
+
+The :method:`db.eval()` method takes a global write lock by default
+before executing the JavaScript function. This means that
+:method:`db.eval()` blocks all other read and write operations to the
+database while the :method:`db.eval()` operation runs. You can,
+however, use the :dbcommand:`eval` command, instead of the
+:method:`db.eval()` method, with the ``nolock`` flag to ``true``. See
+:dbcommand:`eval` command for more details.

--- a/source/reference/command/eval.txt
+++ b/source/reference/command/eval.txt
@@ -54,13 +54,10 @@ eval
       An array of corresponding arguments to the ``function``. Omit
       ``args`` if the ``function`` does not take arguments.
 
-   :field boolean nolock:
+   :field boolean nolock: Optional.
 
-      Optional. By default, :dbcommand:`eval` takes a global write lock
-      before evaluating the JavaScript function. If ``nolock`` is
-      ``true``, the :dbcommand:`eval` does not take this global write
-      lock before evaluating the function. The flag does not impact
-      whether the JavaScript code itself takes a write lock.
+      .. include:: /includes/fact-eval-lock.rst
+         :end-before: eval-method-lock
 
    Consider the following example which uses :dbcommand:`eval` to
    perform an increment and calculate the average on the server:
@@ -138,15 +135,8 @@ eval
 
    .. warning::
 
-      - The :dbcommand:`eval` command takes a global write lock by
-        default before executing the JavaScript function. This means
-        that :dbcommand:`eval` blocks all other read and write
-        operations to the database while the :dbcommand:`eval`
-        operation runs. You can, however, set the ``nolock`` flag to
-        ``true`` to prevent the :dbcommand:`eval` command from taking a
-        global write lock before executing the JavaScript function. The
-        flag does not impact whether the JavaScript code itself takes
-        a write lock.
+      - .. include:: /includes/fact-eval-lock.rst
+           :end-before: eval-method-lock
 
       - :dbcommand:`eval` also takes a JavaScript lock.
 

--- a/source/reference/method/db.eval.txt
+++ b/source/reference/method/db.eval.txt
@@ -93,15 +93,9 @@ db.eval()
 
    .. warning::
 
-      - The :method:`db.eval()` method takes a global write lock by
-        default before executing the JavaScript function. This means
-        that :method:`db.eval()` blocks all other read and write
-        operations to the database while the :method:`db.eval()`
-        operation runs. You can, however, use the :dbcommand:`eval`
-        command, instead of the :method:`db.eval()` method, with the
-        ``nolock`` flag to ``true``. See :dbcommand:`eval` command for
-        more details.
-
+      -  .. include:: /includes/fact-eval-lock.rst
+            :start-after: eval-method-lock
+         
       - :method:`db.eval()` also takes a JavaScript lock.
 
 .. modified in 2.4 version, the JavaScript lock is up to and including version 2.2


### PR DESCRIPTION
DOCS-954 db.eval() method and nolock option

DOCS-954 incorporate Scott's feedback

incorporate Tad's comments

DOCS-954 eval and lock incorporate Ben's comments
