### PR TITLE
Corrected double-negative

### DIFF
--- a/source/tutorial/perform-two-phase-commits.txt
+++ b/source/tutorial/perform-two-phase-commits.txt
@@ -184,8 +184,8 @@ Apply Transaction to Both Accounts
 ``````````````````````````````````
 
 Continue by applying the transaction to both accounts. The
-:method:`update() <db.collection.update()>` query will prevent you from
-applying the transaction *if* the transaction is *not* already
+:method:`update() <db.collection.update()>` query will only allow you to
+apply the transaction *if* the transaction is *not* already
 pending. Use the following :method:`update() <db.collection.update()>`
 operation:
 


### PR DESCRIPTION
It looks to me like {$ne: t._id} specifies we can only perform this update if t._id is NOT already in the pendingTransactions array.  The original description seemed to be saying the opposite (prevent if NOT, instead of perform if NOT)!
