### PR TITLE
DOCS-2435: Clarify maximum number of collections

### DIFF
--- a/source/reference/limits.txt
+++ b/source/reference/limits.txt
@@ -96,8 +96,13 @@ Indexes
 
 .. seealso:: The unique indexes limit in :ref:`limits-sharding-operations`.
 
-Capped Collections
-------------------
+Collections
+-----------
+
+.. limit:: Maximum Number of Collections in a Database
+
+   A single database can have *no more* collections than the
+   :ref:`maximum number of namespaces <limit-number-of-namespaces>`.
 
 .. limit:: Maximum Number of Documents in a Capped Collection
 


### PR DESCRIPTION
I took the style from the "Number of Indexes per Collection" entry.
