### PR TITLE
Update journaling.txt

### DIFF
--- a/source/core/journaling.txt
+++ b/source/core/journaling.txt
@@ -41,8 +41,11 @@ different filesystem.
 .. important::
 
    If you place the journal on a different filesystem from your data
-   files you *cannot* use a filesystem snapshot to capture valid
-   backups of a :setting:`dbpath` directory.
+   files you *cannot* use a filesystem snapshot alone to capture valid
+   backups of a :setting:`dbpath` directory. In this case, use 
+   :method:`~db.fsyncLock()` to ensure that database files are consistent
+   before the snapshot and :method:`~db.fsyncUnlock()` once the snapshot
+   is complete.
 
 .. note::
 


### PR DESCRIPTION
note to use fsyncLock / fsyncUnlock for snapshots when database and journal files are on separate physical media
