### PR TITLE
Update sharded-cluster-config-servers.txt

### DIFF
--- a/source/core/sharded-cluster-config-servers.txt
+++ b/source/core/sharded-cluster-config-servers.txt
@@ -50,9 +50,6 @@ this data and use it to route reads and writes to shards.
 Read and Write Operations on Config Servers
 -------------------------------------------
 
-The load on the config servers is small because each :program:`mongos`
-instance caches the metadata.
-
 MongoDB only writes data to the config server in the following cases:
 
 - To create splits in existing chunks. For more information, see


### PR DESCRIPTION
That statement is not true.  People following it has led to system failures due to config server overload(according to stories from SA/CE in training bootcamp).  The docs also appear to fail to mention that the config servers hold the distributed locks.  A large source of read/writes.
