### PR TITLE
$orderby should have warning for 32MB limit

### DIFF
--- a/source/reference/operator/meta/orderby.txt
+++ b/source/reference/operator/meta/orderby.txt
@@ -35,3 +35,12 @@ $orderby
    large in-memory sort. The :method:`cursor.limit()` increases the
    speed and reduces the amount of memory required to return this query
    by way of an optimized algorithm.
+
+.. warning::
+
+   The sort function requires that the entire sort be able to
+   complete within 32 megabytes. When the sort option consumes more
+   than 32 megabytes, MongoDB will return an error. Use :operator:`$maxScan`
+   and/or :method:`~cursor.limit()`, or create an index on the field that you're
+   sorting to avoid this error.
+


### PR DESCRIPTION
cursor.sort() contains a warning about the 32MB limit on non-indexed sorting, this adds the same warning to $orderby - which is the underlying operator that powers sort().
The warning is largely a copy+paste with superficial name replacements.
