### PR TITLE
DOCS-1250: Read-only users can't read system.users.

### DIFF
--- a/source/administration/security.txt
+++ b/source/administration/security.txt
@@ -277,9 +277,11 @@ authentication system:
      db.system.users.find()
 
 - The ``admin`` database is unique. Users with *normal* access to the
-  ``admin`` database have read and write access to all
-  databases. Users with *read only* access to the ``admin`` database
-  have read only access to all databases.
+  ``admin`` database have read and write access to all databases. Users
+  with *read only* access to the ``admin`` database have read only
+  access to all databases, with the exception of the ``system.users``
+  collection, which is protected to prevent privilege escalation
+  attacks.
 
   Additionally the ``admin`` database exposes several commands and
   functionality, such as :dbcommand:`listDatabases`.


### PR DESCRIPTION
Users with read only access to the admin database can't read the
system.users collection.

I considered adding a link to [Password Hashing
Insecurity](http://docs.mongodb.org/manual/tutorial/control-access-to-mongodb-with-authentication/#password-hashing-insecurity) but it doesn't add value. I could footnote a link to [SERVER-4692](https://jira.mongodb.org/browse/SERVER-4692).

It's only fair that I patch this, since it was my support ticket that
caused it to be opened in the first place.
