### PR TITLE
Update crud-introduction.txt

### DIFF
--- a/source/core/crud-introduction.txt
+++ b/source/core/crud-introduction.txt
@@ -6,7 +6,7 @@ MongoDB CRUD Introduction
 
 MongoDB stores data in the form of *documents*, which are JSON-like
 field and value pairs. Documents are analogous to structures in
-programming languages that associate keys with values, where keys may
+programming languages that associate keys with values, where values may
 nest other pairs of keys and values (e.g. dictionaries, hashes, maps,
 and associative arrays). Formally, MongoDB documents are :term:`BSON`
 documents, which is a binary representation of :term:`JSON` with


### PR DESCRIPTION
If I understand MongoDB properly, it allows

{
  'a': [1, 2]('a')
}

and not

{

}

Or maybe I don't understand the text correctly.
