### PR TITLE
Fixed verbage about non-voting members

### DIFF
--- a/source/core/replication.txt
+++ b/source/core/replication.txt
@@ -159,7 +159,7 @@ Non-Voting Members
 ~~~~~~~~~~~~~~~~~~
 
 These members do not vote in elections. Non-voting members are only
-used for larger sets with more than 12 members. To configure a member
+used for larger sets with more than 7 members. To configure a member
 as non-voting, see
 :doc:`/tutorial/configure-a-non-voting-replica-set-member`.
 


### PR DESCRIPTION
You cannot have more than 12 members.  You cannot have more than 7 voting members.  So fixing this sentence to explain non-voting members are needed in replica sets with more than 7 members (not 12).
