### PR TITLE
Update expire-data.txt

### DIFF
--- a/source/tutorial/expire-data.txt
+++ b/source/tutorial/expire-data.txt
@@ -49,6 +49,8 @@ Consider the following limitations:
 - the indexed field must be a date :term:`BSON type <BSON types>`. If
   the field does not have a date type, the data will not expire.
 
+- Documents that omit the indexed field will never expire.
+
 - you cannot create this index on the ``_id`` field, or a field that
   already has an index.
 


### PR DESCRIPTION
Clarifying how Mongo handles documents under a TTL index, that omit the indexed column.
