### PR TITLE
DOCS-1280 remove references to noMoveParanoia

### DIFF
--- a/source/faq/sharding.txt
+++ b/source/faq/sharding.txt
@@ -186,9 +186,6 @@ Yes. :program:`mongod` creates these files as backups during normal
 
 Once these migrations are complete, you may delete these files.
 
-You can set :setting:`noMoveParanoia` to ``true`` to disable this
-behavior.
-
 How does ``mongos`` use connections?
 ------------------------------------
 
@@ -375,7 +372,7 @@ the hash of a key with an ascending value.
 
    You can use a :ref:`hashed index <index-type-hashed>` and
    :term:`hashed shard key`
-   or you can compute and maintain this hashed value in your 
+   or you can compute and maintain this hashed value in your
    application.
 
 What do ``moveChunk commit failed`` errors mean?

--- a/source/reference/configuration-options.txt
+++ b/source/reference/configuration-options.txt
@@ -807,19 +807,6 @@ Sharded Cluster Options
    these instances is ``27018``. The only affect of
    :setting:`shardsvr` is to change the port number.
 
-.. setting:: noMoveParanoia
-
-   *Default:* false
-
-   When set to ``true``, :setting:`noMoveParanoia` disables a
-   "paranoid mode" for data writes for chunk migration operation. See
-   the :ref:`chunk migration <sharding-chunk-migration>` and
-   :dbcommand:`moveChunk` command documentation for more information.
-
-   By default :program:`mongod` will save copies of migrated chunks on
-   the "from" server during migrations as "paranoid mode." Setting
-   this option disables this paranoia.
-
 .. setting:: configdb
 
    *Default:* None.

--- a/source/reference/mongod.txt
+++ b/source/reference/mongod.txt
@@ -639,17 +639,6 @@ Sharding Cluster Options
    ``27018``.  The only effect of :option:`--shardsvr` is to change
    the port number.
 
-.. option:: --noMoveParanoia
-
-   Disables a "paranoid mode" for data writes for chunk migration
-   operation. See the
-   :ref:`chunk migration <sharding-chunk-migration>`
-   and :dbcommand:`moveChunk` command documentation for more information.
-
-   By default :program:`mongod` will save copies of migrated chunks on
-   the "from" server during migrations as "paranoid mode." Setting
-   this option disables this paranoia.
-
 SSL Options
 ```````````
 


### PR DESCRIPTION
per scott/jeremy is now totally internal.
