### PR TITLE
Change message to wait to stop mongod

### DIFF
--- a/source/tutorial/manage-journaling.txt
+++ b/source/tutorial/manage-journaling.txt
@@ -118,7 +118,7 @@ will create them again.
 
       .. code-block:: sh
 
-         web admin interface listening on port 11000
+         [initandlisten] waiting for connections on port 10000
 
    #. Preallocate journal files for the new instance of
       :program:`mongod` by moving the journal files from the data directory


### PR DESCRIPTION
Using the actual port rather than the admin web console, and include the thread: `[initandlisten]`
