### PR TITLE
Change language for required access. Remove redundant file.

### DIFF
--- a/source/includes/access-create-role.rst
+++ b/source/includes/access-create-role.rst
@@ -1,12 +1,12 @@
-To create a role on a database, a user must have access that includes
-the :authaction:`createRole` action on that database.
+A user must have the :authaction:`createRole` :ref:`action
+<security-user-actions>` on a database to create a role on that database.
 
-To grant a privilege to the role, a user must have access that includes the
-:authaction:`grantRole` action on the database the privilege
-targets. If the privilege targets multiple databases or the
-``cluster`` resource , the user must have access that includes the :authaction:`grantRole`
-action on the ``admin`` database.
+A user must have the :authaction:`grantRole` :ref:`action
+<security-user-actions>` on the database that a privilege targets in order
+to grant that privilege to a role. If the privilege targets multiple
+databases or the ``cluster`` resource , the user must have the
+:authaction:`grantRole` action on the ``admin`` database.
 
-To specify roles from which the new role inherits from, a
-user must have access that includes the
-:authaction:`grantRole` action on the inherited role's database.
+A user must have the :authaction:`grantRole` :ref:`action
+<security-user-actions>` on a role's database to grant the role to another
+role.

--- a/source/includes/access-create-user.rst
+++ b/source/includes/access-create-user.rst
@@ -1,5 +1,7 @@
-To run |local-cmd-name|, a user must have access
-that includes the :authaction:`createUser` action on the database.
+A user must have :authaction:`createUser` :ref:`action
+<security-user-actions>` on a database to create a new user on that
+database.
 
-To grant a role to a new user, the user granting the role must have access
-that includes the :authaction:`grantRole` action on the role's database.
+A user must have the :authaction:`grantRole` :ref:`action
+<security-user-actions>` on a role's database to grant the role to another
+user.

--- a/source/includes/access-drop-all-users.rst
+++ b/source/includes/access-drop-all-users.rst
@@ -1,3 +1,0 @@
-To issue the |local-cmd-name|, a user must
-have access that includes the :authaction:`dropUser` action for that
-database.

--- a/source/includes/access-drop-user.rst
+++ b/source/includes/access-drop-user.rst
@@ -1,2 +1,2 @@
-To use the |local-cmd-name|  a user must have access that includes
-the :authaction:`dropUser` action for that database.
+A user must have the :authaction:`dropUser` :ref:`action
+<security-user-actions>` on a database to drop a user from that database.

--- a/source/includes/access-grant-roles.rst
+++ b/source/includes/access-grant-roles.rst
@@ -1,2 +1,2 @@
-A user must have privileges that include the :authaction:`grantRole` action on a
-database to grant a role on the database.
+A user must have the :authaction:`grantRole` :ref:`action
+<security-user-actions>` on a database to grant a role on that database.

--- a/source/includes/access-revoke-roles.rst
+++ b/source/includes/access-revoke-roles.rst
@@ -1,2 +1,2 @@
-A user must have privileges that include the :authaction:`revokeRole` action on
-a database to revoke a role on that database.
+A user must have the :authaction:`revokeRole` :ref:`action
+<security-user-actions>` on a database to revoke a role on that database.

--- a/source/includes/access-roles-info.rst
+++ b/source/includes/access-roles-info.rst
@@ -1,2 +1,3 @@
-To view role information, a user must have privileges that contain the
-:authaction:`viewRole` action on the database where the role exists.
+A user must have the :authaction:`viewRole` :ref:`action
+<security-user-actions>` on a role's database to view the role's
+information.

--- a/source/includes/access-update-user.rst
+++ b/source/includes/access-update-user.rst
@@ -1,16 +1,15 @@
-To update the :data:`~admin.system.users.roles` array, a user must have
-access that includes the :authaction:`revokeRole` action on all
-databases. To add roles in an update, a user must have access that
-includes the :authaction:`grantRole` action on the database where
-the role exists.
+A user must have access that includes the :authaction:`revokeRole`
+:ref:`action <security-user-actions>` on all databases in order to update a
+user's :data:`~admin.system.users.roles` array.
+
+A user must have the :authaction:`grantRole` :ref:`action
+<security-user-actions>` on a role's database to add the role to a user.
 
 To modify *their own* ``pwd`` or :data:`~admin.system.users.customData`
-fields, users must have access that includes the
-:authaction:`changeOwnPassword` action and
-:authaction:`changeOwnCustomData` action respectively on the
-``cluster`` resource.
+fields, users must have the :authaction:`changeOwnPassword` and
+:authaction:`changeOwnCustomData` :ref:`actions <security-user-actions>`
+respectively on the ``cluster`` resource.
 
-To change another user's ``pwd`` or ``customData`` field, a user must
-have access that includes the :authaction:`changeAnyPassword` action
-and :authaction:`changeAnyCustomData` action respectively on that
-user's database.
+To change another user's ``pwd`` or ``customData`` field, a user must have
+the :authaction:`changeAnyPassword` and :authaction:`changeAnyCustomData`
+:ref:`actions <security-user-actions>` respectively on that user's database.

--- a/source/includes/access-user-info.rst
+++ b/source/includes/access-user-info.rst
@@ -1,4 +1,5 @@
-Users must have the :authaction:`viewUser` action on another users database
-to view that user's credentials.
+Users must have the :authaction:`viewUser` :ref:`action
+<security-user-actions>` on another user's database to view the other user's
+credentials.
 
 Users can view their own information.

--- a/source/reference/command/dropAllUsersFromDatabase.txt
+++ b/source/reference/command/dropAllUsersFromDatabase.txt
@@ -35,7 +35,7 @@ Required Access
 
 .. |local-cmd-name| replace:: :command:`dropAllUsersFromDatabase`
 
-.. include:: /includes/access-drop-all-users.rst
+.. include:: /includes/access-drop-user.rst
 
 Example
 -------

--- a/source/reference/method/db.dropAllUsers.txt
+++ b/source/reference/method/db.dropAllUsers.txt
@@ -28,7 +28,7 @@ Definition
 Required Access
 ---------------
 
-.. include:: /includes/access-drop-all-users.rst
+.. include:: /includes/access-drop-user.rst
 
 Example
 -------


### PR DESCRIPTION
We'd talked a while back about putting the action first or not in our "required access" includes. After reviewing the built doc today, it seemed clearest to put the action first and also include a link to the actions document.
