### PR TITLE
Update production-notes.txt

### DIFF
--- a/source/administration/production-notes.txt
+++ b/source/administration/production-notes.txt
@@ -149,7 +149,7 @@ SSDs' capacity for random I/O operations works well with the update
 model of :program:`mongod`.
 
 Commodity (SATA) spinning drives are often a good option, as the
-increase to random I/O for more expensive drives is not that
+random I/O performance increase with more expensive spinning drives is not that
 dramatic (only on the order of 2x). Using SSDs or increasing RAM may
 be more effective in increasing I/O throughput.
 


### PR DESCRIPTION
Phrasing was ambiguous: "increase to random I/O" could imply a degradation in performance since it could be an increase in time, and "more expensive drives" could imply a more expensive SSD drive.
