### PR TITLE
explain returns a document

### DIFF
--- a/source/reference/method/db.collection.aggregate.txt
+++ b/source/reference/method/db.collection.aggregate.txt
@@ -22,7 +22,7 @@ Definition
    :returns:
       A :term:`cursor` to the documents produced by the final stage of
       the aggregation pipeline operation, or if you include the
-      ``explain`` option, a cursor to the document that provides
+      ``explain`` option, the document that provides
       details on the processing of the aggregation operation.
 
       If the pipeline includes the :pipeline:`$out` operator,


### PR DESCRIPTION
explain does not return a cursor but a document with explain plan stuff.
