### PR TITLE
Fixes typo in not operator text

### DIFF
--- a/source/reference/operator/not.txt
+++ b/source/reference/operator/not.txt
@@ -25,7 +25,7 @@ $not
    - the ``price`` field does not exist
    
    ``{ $not: { $gt: 1.99 } }`` is different from the :operator:`$lte`
-   operator. ``{ $lt: 1.99 }`` returns *only* the documents where
+   operator. ``{ $lte: 1.99 }`` returns *only* the documents where
    ``price`` field exists and its value is less than or equal to
    ``1.99``.
   


### PR DESCRIPTION
$lt operator should be $lte in the given example.
