### PR TITLE
Just an example using $unset

### DIFF
--- a/source/includes/table-sql-to-mongo-schema-examples.yaml
+++ b/source/includes/table-sql-to-mongo-schema-examples.yaml
@@ -72,13 +72,17 @@ sql3: |
          ALTER TABLE users
          DROP COLUMN join_date
 mongo3: |
-        Collections do not describe or enforce the structure of the
-        constituent documents. See the :doc:`/core/data-modeling`
-        page for more information.
+        .. code-block:: javascript
+           :emphasize-lines: 1-5
+
+           db.users.update(
+               { },
+               { $unset: { join_date: "" } },
+               { multi: true }
+           )
 ref3: |
       See :method:`update() <db.collection.update()>` and
-      :operator:`$set` for more information on changing the structure
-      of documents in a collection.
+      :operator:`$unset` for more information.
 sql4: |
       .. code-block:: sql
 


### PR DESCRIPTION
There's a MongoDB solution for changing collections that resembles SQL's ALTER TABLE ... DROP COLUMN. This pull request just changed the MongoDB documentation to give that solution (with $unset) as an example, instead of just repeating the message from the ALTER TABLE ... ADD.
