### PR TITLE
tutorial: mongo repair should be carried out by the mongodb user

### DIFF
--- a/source/tutorial/recover-data-following-unexpected-shutdown.txt
+++ b/source/tutorial/recover-data-following-unexpected-shutdown.txt
@@ -118,6 +118,11 @@ unexpected shutdown:
 Procedures
 ~~~~~~~~~~
 
+The following procedures should be carried out with the permissions of your usual
+mongodb user (typically user name `mongodb`). On linux systems this can usually be acheived
+with the `-u` and `-g` options of the `sudo` command. If you forget to do this, 
+you can change the ownership of the mongodb data files after repair is complete.
+
 To repair your data files using the :option:`--repairpath <mongod --repairpath>`
 option to preserve the original data files unmodified:
 
@@ -139,7 +144,9 @@ option to preserve the original data files unmodified:
       mongod --dbpath /data/db0
 
    Once you confirm that the data files are operational you may delete
-   or archive the data files in the ``/data/db`` directory.
+   or archive the old data files in the ``/data/db`` directory. You may 
+   also wish to move the repaired files to the old database location or
+   edit mongodb.conf to indicate the new location.
 
 To repair your data files without preserving the original files, do
 not use the :option:`--repairpath <mongod --repairpath>` option, as in


### PR DESCRIPTION
Added a paragraph indicating that repair should be carried out by the mongodb user and that the repaired database folder should be moved to the original location (or mongodb.conf updated)
