### PR TITLE
Update install-mongodb-on-windows.txt

### DIFF
--- a/source/tutorial/install-mongodb-on-windows.txt
+++ b/source/tutorial/install-mongodb-on-windows.txt
@@ -87,7 +87,9 @@ Set Up the Data Directory
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 MongoDB requires a :term:`data folder <dbpath>` to store its files. The
-default location for the MongoDB data directory is ``C:\data\db``.
+default location for the MongoDB data directory is ``C:\data\db``
+(if mongodb.exe is located on drive ``C:``. 
+If located on drive ``D``: then ``D:\data\db``, etc).
 Create this folder using the :guilabel:`Command Prompt`. Go to the
 ``C:\`` directory and issue the following command sequence:
 


### PR DESCRIPTION
Default location for the MongoDB data directory for Windows is not C:, but depends on location of mongod.exe file. So if MongoDB is installed on D: then it will look for data directory in d:\data\db location, etc.
