### PR TITLE
State the version number in conf.version.published

### DIFF
--- a/bin/docs_meta.yaml
+++ b/bin/docs_meta.yaml
@@ -19,7 +19,7 @@ version:
   release: '2.5.3'
   branch: '2.5'
   published:
-    - 'upcoming'
+    - '2.6'
     - '2.4'
     - '2.2'
   stable: '2.4'


### PR DESCRIPTION
Although the new version navigator should still work with the current configuration, this value should still be '2.6' rather than `upcoming`. This inconsistency may be an artifact of a previous change made to this yaml file.

See: https://github.com/mongodb/docs-tools/pull/22
