### PR TITLE
SERVER-10186 changed language to say what the length of the key should be, not the file

### DIFF
--- a/source/tutorial/generate-key-file.txt
+++ b/source/tutorial/generate-key-file.txt
@@ -11,7 +11,7 @@ authentication information. After generating a key file, specify the key
 file using the :setting:`keyFile` option when starting a
 :program:`mongod` or :program:`mongos` instance.
 
-A key file must be less than one kilobyte in size and may only contain
+A key's length must be between 6 and 1024 characters and may only contain
 characters in the base64 set. The key file must not have group or world
 permissions on UNIX systems. Key file permissions are not checked on
 Windows systems.


### PR DESCRIPTION
This change should only be pulled pending the acceptance of https://github.com/mongodb/mongo/pull/457
