### PR TITLE
Update production-notes.txt

### DIFF
--- a/source/administration/production-notes.txt
+++ b/source/administration/production-notes.txt
@@ -56,7 +56,7 @@ For MongoDB on Linux use the following recommended configurations:
 - Turn off ``atime`` for the storage volume with the :term:`database
   files <dbpath>`.
 
-- Set file descriptor limit and user process limit to 20,000,
+- Set the file descriptor limit and the user process limit above 20,000,
   according to the suggestions in :doc:`/administration/ulimit`. A low
   ulimit will affect MongoDB when under heavy use and will produce
   weird errors.


### PR DESCRIPTION
Tweaked the ulimit text so that it's more accurate - 20k is below what we recommend in the ulimit page.
