### PR TITLE
Minor: redundant term

### DIFF
--- a/source/core/read.txt
+++ b/source/core/read.txt
@@ -563,10 +563,9 @@ more information regarding cursors.
 ``findOne()``
 -------------
 
-The :method:`~db.collection.findOne()` method selects and
-returns a single document from a collection and returns that
-document. :method:`~db.collection.findOne()` does *not*
-return a cursor.
+The :method:`~db.collection.findOne()` method selects a single
+document from a collection and returns that document.
+:method:`~db.collection.findOne()` does *not* return a cursor.
 
 The :method:`~db.collection.findOne()` method has the following
 syntax:


### PR DESCRIPTION
This paragraph sounds redundant:

> The **findOne()** method selects and **returns** a single document from a collection and **returns** that document.
