### PR TITLE
Clean: concurrency.txt; typo.

### DIFF
--- a/source/faq/concurrency.txt
+++ b/source/faq/concurrency.txt
@@ -196,7 +196,7 @@ instances.
 
 Each :program:`mongod` instance is independent of the others in the
 shard cluster and uses the MongoDB :ref:`readers-writer lock
-<faq-concurrency-locking>`). The operations on one :program:`mongod`
+<faq-concurrency-locking>`. The operations on one :program:`mongod`
 instance do not block the operations on any others.
 
 .. _faq-concurrency-replication:


### PR DESCRIPTION
Removed a stray parenthesis.
