### PR TITLE
Extend 2.6 release notes for $out

### DIFF
--- a/source/release-notes/2.6.txt
+++ b/source/release-notes/2.6.txt
@@ -88,8 +88,20 @@ Aggregation Pipeline Changes
       :pipeline:`$out`.
 
    :pipeline:`$out` will create a new collection if one does not
-   already exist in the current database.
-
+   already exist in the current database. This collection will not be
+   visible at that name until the aggregation completes. If the aggregation
+   fails part-way through, no collection will be created.
+   
+   If the output collection already exists, the behavior is the same
+   as MapReduce's replace mode. To be specific if the aggregation completes
+   successfully, the output collection will be atomically replaced by a newer
+   version. Any indexes that existed at the start of the aggregation on the
+   original output collection will also exist on the new collection.
+   Importantly, this means that the pipeline will error out if the output
+   documents would violate any unique indexes (including _id) that existed
+   on the original output collection.
+   
+   
    You may *only* specify :pipeline:`$out` at the end of a pipeline.
 
 .. example::


### PR DESCRIPTION
Filling in details on when the collection appears and what we do when the output collection already exists.

This could probably use some copy-editing and some markup.
