### PR TITLE
DOCS-3063 convert homebrew install to steps format

### DIFF
--- a/source/includes/steps-install-mongodb-on-osx-with-homebrew.yaml
+++ b/source/includes/steps-install-mongodb-on-osx-with-homebrew.yaml
@@ -1,0 +1,39 @@
+title: Update Homebrew's package database.
+stepnum: 1
+ref: update-brew
+action:
+  pre: |
+    In a system shell, issue the following command:
+  language: sh
+  code: |
+    brew update
+---
+title: Install MongoDB.
+stepnum: 2
+ref: install
+pre: |
+  You can install MongoDB with via ``brew`` in several different ways. Use
+  one of the following methods:
+action:
+  - heading: Install the MongoDB Binaries
+    pre: |
+      To install the MongoDB binaries, issue the following command in a
+      system shell:
+    language: sh
+    code: |
+      brew install mongodb
+  - heading: Build MongoDB from Source with SSL Support
+    pre: |
+      To build MongoDB from the source files and include SSL support,
+      issue the following from a system shell:
+    language: sh
+    code: |
+      brew install mongodb --with-openssl
+  - heading: Install the Latest Development Release of MongoDB
+    pre: |
+      To install the latest development release for use in testing and
+      development, issue the following command in a system shell:
+    language: sh
+    code: |
+     brew install mongodb --devel
+...

--- a/source/tutorial/install-mongodb-on-os-x.txt
+++ b/source/tutorial/install-mongodb-on-os-x.txt
@@ -28,41 +28,11 @@ Install MongoDB with Homebrew
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 `Homebrew <http://brew.sh/>`_ installs binary packages based on published
-"formulae". This section describes how to update ``brew`` to the latest
+"formulae." This section describes how to update ``brew`` to the latest
 packages and install MongoDB. Homebrew requires some initial setup and
 configuration, which is beyond the scope of this document.
 
-You can install MongoDB with via ``brew`` in several different ways:
-
-- In a terminal shell, use the following sequence of commands to
-  update``brew`` to the latest packages and install MongoDB:
-
-  .. code-block:: sh
-
-     brew update
-     brew install mongodb
-
-  If you later need to upgrade MongoDB, you can run the following sequence
-  of commands:
-
-  .. code-block:: sh
-
-     brew update
-     brew upgrade mongodb
-
-- Build MongoDB from source. In a terminal shell, use the following
-  command to build MongoDB with SSL support:
-
-  .. code-block:: sh
-
-     brew install mongodb --with-openssl
-
-- Install the latest development release of MongoDB for testing and
-  development with the following command:
-
-  .. code-block:: sh
-
-     brew install mongodb --devel
+.. include:: /includes/steps/install-mongodb-on-osx-with-homebrew.rst
 
 Install MongoDB Manually
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Ready for merge, per Docs approval. I've intentionally left out "brew upgrade," which is extraneous to this document and has no parallel in the other install docs.
