### PR TITLE
minor: Fix incorrect traceExceptions example

### DIFF
--- a/source/reference/parameters.txt
+++ b/source/reference/parameters.txt
@@ -209,12 +209,12 @@ Parameters
    traces on assertions or errors.
 
    Consider the following example which sets the
-   ``traceExceptions`` to ``1``:
+   ``traceExceptions`` to ``true``:
 
    .. code-block:: javascript
 
       use admin
-      db.runCommand( { setParameter: 1, traceExceptions: 1 } )
+      db.runCommand( { setParameter: 1, traceExceptions: true } )
 
    .. seealso:: :setting:`traceExceptions`
 


### PR DESCRIPTION
The current example generates an error. A bool is expected.
