### PR TITLE
Fix multikey index example typo

### DIFF
--- a/source/core/indexes.txt
+++ b/source/core/indexes.txt
@@ -417,7 +417,7 @@ arrays, as in the following example:
 
    .. code-block:: javascript
 
-      db.feedback.find( { "comments.text": "Please expand the selection." } )
+      db.feedback.find( { "comments.text": "Please expand the olive selection." } )
 
    This would select the document, that contains the following
    document in the ``comments.text`` array:


### PR DESCRIPTION
Missing the word "olive" in the multikey index example query.
