### PR TITLE
Add some information about finding docs with undefined values

### DIFF
--- a/source/faq/developers.txt
+++ b/source/faq/developers.txt
@@ -514,6 +514,22 @@ Different query operators treat ``null`` values differently:
 
      { "_id" : 2 }
 
+Note that the value of a field may also be ``undefined``, which is different from ``null``
+(though the shell renders them both as ``null``). 
+
+- You can find ``undefined`` values by BSON type:
+
+   .. code-block:: javascript
+
+      db.test.find( { cancelDate : { $type : 6 } } )
+
+- Alternatively, you can find ``undefined`` values using ``$in``:
+
+  .. code-block:: javascript
+
+      db.test.find( { cancelDate : { $in : [ undefined ] } } )
+
+
 .. seealso:: The reference documentation for the :operator:`$type` and
    :operator:`$exists` operators.
 


### PR DESCRIPTION
In case someone else runs into the puzzling situation where the shell shows a null value, but querying for null doesn't work.
