### PR TITLE
Minor typo on applications.txt document

### DIFF
--- a/source/applications.txt
+++ b/source/applications.txt
@@ -17,8 +17,7 @@ documents.  For an introduction to basic MongoDB use, see the
 
 .. seealso:: :doc:`/crud` section and the :doc:`/faq/developers`
    document. Developers should also be familiar with the :doc:`mongo`
-   shell and the MongoDB :doc:`query and update operators
-   </reference/operators>`.
+   and the MongoDB :doc:`query and update operators </reference/operators>`.
 
 Development Considerations
 --------------------------


### PR DESCRIPTION
Sphinx renders the `:doc:`mongo`` directive as a link: [The mongo Shell](http://es.docs.mongodb.org/manual/mongo/)
