### PR TITLE
Update fact-upgrade-sharded-cluster-prereq.rst

### DIFF
--- a/source/includes/fact-upgrade-sharded-cluster-prereq.rst
+++ b/source/includes/fact-upgrade-sharded-cluster-prereq.rst
@@ -6,6 +6,6 @@ currently used by the :doc:`config database
 
 Additionally, ensure that all indexes in the :doc:`config database
 </reference/config-database>` are ``{v:1}`` indexes. If a critical
-index is a ``{v:0}`` index, chunk splits can fail following the
-upgrade. ``{v:0}`` indexes are present on clusters created with
+index is a ``{v:0}`` index, chunk splits can fail due to known issues
+with the ``{v:0}`` format. ``{v:0}`` indexes are present on clusters created with
 MongoDB 2.0 or earlier.


### PR DESCRIPTION
Unless I'm missing something here, the issue we identified with v:0 indexes isn't related to upgrade at all, and is no more or less likely after the upgrade.  We definitely want to encourage index upgrade, but not doing so won't make things worse.

Mention this because seeing customer concern about this warning in the docs.
