### PR TITLE
Update install-mongodb-on-ubuntu.txt

### DIFF
--- a/source/tutorial/install-mongodb-on-ubuntu.txt
+++ b/source/tutorial/install-mongodb-on-ubuntu.txt
@@ -62,7 +62,7 @@ to import the `10gen public GPG Key <http://docs.mongodb.org/10gen-gpg-key.asc>`
 
 .. code-block:: sh
 
-   sudo apt-key adv --keyserver keyserver.ubuntu.com --recv 7F0CEB10
+   sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
 
 Create a ``/etc/apt/sources.list.d/10gen.list`` file using the
 following command.


### PR DESCRIPTION
Use URI prefix and port 80 for keyserver.  Should be generically good when called from inside more restrictive network environments and harmless elsewhere.

See:  http://stackoverflow.com/questions/13112400/gpgkeys-key-7f0ceb10-not-found-on-keyserver-while-installing-mongodb-on-ubunt
