### PR TITLE
Typo Run: the return of typo run

### DIFF
--- a/source/tutorial/adjust-replica-set-member-priority.txt
+++ b/source/tutorial/adjust-replica-set-member-priority.txt
@@ -37,7 +37,7 @@ of ``0``. :ref:`Hidden members <replica-set-hidden-members>`,
 <replica-set-arbiters>` all have
 :data:`~local.system.replset.members[n].priority` set to ``0``.
 
-Adjust priority during a sheduled maintenance window. Reconfiguring
+Adjust priority during a scheduled maintenance window. Reconfiguring
 priority can force the current primary to step down, leading to an
 election. Before an election the primary closes all open :term:`client`
 connections.

--- a/source/tutorial/backup-sharded-cluster-with-filesystem-snapshots.txt
+++ b/source/tutorial/backup-sharded-cluster-with-filesystem-snapshots.txt
@@ -75,7 +75,7 @@ shard.
    - Create a file-system snapshot of the config server. Use the procedure in
      :doc:`/tutorial/backup-with-filesystem-snapshots`.
 
-     .. important:: This is only avalible if the config server has
+     .. important:: This is only available if the config server has
         :term:`journal <journaling>` is enabled. *Never*
         use  :method:`db.fsyncLock()` on config databases.
 

--- a/source/tutorial/install-mongodb-on-red-hat-centos-or-fedora-linux.txt
+++ b/source/tutorial/install-mongodb-on-red-hat-centos-or-fedora-linux.txt
@@ -19,7 +19,7 @@ The MongoDB package repository contains five packages:
 
   This package is a ``metapackage`` that will automatically install
   the four component packages listed below.
-g
+
 - ``mongodb-org-server``
 
   This package contains the :program:`mongod` daemon and associated


### PR DESCRIPTION
Also, in ~docs/source/includes/steps-create-admin-then-enable-authentication.yaml and ~docs/source/includes/steps-enable-authentication.yaml "additional" is misspelled in "ref: create-additonal-users" but I didn't change since it was unclear if these are referenced elsewhere (I didn't find any other occurrences though).
