### PR TITLE
Update index-sparse.txt

### DIFF
--- a/source/core/index-sparse.txt
+++ b/source/core/index-sparse.txt
@@ -117,5 +117,5 @@ However, this index *would not permit* adding the following documents:
 
 .. code-block:: javascript
 
-   db.scores.insert( { "userid": "PWWfO8lFs1", "score": 82 } )
-   db.scores.insert( { "userid": "XlSOX66gEy", "score": 90 } )
+   db.scores.insert( { "userid": "retTgdgefy", "score": 43 } )
+   db.scores.insert( { "userid": "nkfkjrfR5s", "score": 34 } )


### PR DESCRIPTION
Index is explained to be on score field, so uniqueness for score field will be check by MongoDB. example should show the conflict for the values of score field, rather userid
