### PR TITLE
Updates serverStatus.mem.virtual

### DIFF
--- a/source/reference/command/serverStatus.txt
+++ b/source/reference/command/serverStatus.txt
@@ -441,13 +441,11 @@ mem
 .. data:: serverStatus.mem.virtual
 
    :data:`~serverStatus.mem.virtual` displays the quantity, in megabytes (MB), of virtual memory
-   used by the :program:`mongod` process. In typical deployments this value
-   is slightly larger than :data:`~serverStatus.mem.mapped`. If this value is
-   significantly (i.e. gigabytes) larger than :data:`~serverStatus.mem.mapped`,
-   this could indicate a memory leak.
+   used by the :program:`mongod` process. With :term:`journaling <journal>` enabled, the value 
+   of :data:`~serverStatus.mem.virtual` is at least twice the value of :data:`~serverStatus.mem.mapped`.
 
-   With :term:`journaling <journal>` enabled, the value of :data:`~serverStatus.mem.virtual`
-   is twice the value of :data:`~serverStatus.mem.mapped`.
+   If this value is significantly (e.g. 3 times or more) larger than :data:`~serverStatus.mem.mapped`,
+   this could indicate a memory leak.
 
 .. data:: serverStatus.mem.supported
 


### PR DESCRIPTION
Since journalling is on by default, rewording the serverStatus.mem.virtual section is needed.

Removed the term "gigabytes", as this is subjective - a mem-map of 1MB shouldn't have 1GB as Virtual memory... But for 200GB, 1GB wouldn't be anything to worry about. A ratio of (for example) thrice mem-map, is better.
