### PR TITLE
Clarification of replica set sizes

### DIFF
--- a/source/tutorial/deploy-replica-set.txt
+++ b/source/tutorial/deploy-replica-set.txt
@@ -25,8 +25,8 @@ deployments require no additional members or configuration.
 Requirements
 ------------
 
-Most replica sets consist of two or more :program:`mongod`
-instances. [#odd-numbered-set-sizes]_ This tutorial
+Most replica sets consist of three or more :program:`mongod`
+instances. [#odd-numbered-set-sizes]_ [#two-member-replica-set]_ This tutorial
 describes a three member set. Production environments should have at
 least three distinct systems so that each system can run its own
 instance of :program:`mongod`. For development systems you can run all three instances
@@ -41,6 +41,8 @@ redundant network paths.
    <replica-set-elections>` always design replica sets with odd numbers
    of members. Use :ref:`replica-set-arbiters` to ensure the set has
    odd number of voting members and avoid tied elections.
+.. [#two-member-replica-set] A two member replica set can exist provided
+   that one of the members of the set is a :ref:`hidden <replica-set-hidden-members>` member.
 
 Procedures
 ----------


### PR DESCRIPTION
The line changed was a line I found misleading/a point of concern after being a mongo user for nearly 9 months. Since a two member replica set is an unusual configuration, most users reading the Deploy a Replica Set page are probably better served by indicating that most replica sets are three or more members.
