### PR TITLE
Remove extra 'remain' from first paragraph.

### DIFF
--- a/source/administration/replica-sets.txt
+++ b/source/administration/replica-sets.txt
@@ -7,7 +7,7 @@ Replica Set Administration
 :term:`Replica sets <replica set>` automate most administrative tasks
 associated with database replication. Nevertheless, several operations
 related to deployment and systems management require administrator
-intervention remain.
+intervention.
 
 The following tutorials provide task-oriented instructions for
 specific administrative tasks related to replica set operation.


### PR DESCRIPTION
Without this remain, I believe the paragraph sounds clearer. The original sentence was a bit convoluted.
