### PR TITLE
fix form action attribute in tumblelog tutorial

### DIFF
--- a/source/tutorial/write-a-tumblelog-application-with-flask-mongoengine.txt
+++ b/source/tutorial/write-a-tumblelog-application-with-flask-mongoengine.txt
@@ -545,7 +545,7 @@ form after displaying comments:
 
    <hr>
    <h2>Add a comment</h2>
-   <form action="." method="post">
+   <form action="" method="post">
      {{ forms.render(form) }}
      <div class="actions">
        <input type="submit" class="btn primary" value="comment">


### PR DESCRIPTION
Attempting to add a comment currently results in a 405 error.

For it to work, the form data must be POSTed to the current page (the detail view) instead of the current directory (the list view).
