### PR TITLE
DOCS-2821 cluster uses sslPEMKeyFile if sslClusterFile not specified

### DIFF
--- a/source/includes/options-mongod.yaml
+++ b/source/includes/options-mongod.yaml
@@ -1121,6 +1121,10 @@ description: |
   file for :ref:`membership authentication <x509-internal-authentication>`
   for the cluster or replica set.
 
+  If this option is not used to specify the .pem file for internal cluster
+  authentication, the cluster uses the .pem file specified in the
+  :option:`--sslPEMKeyFile` option.
+
   The default distribution of MongoDB does not contain support for SSL.
   For more information on MongoDB and SSL, see :doc:`/tutorial/configure-ssl`.
 optional: true


### PR DESCRIPTION
Ready for merge per docs review.
