### PR TITLE
Correcting findAndModify update and remove field descriptions

### DIFF
--- a/source/reference/command/findAndModify.txt
+++ b/source/reference/command/findAndModify.txt
@@ -56,15 +56,17 @@ findAndModify
 
    :field boolean remove:
 
-      Optional if ``update`` field exists. When ``true``, removes
-      the selected document. The default is ``false``.
+      Optional if no ``update`` field exists. When ``true``, removes
+      the selected document. The default is ``false``. An error will be
+      returned if used in combination with ``update``.
 
    :field document update:
 
-      Optional if ``remove`` field exists. Performs an update of the
-      selected document. The ``update`` field employs the same
+      Optional if ``remove`` field does not exist. Performs an update of
+      the selected document. The ``update`` field employs the same
       :ref:`update operators <update-operators>` or ``field: value``
-      specifications to modify the selected document.
+      specifications to modify the selected document. An error will be
+      returned in used in combination with ``remove``.
 
    :field boolean new:
 


### PR DESCRIPTION
The descriptions of the update and remove fields in findAndModify indicated that you could use the two in combination.  They must be used exclusively so I've updated the text.
