### PR TITLE
production: fix path for include files

### DIFF
--- a/source/reference/configuration-options.txt
+++ b/source/reference/configuration-options.txt
@@ -46,7 +46,7 @@ Declare all settings in this file using the following form:
    parameters, register as true, if they appear in the configuration
    file, regardless of their value.
 
-.. include:: /include/note-configuration-file-must-be-ascii.rst
+.. include:: /includes/note-configuration-file-must-be-ascii.rst
 
 Settings
 --------

--- a/source/reference/program/mongod.txt
+++ b/source/reference/program/mongod.txt
@@ -51,7 +51,7 @@ Core Options
    mongod. See the ":doc:`/reference/configuration-options`" document
    for more information about these options.
 
-   .. include:: /include/note-configuration-file-must-be-ascii.rst
+   .. include:: /includes/note-configuration-file-must-be-ascii.rst
 
 .. option:: --verbose, -v
 

--- a/source/reference/program/mongos.txt
+++ b/source/reference/program/mongos.txt
@@ -56,7 +56,7 @@ Options
    Not all configuration options for :program:`mongod` make sense in
    the context of :program:`mongos`.
 
-   .. include:: /include/note-configuration-file-must-be-ascii.rst
+   .. include:: /includes/note-configuration-file-must-be-ascii.rst
 
 .. option:: --verbose, -v
 


### PR DESCRIPTION
Path for /includes/note-configuration-file-must-be-ascii.rst was in error
