### PR TITLE
Correct documentation for db.collection.remove()

### DIFF
--- a/source/reference/method/db.collection.remove.txt
+++ b/source/reference/method/db.collection.remove.txt
@@ -63,7 +63,7 @@ db.collection.remove()
 
         db.products.remove( { qty: { $gt: 20 } }, true )
 
-     This operation removes all the documents from the collection
+     This operation removes the first document from the collection
      ``products`` where ``qty`` is greater than ``20``.
 
    .. examples-end


### PR DESCRIPTION
The comment below the example of `db.collection.remove()` with the `justOne` flag set was identical to the one _without_ the flag set.

This change corrects that error.
