### PR TITLE
Clarification on authentication and executing a file

### DIFF
--- a/source/reference/program/mongo.txt
+++ b/source/reference/program/mongo.txt
@@ -99,6 +99,9 @@ Options
    :option:`--password` option, :program:`mongo` will prompt for a
    password interactively, if the :program:`mongod` or
    :program:`mongos` requires authentication.
+   Note that if you chose not to provide an argument, and wish 
+   to be prompted for the password, :option`--password` must be
+   the last option.
 
 .. |binary-name| replace:: :program:`mongo`
 .. include:: /includes/manpage-options-auth-mongo.rst
@@ -190,7 +193,15 @@ Options
 .. option:: <file.js>
 
    Specifies a JavaScript file to run and then exit.
-   Must be the last option specified.
+   Generally this should be the last option specified. 
+   However if authentication is required with a prompted
+   password, pass this as the first parameter with 
+   subsequent options. For example:
+
+   .. code-block:: sh
+
+      mongo file.js -u username -p
+
    Use the
    :option:`--shell` option to return to a shell after the file
    finishes running.
@@ -454,6 +465,13 @@ file before starting a shell session, use the following form:
 
    mongo --shell --norc alternate-environment.js
 
+To execute a JavaScript file with authentication, with password prompted 
+rather than provided on the command-line, use the following form:
+
+.. code-block:: sh
+
+   mongo script-file.js -u <user> -p
+   
 To print return a query as :term:`JSON`, from the system prompt using
 the :option:`--eval <mongo --eval>` option, use the following form:
 


### PR DESCRIPTION
The documentation is misleading (or wrong) about how a file should be executed, since --password MUST be the last option if it is provided without an argument (meaning user should be prompted for password).
