### PR TITLE
Resident memory is in MB

### DIFF
--- a/source/reference/server-status.txt
+++ b/source/reference/server-status.txt
@@ -403,7 +403,7 @@ mem
 .. data:: serverStatus.mem.resident
 
    The value of :data:`~serverStatus.mem.resident` is roughly equivalent to the amount
-   of RAM, in bytes, currently used by the database process. In normal
+   of RAM, in megabytes (MB), currently used by the database process. In normal
    use this value tends to grow. In dedicated database servers this
    number tends to approach the total amount of system memory.
 


### PR DESCRIPTION
This seems to have been missed in the edits related to https://jira.mongodb.org/browse/DOCS-741.
