### PR TITLE
fixes inconsistent use of 'Patterns and Examples'

### DIFF
--- a/source/core/data-models.txt
+++ b/source/core/data-models.txt
@@ -13,7 +13,7 @@ model for your application needs.
 For a general introduction to data modeling in MongoDB, see the
 :doc:`Data Modeling Introduction
 </core/data-modeling-introduction>`. For example data models, see
-:doc:`Data Modeling Patterns and Examples
+:doc:`Data Modeling Examples and Patterns
 </applications/data-models>`.
 
 .. include:: /includes/toc/dfn-list-data-modeling-concepts.rst


### PR DESCRIPTION
reordered to be consistent with the rest of the docs
