### PR TITLE
Update directions to reflect what to do with the config servers whose hostnames did not change

### DIFF
--- a/source/tutorial/migrate-config-servers-with-different-hostnames.txt
+++ b/source/tutorial/migrate-config-servers-with-different-hostnames.txt
@@ -42,6 +42,8 @@ procedure to :doc:`migrate a config server and use the same hostname
 
 #. Restart all :program:`mongod` processes that provide the shard
    servers.
+   
+#. Restart the config instances, which have not changed hostnames.
 
 #. Update the :option:`--configdb <mongos --configdb>` parameter (or
    :setting:`configdb`) for all :program:`mongos` instances and


### PR DESCRIPTION
The original directions indicate that all config mongod's should be shutdown, but do not indicate that the config mongod whose hostnames did not change should be restarted.
