### PR TITLE
PyMongo supports Kerberos.

### DIFF
--- a/source/tutorial/control-access-to-mongodb-with-kerberos-authentication.txt
+++ b/source/tutorial/control-access-to-mongodb-with-kerberos-authentication.txt
@@ -228,16 +228,14 @@ privileges as needed.
 Use MongoDB Drivers to Authenticate with Kerberos
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-At the time of release, the C++, Java, and C# drivers all
+At the time of release, the C++, Java, C#, and Python drivers all
 provide support for Kerberos authentication to MongoDB. Consider the
 following tutorials for more information:
 
 - :ecosystem:`Java </tutorial/authenticate-with-java-driver/>`
 - :ecosystem:`C# </tutorial/authenticate-with-csharp-driver/>`
 - :ecosystem:`C++ </tutorial/authenticate-with-cpp-driver/>`
-
-.. uncomment wen links exist.
-   - :ecosystem:`Python </tutorial/authenticate-with-python-driver/>`
+- `Python <http://api.mongodb.org/python/current/faq.html#how-do-i-use-kerberos-authentication-with-pymongo>`_
 
 .. _kerberos-troubleshooting:
 


### PR DESCRIPTION
Add PyMongo to the list of drivers supporting kerberos. I know we want a tutorial page for authentication with python but people seem to think PyMongo doesn't support kerberos because it's not listed on this page.
