### PR TITLE
Minor grammatical error

### DIFF
--- a/source/reference/operator/aggregation/unwind.txt
+++ b/source/reference/operator/aggregation/unwind.txt
@@ -24,7 +24,7 @@ $unwind (aggregation)
 
    .. note::
 
-      The dollar sign (i.e. ``$``) must proceed the field
+      The dollar sign (i.e. ``$``) must precede the field
       specification handed to the :pipeline:`$unwind` operator.
 
    In the above aggregation :pipeline:`$project` selects


### PR DESCRIPTION
I think what is meant is "precede" instead of "proceed"?
