### PR TITLE
Slight update to User Defined Roles description

### DIFF
--- a/source/release-notes/2.6.txt
+++ b/source/release-notes/2.6.txt
@@ -890,7 +890,8 @@ to have only the privileges granted by the roles.
 
 User data includes the user's authentication credentials as well as any
 roles assigned to the user. MongoDB stores the user data in the
-:ref:`system.users <admin-system-users-collection>` collection.
+:ref:`system.users <admin-system-users-collection>` collection of the 
+``admin`` database.
 
 .. _resource-document:
 


### PR DESCRIPTION
Make it clear that the system.users collection lives in the "admin" database, not in arbitrary databases as was true in v2.4.
