### PR TITLE
DOCS-1153 add an example to db.addUser()

### DIFF
--- a/source/reference/method/db.addUser.txt
+++ b/source/reference/method/db.addUser.txt
@@ -4,7 +4,7 @@ db.addUser()
 
 .. default-domain:: mongodb
 
-.. method:: db.addUser("username", "password"[, readOnly])
+.. method:: db.addUser("username", "password" [, readOnly] )
 
    :param string username: Specifies a new username.
 
@@ -17,3 +17,9 @@ db.addUser()
    username and password as arguments to the command. If you want to
    restrict the user to have only read-only privileges, supply a true
    third argument; however, this defaults to false.
+
+   For example:
+
+   .. code-block:: javascript
+
+      db.addUser("user1" , "pass" , { readOnly : true } )


### PR DESCRIPTION
Adds this example to db.addUser():
db.addUser("user1" , "pass" , { readOnly : true } )
