### PR TITLE
Changes collection to namespace

### DIFF
--- a/source/reference/method/sh.shardCollection.txt
+++ b/source/reference/method/sh.shardCollection.txt
@@ -4,9 +4,9 @@ sh.shardCollection()
 
 .. default-domain:: mongodb
 
-.. method:: sh.shardCollection(collection,key,unique)
+.. method:: sh.shardCollection(namespace,key,unique)
 
-   :param string collection: The namespace of the collection to shard.
+   :param string namespace: The :term:`namespace` of the collection to shard.
 
    :param document key: 
 


### PR DESCRIPTION
Since you shard on the namespace - e.g. "mydb.users" - and not "users", this commit helps remove the ambiguity between namespace and collection for this page.
