### PR TITLE
Update mongostat.txt

### DIFF
--- a/source/reference/program/mongostat.txt
+++ b/source/reference/program/mongostat.txt
@@ -109,7 +109,7 @@ Options
    supply a username.
 
    If you specify a :option:`--username <mongostat --username>`
-   without the :option:`--password` option, :program:`mongostat` will
+   and the :option:`--password` option without an argument, :program:`mongostat` will
    prompt for a password interactively.
 
 .. |binary-name| replace:: :program:`mongostat`


### PR DESCRIPTION
Clarify that user must specify -p or --password without an argument to be prompted for a password interactively.
