### PR TITLE
change the name of the example 'users' collection

### DIFF
--- a/source/reference/resource-document.txt
+++ b/source/reference/resource-document.txt
@@ -26,12 +26,12 @@ Specify a Collection of a Database as Resource
 If both the ``db`` field and the ``collection`` field are specified,
 i.e. both are non-empty strings, the resource is the specified
 collection in the specified database. For example, the following
-document specifies a resource of the ``users`` collection in the
-``test`` database:
+document specifies a resource of the ``widgets`` collection in the
+``products`` database:
 
 .. code-block:: javascript
 
-   { db: "test", collection: "users" }
+   { db: "products", collection: "widgets" }
 
 .. include:: /includes/resource-document-facts.rst
    :end-before: admin-resources
@@ -80,11 +80,11 @@ Specify Collections Across Databases as Resource
 If only the ``db`` field is an empty string (``""``), the resource is
 all collections with the specified name across all databases. For
 example, the following document specifies the resource of all
-the ``users`` collections across all the databases:
+the ``accounts`` collections across all the databases:
 
 .. code-block:: javascript
 
-   { db: "", collection: "users" }
+   { db: "", collection: "accounts" }
 
 .. include:: /includes/resource-document-facts.rst
    :start-after: admin-resources


### PR DESCRIPTION
Ready for merge. Changed the name of the example "users" collection. Given that the changes to system.users might confuse some people, thought it would be best not to use "users" as an example.
