### PR TITLE
explain.scanAndOrder available before 2.2

### DIFF
--- a/source/reference/explain.txt
+++ b/source/reference/explain.txt
@@ -190,8 +190,6 @@ Core Explain Output
 
 .. data:: explain.scanAndOrder
 
-   .. versionadded:: 2.2
-
    :data:`~explain.scanAndOrder` is a boolean that is ``true`` when
    the query **cannot** use the index for returning sorted results.
 


### PR DESCRIPTION
Removed introduction version from explain.scanAndOrder since available in 2.0.8 and perhaps earlier.
