### PR TITLE
Fixed typos and bad-formed intersphinx link

### DIFF
--- a/source/administration/production-notes.txt
+++ b/source/administration/production-notes.txt
@@ -445,7 +445,7 @@ Additional Deployment Considerations
   prefetch settings. Note on linux the parameter is in *sectors*, not
   bytes. 32KBytes (a setting of 64 sectors) is pretty reasonable.
 
-- Check :doc:`ulimits </reference/ulimit>` settings.
+- Check :doc:`ulimit </reference/ulimit>` settings.
 
 - Use SSD if available and economical. Spinning disks can work well
   but SSDs' capacity for random I/O operations work well with the update

--- a/source/faq/fundamentals.txt
+++ b/source/faq/fundamentals.txt
@@ -79,7 +79,7 @@ What languages can I use to work with MongoDB?
 MongoDB :term:`client drivers <driver>` exist for
 all of the most popular programming languages, and many
 other ones. See the :ecosystem:`latest list of
-drivers <drivers>`
+drivers </drivers>`
 for details.
 
 .. seealso:: ":doc:`/applications/drivers`."

--- a/source/includes/table-mongodb-extended-json.yaml
+++ b/source/includes/table-mongodb-extended-json.yaml
@@ -171,7 +171,7 @@ mongo_ref: |
 notes_ref: |
            ``<name>`` is a string of valid JSON characters.
 
-           ``<id>`` is any valid etended JSON type.
+           ``<id>`` is any valid extended JSON type.
 
 bson_undef: ".. bsontype:: data_undefined"
 strict_undef: |

--- a/source/meta/style-guide.txt
+++ b/source/meta/style-guide.txt
@@ -134,7 +134,7 @@ Verb tense and mood preferences, with examples:
 - **Use** the second person. "If you need to back up your database,
   start by locking the database first." In practice, however, it's
   more concise to imply second person using the imperative, as in
-  "Before inititating a back up, lock the database."
+  "Before initiating a backup, lock the database."
 
 - When indicated, use the imperative mood. For example: "Backup your
   databases often" and "To prevent data loss, back up your databases."

--- a/source/release-notes/1.4.txt
+++ b/source/release-notes/1.4.txt
@@ -86,7 +86,7 @@ Query Language Improvements
 
 - :doc:`$pull </reference/operator/pull>` supports object matching
 
-- :doc:`$set </reference/operator/set>` with array indices
+- :doc:`$set </reference/operator/set>` with array indexes
 
 Geo
 ---


### PR DESCRIPTION
I was wondering if I can fix the term "Back up" to "Backup". Can I go for it?
