### PR TITLE
replica-members-add-on-one-machine.txt

### DIFF
--- a/source/tutorial/deploy-replica-set.txt
+++ b/source/tutorial/deploy-replica-set.txt
@@ -257,7 +257,7 @@ To deploy a production replica set:
       rs.conf()
 
 #. Add two members to the replica set by issuing a sequence of commands
-   similar to the following:
+   similar to the following to the primary machine:
 
    .. code-block:: javascript
 


### PR DESCRIPTION
The documentation doesn't say clearly that rs.add() should be called only on one machine, and that these configurations propagate to the other members
