### PR TITLE
Fix broken link to EC2 Backup and Restore document

### DIFF
--- a/source/core/backups.txt
+++ b/source/core/backups.txt
@@ -96,7 +96,7 @@ For more information, see
 documents for complete instructions on using LVM to create
 snapshots. Also see :ecosystem:`Back up and Restore Processes for
 MongoDB on Amazon EC2
-</tutorial/backup-and-restore-mongodb-on-amazon-EC2>`.
+</tutorial/backup-and-restore-mongodb-on-amazon-ec2>`.
 
 .. _backup-with-mongodump:
 


### PR DESCRIPTION
/tutorial/backup-and-restore-mongodb-on-amazon-EC2 is a 404.

/tutorial/backup-and-restore-mongodb-on-amazon-ec2 is the correct link.
