### PR TITLE
Update array doc - mention that the array field must appear last in the query argument

### DIFF
--- a/source/core/update.txt
+++ b/source/core/update.txt
@@ -171,8 +171,8 @@ Update an Element without Specifying Its Position
 
 The :method:`~db.collection.update()` method can perform the
 update using the :operator:`$` positional operator if the position is
-not known. The array field must appear in the ``query`` argument in
-order to determine which array element to update.
+not known. The array field must appear in the ``query`` argument as
+the last item in order to determine which array element to update.
 
 The following operation queries the ``bios`` collection for the first
 document where the ``_id`` field equals ``3`` and the ``contribs``


### PR DESCRIPTION
Discovered that if there is any ambiguity with fields in the query argument, the array element that is identified will not be updated unless the specific array field that identifies the array element is the last item in the query argument.
