### PR TITLE
edits+readability: rs-replace-member

### DIFF
--- a/source/tutorial/replace-replica-set-member.txt
+++ b/source/tutorial/replace-replica-set-member.txt
@@ -4,25 +4,30 @@ Replace a Replica Set Member
 
 .. default-domain:: mongodb
 
-Use this procedure to replace a member of a replica set when the hostname
-has changed. This procedure preserves all existing configuration
-for a member, except its hostname/location.
+This procedure changes the hostname for a member of a :term:`replica
+set` but preserves all other configuration options.
 
-You may need to replace a replica set member if you want to replace an
-existing system and only need to change the hostname rather than
-completely replace all configured options related to the previous
-member.
+The procedure can be useful if you must replace an existing deployment
+with a new deployment. If the new deployment uses the same configuration
+options but different hostnames, use this procedure.
 
-Use :method:`rs.reconfig()` to change the value of the
-:data:`~local.system.replset.members[n].host` field to reflect the new hostname or port
-number. :method:`rs.reconfig()` will not change the value of
-:data:`~local.system.replset.members[n]._id`.
+To change the hostname for a replica set member, use
+:method:`rs.reconfig()` to change the value of the member's
+:data:`~local.system.replset.members[n].host` field. The
+:method:`rs.reconfig()` method does not change the value of the
+:data:`~local.system.replset.members[n]._id` field.
 
-.. code-block:: javascript
+.. example::
 
-   cfg = rs.conf()
-   cfg.members[0].host = "mongo2.example.net:27019"
-   rs.reconfig(cfg)
+   To change the hostname to ``mongo2.example.net`` for the replica set
+   member configured at ``members[0]``, issue the following sequence of
+   commands:
+
+   .. code-block:: javascript
+
+      cfg = rs.conf()
+      cfg.members[0].host = "mongo2.example.net"
+      rs.reconfig(cfg)
 
 .. warning::
 


### PR DESCRIPTION
## Old

file: build/rs-replace/json/tutorial/replace-replica-set-member.json
source: source/tutorial/replace-replica-set-member.txt
stats:
   coleman-liau: 11.372450331125826
   flesch-ease: 44.58619757174395
   flesch-level: 13.292549668874177
   foggy:
      count: 4
      factor: 0.026490066225165563
      threshold: 3
   sentence-count: 6
   sentence-len-avg: 25
   smog-index: 7.793537801064561
   word-count: 151
## New

file: build/rs-replace/json/tutorial/replace-replica-set-member.json
source: source/tutorial/replace-replica-set-member.txt
stats:
   coleman-liau: 11.559030303030301
   flesch-ease: 46.95153409090912
   flesch-level: 11.834356060606058
   foggy:
      count: 4
      factor: 0.024242424242424242
      threshold: 3
   sentence-count: 8
   sentence-len-avg: 20
   smog-index: 7.168621630094336
   word-count: 165
