### PR TITLE
Correct Max BSON size to 16 MB

### DIFF
--- a/source/reference/command/isMaster.txt
+++ b/source/reference/command/isMaster.txt
@@ -64,7 +64,7 @@ roles:
 
    The maximum permitted size of a :term:`BSON` object in bytes for
    this :program:`mongod` process. If not provided, clients should
-   assume a max size of "``4 * 1024 * 1024``".
+   assume a max size of "``16 * 1024 * 1024``".
 
 .. data:: isMaster.maxMessageSizeBytes
 


### PR DESCRIPTION
Maximum document size is listed incorrectly in the document page.
