### PR TITLE
Update read-operations.txt

### DIFF
--- a/source/core/read-operations.txt
+++ b/source/core/read-operations.txt
@@ -5,7 +5,7 @@ Read Operations
 .. default-domain:: mongodb
 
 Read operations include all operations that return a cursor in
-response to application request data (i.e. *queries*,) and also
+response to application data requests (i.e. *queries*,) and also
 include a number of :doc:`aggregation </aggregation>` operations that
 do not return a cursor but have similar properties as queries. These
 commands include :dbcommand:`aggregate`, :dbcommand:`count`, and


### PR DESCRIPTION
I corrected the grammar on line 8 where 'application request data' was incorrectly equated with 'queries'. A query is a request; therefore, 'application data requests' makes sense.
