### PR TITLE
Added example command for listing shards

### DIFF
--- a/source/tutorial/remove-shards-from-cluster.txt
+++ b/source/tutorial/remove-shards-from-cluster.txt
@@ -52,6 +52,8 @@ To determine the name of the shard, do one of the following:
 
 - From the ``admin`` database, run the :dbcommand:`listShards` command.
 
+   db.runCommand( { listShards: 1 } )
+
 - Run either the :method:`sh.status()` method or the
   :method:`db.printShardingStatus()` method.
 


### PR DESCRIPTION
I took me a little while to get that the `listShards` command should be executed with `db.runCommand`. Added an example to the docs.
