### PR TITLE
The oplog option confusion clarification

### DIFF
--- a/source/reference/program/mongodump.txt
+++ b/source/reference/program/mongodump.txt
@@ -181,13 +181,14 @@ Options
 .. option:: --oplog
 
    Use this option to ensure that :program:`mongodump` creates a dump
-   of the database that includes an :term:`oplog`, to create a
+   of the database that includes a partial :term:`oplog` containing
+   duration of the mongodump command, which allows you to create a
    point-in-time snapshot of the state of a :program:`mongod` instance. To
    restore to a specific point-in-time backup, use the output created
    with this option in conjunction with :option:`mongorestore --oplogReplay`.
 
    Without :option:`--oplog`, if there are write operations during the
-   dump operation, the dump will not reflect a single moment in
+   dump operation, the dump will not reflect a consistent point in
    time. Changes made to the database during the update process can
    affect the output of the backup.
 
@@ -201,7 +202,9 @@ Options
       :option:`--oplog` only works against nodes that maintain an
       :term:`oplog`. This includes all members of a replica set, as
       well as :term:`master` nodes in master/slave replication
-      deployments.
+      deployments.  
+      
+      :option:`--oplog` does not dump the oplog collection.
 
 .. option:: --repair
 


### PR DESCRIPTION
The --oplog option only dumps anything that would have been written during the duration of 'mongodump' operation.  It does not dump out the oplog.rs collection as many people seem to mistakenly think.
