### PR TITLE
Added global lock warning

### DIFF
--- a/source/core/capped-collections.txt
+++ b/source/core/capped-collections.txt
@@ -161,6 +161,8 @@ the :dbcommand:`convertToCapped` command:
 The ``size`` parameter specifies the size of the capped collection in
 bytes.
 
+.. include:: /includes/warning-blocking-global.rst
+
 .. versionchanged:: 2.2
    Before 2.2, capped collections did not have an index on ``_id``
    unless you specified ``autoIndexId`` to the :dbcommand:`create`,


### PR DESCRIPTION
This page contains enough info to not need to go and read http://docs.mongodb.org/manual/reference/command/convertToCapped/ so the warning should be present here too.
