### PR TITLE
change sharding example to use a better shard key

### DIFF
--- a/source/tutorial/view-sharded-cluster-configuration.txt
+++ b/source/tutorial/view-sharded-cluster-configuration.txt
@@ -85,24 +85,18 @@ To view cluster details, issue :method:`db.printShardingStatus()` or
           {  "_id" : "shard0001",  "host" : "m3.example2.net:50000" }
         databases:
           {  "_id" : "admin",  "partitioned" : false,  "primary" : "config" }
-          {  "_id" : "animals",  "partitioned" : true,  "primary" : "shard0000" }
-              foo.big chunks:
-                      shard0001    1
-                      shard0000    6
-                  { "a" : { $minKey : 1 } } -->> { "a" : "elephant" } on : shard0001 Timestamp(2000, 1) jumbo
-                  { "a" : "elephant" } -->> { "a" : "giraffe" } on : shard0000 Timestamp(1000, 1) jumbo
-                  { "a" : "giraffe" } -->> { "a" : "hippopotamus" } on : shard0000 Timestamp(2000, 2) jumbo
-                  { "a" : "hippopotamus" } -->> { "a" : "lion" } on : shard0000 Timestamp(2000, 3) jumbo
-                  { "a" : "lion" } -->> { "a" : "rhinoceros" } on : shard0000 Timestamp(1000, 3) jumbo
-                  { "a" : "rhinoceros" } -->> { "a" : "springbok" } on : shard0000 Timestamp(1000, 4)
-                  { "a" : "springbok" } -->> { "a" : { $maxKey : 1 } } on : shard0000 Timestamp(1000, 5)
-              foo.large chunks:
-                      shard0001    1
-                      shard0000    5
-                  { "a" : { $minKey : 1 } } -->> { "a" : "hen" } on : shard0001 Timestamp(2000, 0)
-                  { "a" : "hen" } -->> { "a" : "horse" } on : shard0000 Timestamp(1000, 1) jumbo
-                  { "a" : "horse" } -->> { "a" : "owl" } on : shard0000 Timestamp(1000, 2) jumbo
-                  { "a" : "owl" } -->> { "a" : "rooster" } on : shard0000 Timestamp(1000, 3) jumbo
-                  { "a" : "rooster" } -->> { "a" : "sheep" } on : shard0000 Timestamp(1000, 4)
-                  { "a" : "sheep" } -->> { "a" : { $maxKey : 1 } } on : shard0000 Timestamp(1000, 5)
+          {  "_id" : "contacts",  "partitioned" : true,  "primary" : "shard0000" }
+              foo.contacts
+                  shard key: { "zip" : 1 }
+                  chunks:
+                      shard0001    2
+                      shard0002    3
+                      shard0000    2
+                  { "zip" : { "$minKey" : 1 } } -->> { "zip" : 56000 } on : shard0001 { "t" : 2, "i" : 0 }
+                  { "zip" : 56000 } -->> { "zip" : 56800 } on : shard0002 { "t" : 3, "i" : 4 }
+                  { "zip" : 56800 } -->> { "zip" : 57088 } on : shard0002 { "t" : 4, "i" : 2 }
+                  { "zip" : 57088 } -->> { "zip" : 57500 } on : shard0002 { "t" : 4, "i" : 3 }
+                  { "zip" : 57500 } -->> { "zip" : 58140 } on : shard0001 { "t" : 4, "i" : 0 }
+                  { "zip" : 58140 } -->> { "zip" : 59000 } on : shard0000 { "t" : 4, "i" : 1 }
+                  { "zip" : 59000 } -->> { "zip" : { "$maxKey" : 1 } } on : shard0000 { "t" : 3, "i" : 3 }
           {  "_id" : "test",  "partitioned" : false,  "primary" : "shard0000" }


### PR DESCRIPTION
Ready for merge.
My original example in /tutorial/view-sharded-cluster-configuration.txt used a poor choice of shard key. I've updated the example to use a better shard key.
