### PR TITLE
Update 2.4-upgrade.txt

### DIFF
--- a/source/release-notes/2.4-upgrade.txt
+++ b/source/release-notes/2.4-upgrade.txt
@@ -60,7 +60,7 @@ other members are available to minimize downtime. Use the following
 procedure:
 
 #. Upgrade the :term:`secondary` members of the set one at a time by
-   shutting down the :program:`mongod` and replacing the 2.0 binary
+   shutting down the :program:`mongod` and replacing the 2.2 binary
    with the 2.4 binary.  After upgrading a :program:`mongod` instance,
    wait for the member to recover to ``SECONDARY`` state
    before upgrading the next instance.


### PR DESCRIPTION
Fixed text - referenced 2.0 when it should've said 2.2.

(Side question, maybe worth a DOCS ticket: should we have instructions for going from 2.0 -> 2.4?  Or just let users do the two-step from 2.0 -> 2.4?)
