### PR TITLE
Update mongod.txt

### DIFF
--- a/source/reference/program/mongod.txt
+++ b/source/reference/program/mongod.txt
@@ -203,7 +203,7 @@ Core Options
    Enables database authentication for users connecting from remote
    hosts. Configure users via the :doc:`mongo shell
    </reference/program/mongo>`. If no users exist, the localhost interface
-   will continue to have access to the database until the you create
+   will continue to have access to the database until you create
    the first user.
 
    See the :doc:`Security and Authentication </core/security>`


### PR DESCRIPTION
removed incorrect "the" in mongod --auth documentation.
