### PR TITLE
Modifying the instructions around openssl usage.

### DIFF
--- a/source/tutorial/control-access-to-mongodb-with-authentication.txt
+++ b/source/tutorial/control-access-to-mongodb-with-authentication.txt
@@ -226,14 +226,20 @@ authentication with specific MongoDB deployments:
 Generate a Key File
 -------------------
 
-Use the following command at the system shell to generate pseudo-random
+Use the following openssl command at the system shell to generate pseudo-random
 content for a key file: 
 
 .. code-block:: sh
 
-   openssl rand -base64 753
+   openssl rand -base64 741
 
 .. note:: 
+
+   The length should not be too high and should be a multiple of 3.
+
+   On Windows, the maximum size you can request and not have to deal with equals signs is 741.
+
+   On non-Windows systems, the maximum is 753. 
 
    Be aware that MongoDB strips whitespace characters (e.g. ``x0d``,
    ``x09``, and ``x20``,) for cross-platform convenience. As a result,


### PR DESCRIPTION
When the length is 753, it breaks setting up keyFile authentication on Windows. Modified the instructions to be clearer and more correct.
