### PR TITLE
DOCS-2411: cloneCollectionAsCapped applies only to source collection

### DIFF
--- a/source/reference/user-privileges.txt
+++ b/source/reference/user-privileges.txt
@@ -56,7 +56,7 @@ Database User Roles
 
    - :dbcommand:`aggregate`
    - :dbcommand:`checkShardingIndex`
-   - :dbcommand:`cloneCollectionAsCapped`
+   - :dbcommand:`cloneCollectionAsCapped` (applies only to the source collection)
    - :dbcommand:`collStats`
    - :dbcommand:`count`
    - :dbcommand:`dataSize`


### PR DESCRIPTION
Ready for merge per docs approval.
