### PR TITLE
 DOCS-1312 - Capitalization and extra word

### DIFF
--- a/source/reference/mongod.txt
+++ b/source/reference/mongod.txt
@@ -186,7 +186,7 @@ Options
 .. option:: --auth
 
    Enables database authentication for users connecting from remote
-   hosts. configure users via the :doc:`mongo shell shell
+   hosts. Configure users via the :doc:`mongo shell
    </reference/mongo>`. If no users exist, the localhost interface
    will continue to have access to the database until the you create
    the first user.


### PR DESCRIPTION
lower case start of sentence and "mongo shell shell" on mongod executable reference page
