### PR TITLE
Update db.copyDatabase.txt

### DIFF
--- a/source/reference/method/db.copyDatabase.txt
+++ b/source/reference/method/db.copyDatabase.txt
@@ -27,3 +27,7 @@ db.copyDatabase()
    This function provides a wrapper around the MongoDB :term:`database
    command` ":dbcommand:`copydb`." The :dbcommand:`clone` database
    command provides related functionality.
+
+Example
+
+> db.copyDatabase('mydb','copyofmydb')


### PR DESCRIPTION
Including an example. There are at least a few cases on the web where folks ( i hit this too) neglected to put quotes around the database name. Hopefully with a live example that will no longer happen
