### PR TITLE
Clarify the need to specify priority: 0 for hidden secondaries

### DIFF
--- a/source/core/replica-set-hidden-member.txt
+++ b/source/core/replica-set-hidden-member.txt
@@ -11,9 +11,9 @@ Hidden Replica Set Members
 A hidden member maintains a copy of the :term:`primary's <primary>`
 data set but is **invisible** to client applications. Hidden members
 are good for workloads with different usage patterns from the other
-members in the :term:`replica set`. Hidden members are always
+members in the :term:`replica set`. Hidden members must always be
 :ref:`priority 0 members <replica-set-secondary-only-members>` and
-**cannot become primary**. The :method:`db.isMaster()` method does not
+so **cannot become primary**. The :method:`db.isMaster()` method does not
 display hidden members. Hidden members, however, **do vote** in
 :ref:`elections <replica-set-elections>`.
 


### PR DESCRIPTION
I found the previous wording suggestive that priority: 0 would be implied if not specified when hidden: true.  I prefer this wording, as I feel it makes clearer the need for priority: 0 to be explicitly specified (even though it's not much of a change).
