### PR TITLE
Add explanation on reIndex() fix typo on getIndexes

### DIFF
--- a/source/release-notes/2.4-upgrade.txt
+++ b/source/release-notes/2.4-upgrade.txt
@@ -172,12 +172,13 @@ operations.
 
 #. .. include:: /includes/fact-upgrade-sharded-cluster-prereq.rst
 
-   To check the version of your indexes, run :method:`~db.collectiongetIndexes()`.
+   To check the version of your indexes, run :method:`db.collection.getIndexes()`.
 
    If any index **on the config database** is ``{v:0}``, you should drop that index using
    :method:`dropIndex() <db.collection.dropIndex>`, and then rebuild it
    with :method:`ensureIndex() <db.collection.ensureIndex>`. This does
-   not apply to indexes on other databases in the cluster.
+   not apply to indexes on other databases in the cluster.  If the ``_id``
+   index needs to be upgraded to ``{v:1}`` use the :method:`reIndex() <db.collection.reIndex>`.
 
 #. Turn off the :ref:`balancer <sharding-balancing-internals>` in the
    :term:`sharded cluster`, as described in


### PR DESCRIPTION
dropIndex doesn't work on _id which most indexes in config DB are. Also there was typo on db.collection.getIndexes().
