### PR TITLE
Update production-notes.txt

### DIFF
--- a/source/administration/production-notes.txt
+++ b/source/administration/production-notes.txt
@@ -336,16 +336,17 @@ Recommended Configuration
 
 - Disable NUMA in your BIOS. If that is not possible see :ref:`MongoDB on NUMA Hardware <production-numa>`.
 
-.. _readahead:
-
-.. TODO update with updated readahead documentation when DOCS-164 closes
-
 - Ensure that readahead settings for the block devices that store the
   database files are appropriate. For random access use patterns, set low
   readahead values. A readahead of 32 (16kb) often works well.
 
 - Use the Network Time Protocol (NTP) to synchronize time among
   your hosts. This is especially important in sharded clusters.
+
+.. _readahead:
+
+.. TODO update with updated readahead documentation when DOCS-164 closes
+
 
 .. _production-virtualization:
 


### PR DESCRIPTION
Comments on readahead (i.e. the "TODO update" and such after the "..") were throwing off the formatting and causing those two bullet points to drop to a lower level bullet.  It was confusing, since they are not sub bullets for NUMA...
