### PR TITLE
serverStatus.metrics.getLastError.wtime.num description typo

### DIFF
--- a/source/reference/command/serverStatus.txt
+++ b/source/reference/command/serverStatus.txt
@@ -1359,7 +1359,7 @@ page.
 .. data:: serverStatus.metrics.getLastError.wtime.num
 
    :data:`~serverStatus.metrics.getLastError.wtime.num` reports the
-   total number of :dbcommand:`getLastError` operations without a
+   total number of :dbcommand:`getLastError` operations with a
    specified write concern (i.e. ``w``) that wait for one or more
    members of a replica set to acknowledge the write operation
    (i.e. greater than ``1``.)


### PR DESCRIPTION
The description for serverStatus.metrics.getLastError.wtime.num states it tracks operations "without a specified write concern". I believe this should be "with a specified write concern" instead as "wtime" tracks operations with a write concern.
