### PR TITLE
Fix collection name in index-unique docs

### DIFF
--- a/source/core/index-unique.txt
+++ b/source/core/index-unique.txt
@@ -14,7 +14,7 @@ operation in the :program:`mongo` shell:
 
 .. code-block:: javascript
 
-   db.addresses.ensureIndex( { "user_id": 1 }, { unique: true } )
+   db.members.ensureIndex( { "user_id": 1 }, { unique: true } )
 
 By default, ``unique`` is ``false`` on MongoDB indexes.
 


### PR DESCRIPTION
Text references collection "members" but the code example says "addresses"
