### PR TITLE
changing 'from' to 'to'

### DIFF
--- a/source/reference/program/mongorestore.txt
+++ b/source/reference/program/mongorestore.txt
@@ -299,10 +299,10 @@ data directory.
    mongorestore --dbpath /srv/mongodb
 
 In the final example, :program:`mongorestore` restores a database
-dump located at ``/opt/backup/mongodump-2011-10-24``, from a database
+dump located at ``/opt/backup/mongodump-2011-10-24``, to a database
 running on port ``37017`` on the host
-``mongodb1.example.net``. :program:`mongorestore` authenticates to
-the this MongoDB instance using the username ``user`` and the
+``mongodb1.example.net``. The :program:`mongorestore` command authenticates to
+the MongoDB instance using the username ``user`` and the
 password ``pass``, as follows:
 
 .. code-block:: sh


### PR DESCRIPTION
The wording should be that the example restores "to a database running on port" etc.

Also:
- added a "The ... command" for visual clarity on the page (we had two bolded commands separated only by a period)
- removed a typo 
