### PR TITLE
DOCS-1314 remove reference to --rest option for mongos

### DIFF
--- a/source/administration/security.txt
+++ b/source/administration/security.txt
@@ -143,8 +143,7 @@ You can limit the network exposure with the following configuration options:
 
   .. todo:: cross reference the above with the firewall rules below.
 
-- the :setting:`rest` setting for :program:`mongod`
-  and :program:`mongos` instances.
+- the :setting:`rest` setting for :program:`mongod`.
 
   Enables a fully interactive administrative :term:`REST` interface,
   which is *disabled by default.* The status interface, which *is*


### PR DESCRIPTION
--rest invalid for mongos 
fixes #DOCS-1314
