### PR TITLE
DOCS-2278 use shell helpers instead of commands in final step

### DIFF
--- a/source/includes/steps-change-user-privileges.yaml
+++ b/source/includes/steps-change-user-privileges.yaml
@@ -97,32 +97,31 @@ ref: user-modification
 action:
   - heading:  Revoke a Role
     pre: |
-      Revoke a role using the :dbcommand:`revokeRolesFromUser` command. For
-      example, to remove the :authrole:`readWrite` role on the ``accounts``
-      database from the user ``accountUser01``, use an operation that
-      resembles the following:
+
+      Revoke a role using the :method:`db.revokeRolesFromUser()` method. For
+      example, the following sequence of operations removes
+      :authrole:`readWrite` on the ``accounts`` database from
+      ``accountUser01``'s existing roles:
+
     language: javascript
     code: |
       use accounts
-      db.runCommand( { revokeRolesFromUser: "accountUser01",
-                       roles: [ { role: "readWrite", db: "accounts" } ]
-                     } )
-    post: |
-      The :dbcommand:`revokeRolesToUser` command removes the
-      :authrole:`readWrite` role on the ``accounts`` database from
-      ``accountUser01``\ 's existing roles.
+      db.revokeRolesFromUser(
+          "accountUser01",
+          [ { role: "readWrite", db: "accounts" } ]
+      )
   - heading: Grant a Role
     pre: |
-      Grant the role using the :dbcommand:`grantRolesToUser` command. For example,
-      to grant the user ``accountUser01`` the :authrole:`read` role on
-      the ``records`` database, use an operation that resembles the following:
+
+      Grant a role using the :method:`db.grantRolesToUser()` method. For
+      example, the following sequence of operations grant ``accountUser01``
+      the :authrole:`read` role on the ``records`` database:
+
     language: javascript
     code: |
          use accounts
-         db.runCommand( { grantRolesToUser: "accountUser01",
-                          roles: [ { role: "read", db: "records" } ]
-                        } )
-    post: |
-      The :dbcommand:`grantRolesToUser` command adds the ``read`` role on the
-      ``records`` database to ``accountUser01``\ 's existing roles.
+         db.grantRolesToUser(
+             "accountUser01",
+             [ { role: "read", db: "records" } ]
+         )
 ...


### PR DESCRIPTION
Ready for docs review!
Notes:
I put line breaks before and after the steps to make it easier to reformat the paras. I noticed it does not affect publishing.
I removed the "post" part of the steps because it was redundant with the "pre." Rewording the "pre" gave all the necessary info.
