### PR TITLE
Update options-mongoexport.yaml

### DIFF
--- a/source/includes/options-mongoexport.yaml
+++ b/source/includes/options-mongoexport.yaml
@@ -212,7 +212,7 @@ directive: option
 args: <JSON>
 description: |
   Provides a :term:`JSON document` as a query that optionally limits
-  the documents returned in the export. Specify JSON in :doc:`strict
+  the documents returned in the export. Specify JSON in :doc:`JSONP
   format </reference/mongodb-extended-json>`.
 
   For example, given a collection named ``records`` in the database


### PR DESCRIPTION
I found out in the meantime it actually expects the JSONP variant and not strict. Apologies.
