### PR TITLE
Alters iostat

### DIFF
--- a/source/administration/production-notes.txt
+++ b/source/administration/production-notes.txt
@@ -240,7 +240,7 @@ For example:
 
 .. code-block:: bash
 
-   iostat -xm 2
+    iostat -xmt 1
 
 Use the mount command to see what device your :setting:`data directory
 <dbpath>` resides on.


### PR DESCRIPTION
"iostat -xmt 1" should be used as this allows:

t -  timestamp
1 - per second resolution

And is more inline with the output for Mongostat
