### PR TITLE
Update options-mongod --auth

### DIFF
--- a/source/includes/options-mongod.yaml
+++ b/source/includes/options-mongod.yaml
@@ -275,7 +275,7 @@ description: |
 
   Configure users via the :doc:`mongo shell
   </reference/program/mongo>`. If no users exist, the localhost interface
-  will continue to have access to the database until the you create
+  will continue to have access to the database until you create
   the first user.
 
   See :doc:`Security and Authentication </core/security>`


### PR DESCRIPTION
Removed incorrect "the" in text of --auth option.
