### PR TITLE
Making sure the user knows that db commands are 'pull', not 'push'.

### DIFF
--- a/source/tutorial/copy-databases-between-instances.txt
+++ b/source/tutorial/copy-databases-between-instances.txt
@@ -13,7 +13,9 @@ entire logical databases between :program:`mongod` instances. With
 these commands you can copy data between instances with a simple
 interface without the need for an intermediate stage. The
 :method:`db.cloneDatabase()` and :method:`db.copyDatabase()` provide
-helpers for these operations in the :program:`mongo` shell.
+helpers for these operations in the :program:`mongo` shell. 
+These migration helpers are 'pull', and not 'push', so you must run the commands on the 
+**destination** server.
 
 Data migrations that require an intermediate stage or that involve
 more than one database instance are beyond the scope of this


### PR DESCRIPTION
I somehow missed the first point in the 'Consideration' list, so I think it could be a little bit clearer.
