### PR TITLE
Explicitly label findAndModify example as Update and return

### DIFF
--- a/source/reference/method/db.collection.findAndModify.txt
+++ b/source/reference/method/db.collection.findAndModify.txt
@@ -129,11 +129,11 @@ instances for *non-sharded* collections function normally.
 Examples
 --------
 
-Update
-~~~~~~
+Update and Return
+~~~~~~~~~~~~~~~~~
 
-The following method updates an existing document in the people
-collection where the document matches the query criteria:
+The following method updates and returns an existing document in the
+people collection where the document matches the query criteria:
 
 .. code-block:: javascript
 


### PR DESCRIPTION
Many people confused into thinking findAndModify is needed to update a document atomically.  Clarifying that it "updates and returns".
