### PR TITLE
Typo run

### DIFF
--- a/source/administration/production-notes.txt
+++ b/source/administration/production-notes.txt
@@ -33,7 +33,7 @@ production deployments as it can store no more than 2GB of data.
 See the :ref:`32-bit limitations
 <faq-32-bit-limitations>` for more information.
 
-32-bit builds exist to support use on development machiness.
+32-bit builds exist to support use on development machines.
 
 Operating Systems
 ~~~~~~~~~~~~~~~~~

--- a/source/core/capped-collections.txt
+++ b/source/core/capped-collections.txt
@@ -47,7 +47,7 @@ collections:
   RAM) *or* accept some write penalty for the required index or
   indexes.
 
-.. _capped-collections-reccomendations-and-restrictions:
+.. _capped-collections-recommendations-and-restrictions:
 
 Recommendations and Restrictions
 --------------------------------

--- a/source/core/index-single.txt
+++ b/source/core/index-single.txt
@@ -75,8 +75,8 @@ the value of an ``_id`` field.
    Before version 2.2, :term:`capped collections <capped collection>`
    did not have an ``_id`` field. In version 2.2 and newer, capped
    collection do have an ``_id`` field, except those in the ``local``
-   :term:`database`. See :ref:`Capped Collections Reccomendations
-   and Restrictions <capped-collections-reccomendations-and-restrictions>`
+   :term:`database`. See :ref:`Capped Collections Recommendations
+   and Restrictions <capped-collections-recommendations-and-restrictions>`
    for more information.
 
 .. index:: index; embedded fields

--- a/source/core/sharding-balancing.txt
+++ b/source/core/sharding-balancing.txt
@@ -52,7 +52,7 @@ workload, both of which can impact database performance. The
 :term:`balancer` attempts to minimize the impact by:
 
 - Moving only one chunk at a time. See also
-  :ref:`chunk-migration-queing`.
+  :ref:`chunk-migration-queuing`.
 
 - Starting a balancing round **only** when the difference in the
   number of chunks between the shard with the greatest number of chunks

--- a/source/core/sharding-chunk-migration.txt
+++ b/source/core/sharding-chunk-migration.txt
@@ -61,12 +61,12 @@ All chunk migrations use the following procedure:
       the source shard, the balancer can start the next chunk
       migration without waiting for the current
       migration process to finish this deletion step. See
-      :ref:`chunk-migration-queing`.
+      :ref:`chunk-migration-queuing`.
 
 The migration process ensures consistency and maximizes the availability of
 chunks during balancing.
 
-.. _chunk-migration-queing:
+.. _chunk-migration-queuing:
 
 Chunk Migration Queuing
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/release-notes/2.4.txt
+++ b/source/release-notes/2.4.txt
@@ -268,7 +268,7 @@ Improved Chunk Migration Queue Behavior
 Increase performance for moving multiple chunks off an overloaded
 shard. The balancer no longer waits for the current migration's
 delete phase to complete before starting the next chunk migration.
-See :ref:`chunk-migration-queing` for details.
+See :ref:`chunk-migration-queuing` for details.
 
 .. _mongodb-enterprise:
 


### PR DESCRIPTION
Fixed a couple of typos in references (patched both the anchor and the :refs: to the anchor)
