### PR TITLE
Document BSON type 6 as 'undefined'

### DIFF
--- a/source/reference/operator/type.txt
+++ b/source/reference/operator/type.txt
@@ -54,6 +54,7 @@ $type
    Object                       3
    Array                        4
    Binary data                  5
+   undefined                    6
    Object id                    7
    Boolean                      8
    Date                         9


### PR DESCRIPTION
E.g.

> db.testcol.insert({v:undefined})
> db.testcol.findOne()
> { "_id" : ObjectId("517ae3259c3c002bf65b97fb"), "v" : null }
> db.testcol.count({v:null})
> 0
> typeof(db.testcol.findOne().v)
> object
> db.testcol.count({v:{$type:6}})
> 1
> db.testcol.count({v:{$in:[undefined]}})
> 1
