### PR TITLE
Fixed typo (comma to period).

### DIFF
--- a/source/reference/mongo.txt
+++ b/source/reference/mongo.txt
@@ -429,7 +429,7 @@ The :program:`mongo` shell supports the following keyboard shortcuts:
    * - Meta->
      - Retrieve the last command in command history
 
-.. [#multiple-bindings] MongoDB accommodates multiple keybinding,
+.. [#multiple-bindings] MongoDB accommodates multiple keybinding.
    Since 2.0, :program:`mongo` includes support for basic emacs
    keybindings.
 


### PR DESCRIPTION
Fixed typo where a comma was used instead of a period.
