### PR TITLE
2.4 removed restriction on BINARY

### DIFF
--- a/source/core/aggregation.txt
+++ b/source/core/aggregation.txt
@@ -387,7 +387,7 @@ Aggregation operations with the :dbcommand:`aggregate` command have
 the following limitations:
 
 - The pipeline cannot operate on values of the following types:
-  ``Binary``, ``Symbol``, ``MinKey``, ``MaxKey``, ``DBRef``, ``Code``,
+  ``Symbol``, ``MinKey``, ``MaxKey``, ``DBRef``, ``Code``,
   ``CodeWScope``.
 
 - Output from the :term:`pipeline` can only contain 16 megabytes. If


### PR DESCRIPTION
See https://jira.mongodb.org/browse/SERVER-4608
