### PR TITLE
Changed Earth radius to reflect the constant used by MongoDB

### DIFF
--- a/source/reference/operator/query/centerSphere.txt
+++ b/source/reference/operator/query/centerSphere.txt
@@ -39,13 +39,13 @@ $centerSphere
    The following example queries grid coordinates and returns all
    documents within a 10 mile radius of longitude ``88 W`` and latitude
    ``30 N``. The query converts the distance to radians by dividing by
-   the approximate radius of the earth, 3959 miles:
+   the approximate equatorial radius of the earth, 3963.2 miles:
 
    .. code-block:: javascript
 
       db.places.find( { loc : { $geoWithin :
                                  { $centerSphere :
-                                   [ [ 88 , 30 ] , 10 / 3959 ]
+                                   [ [ 88 , 30 ] , 10 / 3963.2 ]
                       } } } )
 
    .. |operator| replace:: :query:`$centerSphere`

--- a/source/tutorial/calculate-distances-using-spherical-geometry-with-2d-geospatial-indexes.txt
+++ b/source/tutorial/calculate-distances-using-spherical-geometry-with-2d-geospatial-indexes.txt
@@ -39,7 +39,7 @@ geometry:
      convert the distance to.
 
    The radius of the Earth is approximately ``3,959`` miles or
-   ``6,371`` kilometers.
+   ``6,378.1`` kilometers.
 
 The following query would return documents from the ``places``
 collection within the circle described by the center ``[ -74, 40.74 ]``

--- a/source/tutorial/calculate-distances-using-spherical-geometry-with-2d-geospatial-indexes.txt
+++ b/source/tutorial/calculate-distances-using-spherical-geometry-with-2d-geospatial-indexes.txt
@@ -38,7 +38,7 @@ geometry:
      of the sphere (e.g. the Earth) in the units system that you want to
      convert the distance to.
 
-   The radius of the Earth is approximately ``3,959`` miles or
+   The radius of the Earth is approximately ``3,963.2`` miles or
    ``6,378.1`` kilometers.
 
 The following query would return documents from the ``places``
@@ -48,7 +48,7 @@ with a radius of ``100`` miles:
 .. code-block:: javascript
 
    db.places.find( { loc: { $geoWithin: { $centerSphere: [ [ -74, 40.74 ] ,
-                                                        100 / 3959 ] } } } )
+                                                        100 / 3963.2 ] } } } )
 
 You may also use the ``distanceMultiplier`` option to the
 :dbcommand:`geoNear` to convert radians in the :program:`mongod`
@@ -124,7 +124,7 @@ conversion. The following example uses ``distanceMultiplier`` in the
    db.runCommand( { geoNear: "places",
                     near: [ -74, 40.74 ],
                     spherical: true,
-                    distanceMultiplier: 3959
+                    distanceMultiplier: 3963.2
                   }  )
 
 The output of the above operation would resemble the following:

--- a/source/tutorial/query-a-2d-index.txt
+++ b/source/tutorial/query-a-2d-index.txt
@@ -78,14 +78,14 @@ Use the following syntax:
 
 The following example query returns all documents within a 10-mile
 radius of longitude ``88 W`` and latitude ``30 N``. The example converts
-distance to radians by dividing distance by the approximate radius of
-the earth, 3959 miles:
+distance to radians by dividing distance by the approximate equatorial radius of
+the earth, 3963.2 miles:
 
 .. code-block:: javascript
 
    db.<collection>.find( { loc : { $geoWithin :
                                     { $centerSphere :
-                                       [ [ 88 , 30 ] , 10 / 3959 ]
+                                       [ [ 88 , 30 ] , 10 / 3963.2 ]
                          } } } )
 
 Proximity to a Point on a Flat Surface

--- a/source/tutorial/query-a-2dsphere-index.txt
+++ b/source/tutorial/query-a-2dsphere-index.txt
@@ -142,12 +142,12 @@ Use the following syntax:
 The following example queries grid coordinates and returns all
 documents within a 10 mile radius of longitude ``88 W`` and latitude
 ``30 N``. The example converts the distance, 10 miles, to radians by
-dividing by the approximate radius of the earth, 3959 miles:
+dividing by the approximate equatorial radius of the earth, 3963.2 miles:
 
 .. code-block:: javascript
 
    db.places.find( { loc :
                      { $geoWithin :
                        { $centerSphere :
-                          [ [ 88 , 30 ] , 10 / 3959 ]
+                          [ [ 88 , 30 ] , 10 / 3963.2 ]
                    } } } )


### PR DESCRIPTION
MongoDB sets a constant defining the Earth's radius in km as 6378.1. Documentation should reflect this to ensure that users are consistent in their conversion from km to rad.