### PR TITLE
Fix cloneCollection description

### DIFF
--- a/source/reference/command/cloneCollection.txt
+++ b/source/reference/command/cloneCollection.txt
@@ -9,8 +9,8 @@ Definition
 
 .. dbcommand:: cloneCollection
 
-   Copies a collection from the current :program:`mongod` instance to
-   a remote :program:`mongod` instance. :dbcommand:`cloneCollection`
+   Copies a collection from a remote :program:`mongod` instance to
+   the current :program:`mongod` instance. :dbcommand:`cloneCollection`
    takes the following form:
 
    .. code-block:: javascript


### PR DESCRIPTION
`cloneCollection` copies from a remote mongod to the current instance.
