### PR TITLE
DOCS-1245: Improve backup strategy overview.

### DIFF
--- a/source/administration/backups.txt
+++ b/source/administration/backups.txt
@@ -65,13 +65,12 @@ instances; creating binary "dumps" of the database using
 
 - binary database dumps are comparatively small, because they don't
   include index content, pre-allocated free space, or :ref:`record
-  padding <write-operations-padding-factor>`, and can reflect a single
-  moment in time using the :option:`--oplog <mongodump --oplog>` option.
+  padding <write-operations-padding-factor>`, but can take significant
+  time to complete.
 
-- filesystem snapshots, sometimes called block-level backups, produce
-  larger backup sizes, but complete quickly and can reflect a single
-  moment in time on a running system. However, snapshot systems
-  require filesystem and operating system support and tools.
+- filesystem snapshots, sometimes called block-level backups, complete
+  quickly, but produce larger backup sizes and require filesystem and
+  operating system support and tools.
 
 The best option depends on the requirements of your deployment and
 disaster recovery needs. The following topics provide details and
@@ -84,6 +83,20 @@ In some cases, taking backups is difficult or impossible because of
 large data volumes, distributed architectures, and data transmission
 speeds. In these situations, increase the number of members in your
 replica set or sets.
+
+Another issue to be considered is how closely a backup can represent a
+single moment in time. This is possible with both binary dumps
+[#oplog]_ and filesystem snapshots if a single node contains the
+complete data set. However, the situation becomes more complex when a
+single node does not contain the complete data set, as with
+:term:`sharded clusters <sharded cluster>` 
+
+.. [#oplog] By default, the :program:`mongodump` command does not
+   include operations after execution has started. However, the
+   :option:`--oplog <mongodump --oplog>` option causes the :term:`oplog`
+   to be included in the dump, which can then be restored using the
+   :program:`mongorestore` :option:`--oplogReplay <mongorestore
+   --oplogReplay>` option.
 
 Backup Strategies for MongoDB Deployments
 -----------------------------------------


### PR DESCRIPTION
Both filesystem snapshots and mongodump can be point in time. Clean
up the language. Leave the details that will help people make a
decision as to their best options in the linked detail pages. Put
the links in the same order we've talked about the options.
