### PR TITLE
minor: copy edit run

### DIFF
--- a/source/core/record-padding.txt
+++ b/source/core/record-padding.txt
@@ -9,7 +9,7 @@ Update operations can increase the size of the document
 :term:`record space <record size>`, MongoDB must allocate a new space
 and move the document to this new location.
 
-To reduce the number of moves, MongoDB includes a small amout of extra
+To reduce the number of moves, MongoDB includes a small amount of extra
 space, or :term:`padding`, when allocating the record space. This
 padding reduces the likelihood that a slight increase in document size
 will cause the document to exceed its allocated record size.

--- a/source/core/write-operations.txt
+++ b/source/core/write-operations.txt
@@ -24,7 +24,7 @@ operations use the same query syntax to specify the criteria as
 :doc:`read operations </core/read-operations>`.
 
 After issuing these modification operations, MongoDB allows
-applications to determine the level of acknowledgement returned from
+applications to determine the level of acknowledgment returned from
 the database. See
 :doc:`/core/write-concern`.
 

--- a/source/images/metadata.yaml
+++ b/source/images/metadata.yaml
@@ -450,7 +450,7 @@ output:
     width: 400
 ---
 name: crud-write-concern-ack
-alt: "Write operation to a ``mongod`` instance with write concern of ``acknowledged``. The client waits for acknowledgement of success or exception."
+alt: "Write operation to a ``mongod`` instance with write concern of ``acknowledged``. The client waits for acknowledgment of success or exception."
 output:
   - type: print
     tag: 'print'
@@ -461,7 +461,7 @@ output:
     width: 460
 ---
 name: crud-write-concern-unack
-alt: "Write operation to a ``mongod`` instance with write concern of ``unacknowledged``. The client does not wait for any acknowledgement."
+alt: "Write operation to a ``mongod`` instance with write concern of ``unacknowledged``. The client does not wait for any acknowledgment."
 output:
   - type: print
     tag: 'print'
@@ -472,7 +472,7 @@ output:
     width: 460
 ---
 name: crud-write-concern-journal
-alt: "Write operation to a ``mongod`` instance with write concern of ``journaled``. The ``mongod`` sends acknowledgement after it commits the write operation to the journal."
+alt: "Write operation to a ``mongod`` instance with write concern of ``journaled``. The ``mongod`` sends acknowledgment after it commits the write operation to the journal."
 output:
   - type: print
     tag: 'print'

--- a/source/tutorial/expire-data.txt
+++ b/source/tutorial/expire-data.txt
@@ -135,7 +135,7 @@ field is a time older than the number of seconds specified in
 Constraints
 -----------
 
-- The ``_id`` field does not support TTL indexex.
+- The ``_id`` field does not support TTL indexes.
 
 - You cannot create a TTL index on a field that already has an index.
 


### PR DESCRIPTION
Mostly typos.
One editorial/style edit: c/acknowledgement/acknowledgment/ ("acknowledgment" was the dominant form already)
