### PR TITLE
readability: rs-hidden-members + move some content to tuturial

### DIFF
--- a/source/core/replica-set-hidden-member.txt
+++ b/source/core/replica-set-hidden-member.txt
@@ -9,42 +9,27 @@ Hidden Replica Set Members
 .. default-domain:: mongodb
 
 A hidden member contains a copy of the :term:`primary's <primary>` data
-set. Hidden members are **invisible** to client applications, and the
-:method:`db.isMaster()` method will not display hidden members. Hidden
-members are also :ref:`priority 0 members
-<replica-set-secondary-only-members>` and **cannot become primary**.
-Hidden members, however, **do vote** in :ref:`elections
-<replica-set-elections>`.
+set but is **invisible** to client applications. Hidden members are
+ideal for instances that have different use patterns from the other
+members in the :term:`replica set`. Hidden members are also
+:ref:`priority 0 members <replica-set-secondary-only-members>` and
+**cannot become primary**. The :method:`db.isMaster()` method will not
+display hidden members. Hidden members, however, **do vote** in
+:ref:`elections <replica-set-elections>`.
 
-For example, in the following 5-member replica set, all four secondary
+In the following five-member replica set, all four secondary
 members have copies of the primary's data set, but one of secondary
 members is hidden.
 
 .. include:: /images/replica-set-hidden-member.rst
 
-A hidden member has its
-:data:`~local.system.replset.members[n].priority` equal to ``0`` and
-its :data:`~local.system.replset.members[n].hidden` equal to ``true``
-in its member configuration:
-
-.. code-block:: javascript
-   :emphasize-lines: 4-5
-
-   {
-     "_id" : <num>
-     "host" : <hostname:port>,
-     "priority" : 0,
-     "hidden" : true
-   }
-
-Hidden members are ideal for instances that will have significantly
-different usage patterns, such as a dedicated instance for reporting or
-backups, from other members and require separation from normal
-traffic. Since no secondary reads reach hidden members, hidden members
-receive no traffic beyond what replication requires.
-
-For dedicated backup, ensure that the hidden member is close, from a
-networking perspective, to the primary or likely primary. Ensure that
+Secondary reads do not reach a hidden member, so the member receives no
+traffic beyond what replication requires. Use hidden members for
+instances that require separation from normal traffic. For example, you
+might use hidden members for instances dedicated to reporting or to
+backups.
+For dedicated backup, ensure that the hidden member is close within
+the network to the primary or likely primary. Ensure that
 the :term:`replication lag` is minimal or non-existent. For more
 information about backing up MongoDB databases, see
 :doc:`/core/backups`.

--- a/source/tutorial/configure-a-hidden-replica-set-member.txt
+++ b/source/tutorial/configure-a-hidden-replica-set-member.txt
@@ -1,6 +1,6 @@
-===================================
-Configure Hidden Replica Set Member
-===================================
+=====================================
+Configure a Hidden Replica Set Member
+=====================================
 
 .. default-domain:: mongodb
 
@@ -15,7 +15,18 @@ detailed description of hidden members and their purposes, see
 To configure a secondary member as hidden, set its
 :data:`~local.system.replset.members[n].priority` value to ``0`` and
 set its :data:`~local.system.replset.members[n].hidden` value to
-``true``.
+``true``
+in its member configuration:
+
+.. code-block:: javascript
+   :emphasize-lines: 4-5
+
+   {
+     "_id" : <num>
+     "host" : <hostname:port>,
+     "priority" : 0,
+     "hidden" : true
+   }
 
 Example
 -------


### PR DESCRIPTION
## Old

file: build/rs-hidden/json/core/replica-set-hidden-member.json
source: source/core/replica-set-hidden-member.txt
stats:
   coleman-liau: 12.233739130434781
   flesch-ease: 36.2294816053512
   flesch-level: 12.60130434782609
   foggy:
      count: 19
      factor: 0.08260869565217391
      threshold: 3
   sentence-count: 13
   sentence-len-avg: 17
   smog-index: 10.035473477838034
   word-count: 230
## New

file: build/rs-hidden/json/core/replica-set-hidden-member.json
source: source/core/replica-set-hidden-member.txt
stats:
   coleman-liau: 11.444660194174755
   flesch-ease: 42.586928802589
   flesch-level: 10.731048543689322
   foggy:
      count: 14
      factor: 0.06796116504854369
      threshold: 3
   sentence-count: 15
   sentence-len-avg: 13
   smog-index: 8.648137234880735
   word-count: 206
