### PR TITLE
putting form before fields - part 1

### DIFF
--- a/source/reference/command/applyOps.txt
+++ b/source/reference/command/applyOps.txt
@@ -13,6 +13,13 @@ Definition
    instance. The :dbcommand:`applyOps` command is primarily an internal
    command to support :term:`sharded clusters <sharded cluster>`.
 
+   The :dbcommand:`applyOps` command has the following prototype form:
+
+   .. code-block:: javascript
+
+      db.runCommand( { applyOps: [ <operations> ],
+                       preCondition: [ { ns: <namespace>, q: <query>, res: <result> } ] } )
+
    The :dbcommand:`applyOps` command takes a document with the following fields:
 
    .. include:: /reference/command/applyOps-field.rst
@@ -21,16 +28,7 @@ Definition
 
    .. include:: /reference/command/applyOps-preCondition-field.rst
 
-Example
--------
-
-The :dbcommand:`applyOps` command has the following prototype form:
-
-.. code-block:: javascript
-
-   db.runCommand( { applyOps: [ <operations> ], preCondition: [ { ns: <namespace>, q: <query>, res: <result> } ] } )
-
-.. include:: /includes/warning-blocking-global.rst
+   .. include:: /includes/warning-blocking-global.rst
 
 .. write-lock
 

--- a/source/reference/command/cleanupOrphaned.txt
+++ b/source/reference/command/cleanupOrphaned.txt
@@ -19,8 +19,6 @@ Definition
    Orphaned data sometimes results from aborted migrations due to
    network latency and power loss.
 
-   .. include:: /reference/command/cleanupOrphaned-field.rst
-
    Run :dbcommand:`cleanupOrphaned` directly on the :program:`mongod`
    instance on the primary replica set member of the shard. Do not
    run :dbcommand:`cleanupOrphaned` from a :program:`mongos` instance.
@@ -35,6 +33,10 @@ Definition
          "startingAtKey": <minimumShardKeyValue>,
          "secondaryThrottle": true
       }
+
+   :dbcommand:`cleanupOrphaned` has the following fields:
+
+   .. include:: /reference/command/cleanupOrphaned-field.rst
 
 Required Access
 ---------------

--- a/source/reference/command/copydb.txt
+++ b/source/reference/command/copydb.txt
@@ -6,11 +6,8 @@ copydb
 
 .. dbcommand:: copydb
 
-   The :dbcommand:`copydb` command copies a database from a remote
-   host to the current host. :dbcommand:`copydb` accepts the following
-   options:
-
-   .. include:: /reference/command/copydb-fields.rst
+   Copies a database from a remote
+   host to the current host.
 
    :dbcommand:`copydb` has the following syntax:
 
@@ -24,6 +21,10 @@ copydb
         username: <username>,
         nonce: <nonce>,
         key: <key> }
+
+   :dbcommand:`copydb` accepts the following options:
+
+   .. include:: /reference/command/copydb-fields.rst
 
 Behavior
 --------

--- a/source/reference/command/getLastError.txt
+++ b/source/reference/command/getLastError.txt
@@ -13,13 +13,15 @@ Definition
    connection*. Clients typically use :dbcommand:`.getLastError` in
    combination with write operations to ensure that the write succeeds.
 
-   .. include:: /reference/command/getLastError-fields.rst
-
-   The following is the prototype form:
+   :dbcommand:`getLastError` uses the following prototype form:
 
    .. code-block:: javascript
 
       { getLastError: 1 }
+
+   :dbcommand:`getLastError` uses the following fields:
+
+   .. include:: /reference/command/getLastError-fields.rst
 
    .. seealso:: :doc:`Write Concern </core/write-concern>`,
       :doc:`/reference/write-concern`, and :ref:`replica-set-write-concern`.

--- a/source/reference/command/hashBSONElement.txt
+++ b/source/reference/command/hashBSONElement.txt
@@ -15,6 +15,12 @@ Description
    :dbcommand:`_hashBSONElement` command returns 8 bytes from the 16
    byte MD5 hash.
 
+   The :dbcommand:`_hashBSONElement` command has the following form:
+
+   .. code-block:: javascript
+
+      db.runCommand({ _hashBSONElement: <key> , seed: <seed> })
+
    The :dbcommand:`_hashBSONElement` command has the following fields:
 
    .. include:: /reference/command/hashBSONElement-field.rst

--- a/source/reference/command/sleep.txt
+++ b/source/reference/command/sleep.txt
@@ -12,18 +12,18 @@ Definition
    Forces the database to block all operations. This is an internal
    command for testing purposes.
 
-   The :dbcommand:`sleep` command has the following options:
+   The :dbcommand:`sleep` command takes the following prototype form:
+
+   .. code-block:: javascript
+
+      { sleep: 1, w: <true|false>, secs: <seconds> }
+
+   The :dbcommand:`sleep` command has the following fields:
 
    .. include:: /reference/command/sleep-field.rst
 
-Example
--------
-
-The :dbcommand:`sleep` command takes the following prototype form:
-
-.. code-block:: javascript
-
-     { sleep: 1, w: <true|false>, secs: <seconds> }
+Behavior
+--------
 
 The command places the :program:`mongod` instance in a :term:`write lock`
 state for a specified number of seconds. Without arguments,

--- a/source/reference/command/split.txt
+++ b/source/reference/command/split.txt
@@ -17,6 +17,13 @@ Definition
    information on these circumstances, and on the MongoDB shell commands
    that wrap :dbcommand:`split`.
 
+   The :dbcommand:`split` command uses the following form:
+
+   .. code-block:: javascript
+
+      db.adminCommand( { split: <database>.<collection>,
+                         <find|middle|bounds> } )
+
    The :dbcommand:`split` command takes a document with the following
    fields:
 


### PR DESCRIPTION
Our method ref pages all show syntax before parameter tables. All but a dozen of our commands do the same (i.e., show their syntax before their fields tables). This and the next commit fix that for those dozen or so command ref pages.
