### PR TITLE
Remove redundant broken link.

### DIFF
--- a/source/core/replication.txt
+++ b/source/core/replication.txt
@@ -111,7 +111,7 @@ the amount of slave delay to apply:
 - The size of the oplog is sufficient to capture *more than* the
   number of operations that typically occur in that period of
   time. For more information on oplog size, see the
-  :ref:`replica-set-oplog-sizing` topic in the :doc:`/core/replication` document.
+  :ref:`replica-set-oplog-sizing` topic in this document.
 
 Delayed members must have a :term:`priority` set to ``0`` to prevent
 them from becoming primary in their replica sets. Also these members


### PR DESCRIPTION
I believe, from the title, that the link is intended to direct to the document it is in. Have removed and changed link text to "this".
