### PR TITLE
s/PGP/public GPG/g

### DIFF
--- a/source/includes/steps-install-configure-debian-packages.yaml
+++ b/source/includes/steps-install-configure-debian-packages.yaml
@@ -1,4 +1,4 @@
-title: Import MongoDB PGP Key
+title: Import MongoDB public GPG Key
 stepnum: 1
 pre: |
   Issue the following command to add the `MongoDB public GPG Key


### PR DESCRIPTION
I would prefer to use "PGP" instead of "GPG", because PGP is the standard and GPG is an implementation. Through of all documentation, "public GPG" is mentioned, so I've fixed this title.
