### PR TITLE
Fix include doc

### DIFF
--- a/source/tutorial/add-user-to-database.txt
+++ b/source/tutorial/add-user-to-database.txt
@@ -19,7 +19,8 @@ user's credentials and privileges. The :method:`db.addUser()` method
 adds the document to the database's :data:`system.users
 <<database>.system.users>` collection.
 
-.. versionchanged:: 2.4 
+.. versionchanged:: 2.4
+
    .. include:: /includes/fact-change-password.rst
    
    To change a user's password in version


### PR DESCRIPTION
This "include" is not working.
See http://docs.mongodb.org/manual/tutorial/add-user-to-database/

I'm pretty sure it's because it's too close to the line above (looking at the other "include"(s) in other docs)
