### PR TITLE
Minor typo in word "and".

### DIFF
--- a/source/core/replica-set-rollbacks.txt
+++ b/source/core/replica-set-rollbacks.txt
@@ -23,7 +23,7 @@ members.
 MongoDB attempts to avoid rollbacks, which should be rare. When a
 rollback does occur, it is often the result of a network
 partition. Secondaries that can not keep up with the throughput of
-operations on the former primary, increase the size an impact of the
+operations on the former primary, increase the size and impact of the
 rollback.
 
 A rollback does *not* occur if the write operations replicate to another


### PR DESCRIPTION
There's a minor typo in the page "Rollbacks During Replica Set Failover". It should say "increase the size _and_ impact of the rollback".
