### PR TITLE
Minor: Removing repeated sentence

### DIFF
--- a/source/core/data-modeling.txt
+++ b/source/core/data-modeling.txt
@@ -101,9 +101,6 @@ MongoDB must be smaller than the :limit:`maximum BSON document size
 <BSON Document Size>`. For larger documents, consider using
 :doc:`GridFS </core/gridfs>`.
 
-For examples in accessing embedded documents, see
-:ref:`read-operations-subdocuments`.
-
 .. seealso::
 
    - :term:`dot notation` for information on "reaching into" embedded


### PR DESCRIPTION
The removed sentence is repeated on `seealso` directive.
