### PR TITLE
change to ref-toc description for updateUser

### DIFF
--- a/source/includes/ref-toc-command-user-management.yaml
+++ b/source/includes/ref-toc-command-user-management.yaml
@@ -4,7 +4,7 @@ description: "Creates a new user."
 ---
 name: :dbcommand:`updateUser`
 file: /reference/command/updateUser
-description: "Updates a user privilege document."
+description: "Updates a user's data."
 ---
 name: :dbcommand:`dropUser`
 file: /reference/command/dropUser


### PR DESCRIPTION
User's don't have privlege documents.
Also, this command updates the "user" but actually replaces the targetted field, which can be the "roles," "pwd," or "customData" field. So we shouldn't say it "updates" when referring to specific field.
