### PR TITLE
Replaced duplicate link to Read Operations with one to Query Documents.

### DIFF
--- a/source/tutorial/getting-started.txt
+++ b/source/tutorial/getting-started.txt
@@ -343,7 +343,7 @@ following command:
    db.testData.findOne()
 
 For more information on querying for documents, see the
-:doc:`/core/read-operations` and :doc:`/core/read-operations` documentation.
+:ref:`read-operations-query-document` and :doc:`/core/read-operations` documentation.
 
 Limit the Number of Documents in the Result Set
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The 'Getting Started' doc had two links to 'Read Operations' in the 'Return a Single Document from a Collection' section. I changed the first link to go to 'Query Documents' instead, as in the 'Query for Specific Documents' section above it.
