### PR TITLE
Add '--headerline' argument for CSV example

### DIFF
--- a/source/reference/mongoimport.txt
+++ b/source/reference/mongoimport.txt
@@ -229,7 +229,7 @@ instance running on the localhost port numbered ``27017``.
 
 .. code-block:: sh
 
-   mongoimport --db users --collection contacts --type csv --file /opt/backups/contacts.csv
+   mongoimport --db users --collection contacts --type csv --headerline --file /opt/backups/contacts.csv
 
 In the following example, :program:`mongoimport` imports the data in
 the :term:`JSON` formatted file ``contacts.json`` into the collection


### PR DESCRIPTION
Add `--headerline` argument for the CSV example, because CSV imports require one of the `--fields`, `--fieldFile`, or `--headerline` arguments.
