### PR TITLE
set hostname arg to host, hostname no longer works

### DIFF
--- a/source/reference/program/mongo.txt
+++ b/source/reference/program/mongo.txt
@@ -439,7 +439,7 @@ non-standard port, use the following form:
 
 .. code-block:: sh
 
-   mongo --username <user> --password <pass> --hostname <host> --port 28015
+   mongo --username <user> --password <pass> --host <host> --port 28015
 
 Alternatively, consider the following short form:
 


### PR DESCRIPTION
Noticed that using --hostname does not work now, we currently only accept --host 
