### PR TITLE
fix to rs.add param table

### DIFF
--- a/source/reference/method/rs.add-param.yaml
+++ b/source/reference/method/rs.add-param.yaml
@@ -9,7 +9,12 @@ type:
   - string
   - document
 position: 1
-description: "Either a string or a document.  If a string, specifies a host (and optionally port-number) for a new host member for the replica set; MongoDB will add this host with the default configuration. If a document, specifies any attributes about a member of a replica set."
+description: |
+  The new member to add to the replica set. If a string, specifies the
+  hostname and optionally the port number for the new member. If a
+  document, specifies a replica set members document, as found in the
+  :data:`~local.system.replset.members` array. To view a replica set's
+  members array, run :method:`rs.conf()`.
 ---
 object:
   name: rs.add()
@@ -20,5 +25,7 @@ field:
 name: arbiterOnly
 type: boolean
 position: 2
-description: "If ``true``, this host is an arbiter. If the second argument evaluates to ``true``, as is the case with some :term:`documents <document>`, then this instance will become an arbiter."
+description: |
+  Applies only if the ``<host>`` value is a string. If ``true``, the
+  added host is an arbiter."
 ...


### PR DESCRIPTION
This clarifies that arbiterOnly applies only if the host value is a string. This also updates the host description.
