### PR TITLE
added missing space 

### DIFF
--- a/source/reference/aggregation.txt
+++ b/source/reference/aggregation.txt
@@ -14,7 +14,7 @@ form as "regular" MongoDB database queries.
 These aggregation operations are all accessible by way of the
 :mongodb:method:`~db.collection.aggregate()` method. While all examples in this document use this
 method, :mongodb:method:`~db.collection.aggregate()` is merely a wrapper around the
-:term:`database command`\ :mongodb:dbcommand:`aggregate`. The
+:term:`database command` :mongodb:dbcommand:`aggregate`. The
 following prototype aggregation operations are equivalent:
 
 .. code-block:: javascript


### PR DESCRIPTION
added missing space between "database command" and "aggregate" (was run together as "database commandaggregate" as viewed in production). 
