### PR TITLE
Update deploy-shard-cluster.txt

### DIFF
--- a/source/tutorial/deploy-shard-cluster.txt
+++ b/source/tutorial/deploy-shard-cluster.txt
@@ -112,6 +112,15 @@ You would issue the following command:
 .. code-block:: sh
 
    mongos --configdb cfg0.example.net:27019,cfg1.example.net:27019,cfg2.example.net:27019
+   
+Each :program:`mongos` in a sharded cluster must use the same
+:setting:`configdb` string, with identical host names listed in
+identical order.
+
+If you start a :program:`mongos` instance with a string that does not exactly
+match the string used by the other :program:`mongos` instances in the cluster, the
+:program:`mongos` fails and you receive the
+:ref:`config-database-string-error` error.
 
 .. _sharding-setup-add-shards:
 


### PR DESCRIPTION
We should make explicit that config order must be the same across mongos instances. This change was copied from the 2.4 docs for the same page.
