### PR TITLE
Update serverStatus.txt

### DIFF
--- a/source/reference/command/serverStatus.txt
+++ b/source/reference/command/serverStatus.txt
@@ -556,8 +556,7 @@ section <server-status-example-extrainfo>` of the
 .. data:: serverStatus.extra_info.page_faults
 
    The :data:`~serverStatus.extra_info.page_faults`
-   field is only available on Unix/Linux
-   systems, and reports the total number of page faults that require
+   Reports the total number of page faults that require
    disk operations. Page faults refer to operations that require the
    database server to access data which isn't available in active
    memory. The :data:`~serverStatus.extra_info.page_faults` counter may


### PR DESCRIPTION
Looks like we added serverStatus.extra_info.page_faults for windows with MongoDB 2.0. We should remove the Unix/Linux disclaimer.
