### PR TITLE
Update db.collection.save.txt

### DIFF
--- a/source/reference/method/db.collection.save.txt
+++ b/source/reference/method/db.collection.save.txt
@@ -67,11 +67,9 @@ If the document contains an :term:`_id` field, then the
 :method:`~db.collection.save()` method performs an :ref:`update with
 upsert <upsert-parameter>`, querying by the ``_id`` field. If a
 document does not exist with the specified ``_id`` value, the
-:method:`~db.collection.save()` method performs an insert. If a
-document exists with the specified ``_id`` value, the
-:method:`~db.collection.save()` method performs an update that replaces
-**all** fields in the existing document with the fields from the
-``document``.
+``document`` is inserted by the :ref:`update with upsert <upsert-parameter>`. 
+If a document exists with the specified ``_id`` value, **all** fields 
+in the existing document are replaced with the fields from the ``document``.
 
 Examples
 --------


### PR DESCRIPTION
When provided a document with an _id, save() always performs an update with upsert, never an insert. Save() only performs an insert command when the _id is missing from the specified document.
