### PR TITLE
Update subscriber edition link to working non-ssl page

### DIFF
--- a/source/release-notes/2.4.txt
+++ b/source/release-notes/2.4.txt
@@ -213,7 +213,7 @@ New Modular Authentication System with Support for Kerberos
 .. note::
 
    Kerberos authentication is only present in the `MongoDB Subscriber
-   Edition <https://www.10gen.com/products/mongodb-enterprise>`_.  To
+   Edition <http://www.10gen.com/products/mongodb-enterprise>`_.  To
    download and install MongoDB Enterprise, see
    :doc:`/tutorial/install-mongodb-enterprise`.
 


### PR DESCRIPTION
Previous URL which doesn't render properly on my machine: 
https://www.10gen.com/products/mongodb-enterprise
New URL which looks much better:
http://www.10gen.com/products/mongodb-enterprise
