### PR TITLE
Fixes a typo

### DIFF
--- a/source/core/replica-set-secondary.txt
+++ b/source/core/replica-set-secondary.txt
@@ -24,7 +24,7 @@ information on how clients direct read operations to replica sets.
 
 A secondary can become a primary.
 If the current primary becomes unavailable, the replica set
-holds an :term:`election` to choose with of the secondaries
+holds an :term:`election` to choose which of the secondaries
 becomes the new primary.
 
 .. start-content-election-example


### PR DESCRIPTION
"holds an :term:'election' to choose **with** of the secondaries" to "holds an :term:'election' to choose **which** of the secondaries"
