### PR TITLE
Refine "Combine Upsert/Multi" example

### DIFF
--- a/source/reference/method/db.collection.update.txt
+++ b/source/reference/method/db.collection.update.txt
@@ -477,6 +477,16 @@ Given a ``books`` collection that includes the following documents:
        "item" : "Monarchia",
        "price" : 14
    }
+   {
+      "_id" : 44,
+      "author" : "Tabucchi",
+      "born" : "Pisa"
+   }
+   {
+      "_id" : 55,
+      "item" : "Codex Urbinas",
+      "price" : 12
+   }
 
 The following command uses the ``multi`` parameter to update all
 documents where ``author`` is ``"Dante"`` and uses the *upsert*


### PR DESCRIPTION
The example looked like a mistake because it resulted in the insertion of a books document that only describes an author and not any actual book. The collection being named "books", this seems counter intuitive.

Hosting basic author information in the same database for an application that has no dedicated author collection could make sense, but the initial collection didn't seem to be intended for that.

Maybe this example should be changed entirely, but for now I've extended the initial collection to show existing entries that match this kind of expectation already.

The local author information would function as a cache of some sorts.
