### PR TITLE
Update 2.6.txt

### DIFF
--- a/source/release-notes/2.6.txt
+++ b/source/release-notes/2.6.txt
@@ -258,7 +258,7 @@ Aggregation Pipeline Changes
 
 .. _aggregation-method-change:
 
-``db.collection.aggregation()`` Accepts Second Parameter
+``db.collection.aggregate()`` Accepts Second Parameter
 ````````````````````````````````````````````````````````
 
 In the 2.5.3 version of the :program:`mongo` shell, the


### PR DESCRIPTION
Fixed typo: `.aggregation()` --> `.aggregate()` in headline at:
http://docs.mongodb.org/master/release-notes/2.6/#db-collection-aggregation-accepts-second-parameter
