### PR TITLE
readability: rs-secondary

### DIFF
--- a/source/core/replica-set-secondary.txt
+++ b/source/core/replica-set-secondary.txt
@@ -6,30 +6,31 @@ Replica Set Secondary Members
 
 .. start-content
 
-Secondaries maintain replicas of the primary's data set. To replicate
-the data set, secondaries replicate the primary's :doc:`oplog
-</core/replica-set-oplog>`. They then apply these operations to
-themselves in an asynchronous process. A replica set can have one or
+A secondary maintains a replica of the :term:`primary's <primary>` data set. To replicate
+the data set, a secondary replicates the primary's :doc:`oplog
+</core/replica-set-oplog>`. The secondary then applies the oplog operations to
+itself in an asynchronous process. A replica set can have one or
 more secondaries.
 
-For example, the following three member replica set has two secondary
-members. The two secondaries replicate the primary's oplog and apply
+The following three-member replica set has two secondary
+members. The secondaries replicate the primary's oplog and apply
 the operations to their data sets.
 
 .. include:: /images/replica-set-primary-with-two-secondaries.rst
 
-Although secondary members cannot accept write operations, they can
-accept read operations from client applications. See
+Although secondary members cannot accept write operations from client applications, they can
+accept read operations. See
 :doc:`/core/read-preference` for more information on how clients direct
-read operations to members of the replica set.
+read operations to replica sets.
 
-If the current primary becomes unavailable, a secondary member can
-become the new primary as the result of an election. See
-:doc:`/core/replica-set-elections` for more details.
+A secondary can become a primary.
+If the current primary becomes unavailable, the replica set
+holds an :term:`election` to choose with of the secondaries
+becomes the new primary.
 
 .. start-content-election-example
 
-In the following 3-member replica set, the primary becomes unavailable.
+In the following three-member replica set, the primary becomes unavailable.
 This triggers an election where one of the remaining
 secondaries becomes the new primary.
 
@@ -37,16 +38,22 @@ secondaries becomes the new primary.
 
 .. end-content-election-example
 
-You can configure individual secondary members for different purposes:
+See
+:doc:`/core/replica-set-elections` for more details.
 
-- To prevent a secondary from becoming a primary in an election, see
+You can configure a secondary member for a specific purpose. You can
+configure a secondary to:
+
+- Prevent it from becoming a primary in an election, which allows it to
+  reside in a secondary data center or to serve as a cold standby. See
   :doc:`/core/replica-set-priority-0-member`.
 
-- To prevent applications from reading from a secondary member, see
+- Prevent applications from reading from it, which allows it to run applications
+  that require separation from normal traffic. See
   :doc:`/core/replica-set-hidden-member`.
 
-- To keep a running "historical" snapshot for use in recovery from
-  certain errors, such as unintentionally deleted databases, see
+- Keep a running "historical" snapshot for use in recovery from
+  certain errors, such as unintentionally deleted databases. See
   :doc:`/core/replica-set-delayed-member`.
 
 .. end-content


### PR DESCRIPTION
## Old

file: build/rs-secondary/json/core/replica-set-secondary.json
source: source/core/replica-set-secondary.txt
stats:
   coleman-liau: 12.80405594405594
   flesch-ease: 32.38998834498838
   flesch-level: 12.124925074925077
   foggy:
      count: 33
      factor: 0.11538461538461539
      threshold: 3
   sentence-count: 21
   sentence-len-avg: 13
   smog-index: 10.290406445055957
   word-count: 286
## New

file: build/rs-secondary/json/core/replica-set-secondary.json
source: source/core/replica-set-secondary.txt
stats:
   coleman-liau: 11.872693498452012
   flesch-ease: 37.07387413669926
   flesch-level: 11.174504643962852
   foggy:
      count: 36
      factor: 0.11145510835913312
      threshold: 3
   sentence-count: 26
   sentence-len-avg: 12
   smog-index: 9.851270322608155
   word-count: 323
