### PR TITLE
confuse Collection with database 

### DIFF
--- a/source/release-notes/2.4.txt
+++ b/source/release-notes/2.4.txt
@@ -1268,7 +1268,7 @@ following:
 
 .. code-block:: javascript
 
-   db.records.ensureIndex( { a: "hashed" } )
+   db.active.ensureIndex( { a: "hashed" } )
 
 This operation creates a hashed index for the ``records`` collection
 on the ``a`` field.


### PR DESCRIPTION
Inconsistency with example:

Original gave an ensureIndex example with a "records" collection. Then used the same name as the "records" collection as the name of the database. A bit confusing. Might be better to keep names consistent if people plan to work through the docs IMHO
