### PR TITLE
Makes IP addresses used RFC 5737 compliant 

### DIFF
--- a/source/administration/configuration.txt
+++ b/source/administration/configuration.txt
@@ -75,7 +75,7 @@ following explanation:
   .. note::
 
      UNIX-like systems require superuser privileges to attach processes
-     to ports lower than 1000.
+     to ports lower than 1024.
 
 - :setting:`quiet` is ``true``. This disables all but
   the most critical entries in output/log file. In normal operation
@@ -119,16 +119,17 @@ following:
 
 .. code-block:: cfg
 
-   bind_ip = 127.0.0.1,10.8.0.10,192.168.4.24
+   bind_ip = 127.0.0.1,192.0.2.6,198.51.100.85
    nounixsocket = true
    auth = true
 
 Consider the following explanation for these configuration decisions:
 
 - ":setting:`bind_ip`" has three values: ``127.0.0.1``, the localhost
-  interface; ``10.8.0.10``, a private IP address typically used for
-  local networks and VPN interfaces; and ``192.168.4.24``, a private
-  network interface typically used for local networks.
+  interface; ``192.0.2.6``, an example private IP address which could
+   be used for local networks and VPN interfaces; and 
+   ``198.51.100.85``, another example of a private network interface 
+   which could be used for local networks.
 
   Because production MongoDB instances need to be accessible from
   multiple database servers, it is important to bind MongoDB to
@@ -217,11 +218,11 @@ configuration option:
 
    configsvr = true
 
-   bind_ip = 10.8.0.12
+   bind_ip = 192.0.2.6
    port = 27001
 
-This creates a config server running on the private IP address
-``10.8.0.12`` on port ``27001``. Make sure that there are no port
+This creates a config server running on IP address ``192.0.2.6`` 
+on port ``27001``. Make sure that there are no port
 conflicts, and that your config server is accessible from all of your
 ":program:`mongos`" and ":program:`mongod`" instances.
 
@@ -238,7 +239,7 @@ Finally, to establish the cluster, configure at least one
 
 .. code-block:: cfg
 
-   configdb = 10.8.0.12:27001
+   configdb = 192.0.2.6:27001
    chunkSize = 64
 
 You can specify multiple :setting:`configdb` instances by


### PR DESCRIPTION
RFC 5737 ( http://tools.ietf.org/html/rfc5737 ) lays out what IP addresses you should use in documentation. This commit makes the documentation for the configuration RFC compliant. 
