### PR TITLE
Example heading correction

### DIFF
--- a/source/reference/program/mongoexport.txt
+++ b/source/reference/program/mongoexport.txt
@@ -177,7 +177,7 @@ Options
          { "_id" : ObjectId("520e6431b7fa4ea22d6b1872"), "a" : 3, "b" : 3, "c" : 6 }
          { "_id" : ObjectId("520e6445b7fa4ea22d6b1873"), "a" : 5, "b" : 6, "c" : 8 }
 
-      And the following :program:`mongoimport`:
+      And the following mongoexport:
 
       .. code:: bash
 


### PR DESCRIPTION
The documentation has a label for a code snipped referencing "mongoimport" but the example code itself is a call to "mongoexport"
