### PR TITLE
Fixing recommendations

### DIFF
--- a/source/reference/read-preference.txt
+++ b/source/reference/read-preference.txt
@@ -164,9 +164,9 @@ Minimize Latency
 ~~~~~~~~~~~~~~~~
 
 To always read from a low-latency node, use :readmode:`nearest`. The
-driver or :program:`mongos` will read from the fastest member and
+driver or :program:`mongos` will read from the nearest member and
 those no more than 15 milliseconds [#secondary-acceptable-latency]_
-further away than the fastest member.
+further away than the nearest member.
 
 :readmode:`nearest` does *not* guarantee consistency. If the nearest
 member to your application server is a secondary with some replication
@@ -197,18 +197,6 @@ from nearby members with the following read preference:
 
 Although :readmode:`nearest` already favors members with low network latency,
 including the tag makes the choice more predictable.
-
-Maximize throughput
-~~~~~~~~~~~~~~~~~~~
-
-If disk I/O is the limiting fact for throughput, scale
-reads capacity using :readmode:`nearest` and by setting the nearest
-threshold [#nearest-threshold]_ very high. This will distribute the
-query load equally among all members.
-
-.. [#nearest-threshold] See :setting:`localThreshold` for
-   :program:`mongos` or your driver documentation for the appropriate
-   *secondaryAcceptableLatencyMS* setting.  
 
 Reduce load on the primary
 ~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
nearest uses closest by ping time which is not what fastest implies.

The recommendation on increasing throughput is highly misleading - there is no way that someone can expect reduced disk I/O and increased throughput by reading from nearest secondary unless their specific problem was something extremely specific (and uncommon!)
