### PR TITLE
Fix parameter to Disable the localhost auth bypass

### DIFF
--- a/source/tutorial/add-user-administrator.txt
+++ b/source/tutorial/add-user-administrator.txt
@@ -74,7 +74,7 @@ To disable the localhost bypass, set the
 
 .. code-block:: javascript
 
-   mongod --setParameter enableLocalhostAuthBypass=1
+   mongod --setParameter enableLocalhostAuthBypass=0
 
 .. note:: 
 


### PR DESCRIPTION
See here:
http://docs.mongodb.org/manual/reference/parameters/#param.enableLocalhostAuthBypass

Specify 0 to disable localhost authentication bypass. Enabled by default.
