### PR TITLE
Add a link to geospatial docs

### DIFF
--- a/source/administration/indexes.txt
+++ b/source/administration/indexes.txt
@@ -99,8 +99,9 @@ Special Creation Options
    TTL collections use a special ``expire`` index option. See
    :doc:`/tutorial/expire-data` for more information.
 
-.. todo::: insert link here to the geospatial index documents when
-   they're published.
+.. note::
+
+   To create geospatial indexes, see :ref:`geospatial-indexes_create`.
 
 .. index:: index; sparse
 .. _index-sparse-index:


### PR DESCRIPTION
Trivial. There was a comment in the indexing documentation to add a link to the geospatial docs when they were complete. 
