### PR TITLE
Update typo in mongosniff.txt

### DIFF
--- a/source/reference/mongosniff.txt
+++ b/source/reference/mongosniff.txt
@@ -33,7 +33,7 @@ development.
 
    Change the path's and name of the shared library as needed.
 
-As an alliterative to :program:`mongosniff`, Wireshark, a popular
+As an alternative to :program:`mongosniff`, Wireshark, a popular
 network sniffing tool is capable of inspecting and parsing the MongoDB
 wire protocol.
 


### PR DESCRIPTION
Fixed a typo: alternative was instead "alliterative"
