### PR TITLE
The current example for skip fails when the pageNumber is 0

### DIFF
--- a/source/reference/method/cursor.skip.txt
+++ b/source/reference/method/cursor.skip.txt
@@ -22,7 +22,7 @@ cursor.skip()
 
       function printStudents(pageNumber, nPerPage) {
          print("Page: " + pageNumber);
-         db.students.find().skip((pageNumber-1)*nPerPage).limit(nPerPage).forEach( function(student) { print(student.name + "<p>"); } );
+         db.students.find().skip(pageNumber > 0 ? ((pageNumber-1)*nPerPage) : 0).limit(nPerPage).forEach( function(student) { print(student.name + "<p>"); } );
       }
 
    The :method:`cursor.skip()` method is often expensive because it requires


### PR DESCRIPTION
When pageNumber is 0, the current example -1 times pageSize which can result in negative value and yield the following error: !ERROR stack MongoError: bad skip value in query
