### PR TITLE
Altered misleading sentence.

### DIFF
--- a/source/tutorial/install-mongodb-on-debian.txt
+++ b/source/tutorial/install-mongodb-on-debian.txt
@@ -67,7 +67,7 @@ sign packages with GPG keys. Issue the following command to import the
    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv 7F0CEB10
 
 Create the ``/etc/apt/sources.list.d/10gen.list`` file and include
-the following line for the 10gen repository.
+a line for the 10gen repository with the following command:
 
 .. code-block:: sh
 


### PR DESCRIPTION
Create the `/etc/apt/sources.list.d/10gen.list` file and include
the following line for the 10gen repository.


Create the `/etc/apt/sources.list.d/10gen.list` file and include
a line for the 10gen repository with the following command:

The original wording suggests that the following line should be added to the .list file, whereas the following line is actually a command to generate the .list file.
