### PR TITLE
Move "Install Packages" before "Manage Installed Versions"

### DIFF
--- a/source/tutorial/install-mongodb-on-ubuntu.txt
+++ b/source/tutorial/install-mongodb-on-ubuntu.txt
@@ -79,6 +79,19 @@ Now issue the following command to reload your repository:
 
 .. _install-ubuntu-version-pinning:
 
+Install Packages
+~~~~~~~~~~~~~~~~
+
+Issue the following command to install the latest stable version of
+MongoDB:
+
+.. code-block:: sh
+
+   sudo apt-get install mongodb-10gen
+
+When this command completes, you have successfully installed MongoDB!
+Continue for configuration and start-up suggestions.
+
 Manage Installed Versions
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -102,19 +115,6 @@ To pin a package, issue the following command at the system prompt to
 .. code-block:: sh
 
    echo "mongodb-10gen hold" | dpkg --set-selections
-
-Install Packages
-~~~~~~~~~~~~~~~~
-
-Issue the following command to install the latest stable version of
-MongoDB:
-
-.. code-block:: sh
-
-   sudo apt-get install mongodb-10gen
-
-When this command completes, you have successfully installed MongoDB!
-Continue for configuration and start-up suggestions.
 
 Configure MongoDB
 -----------------


### PR DESCRIPTION
This order seems more logical to me and matches the other distribution installation instruction pages - http://docs.mongodb.org/manual/tutorial/install-mongodb-on-debian/ and http://docs.mongodb.org/manual/tutorial/install-mongodb-on-red-hat-centos-or-fedora-linux/
