### PR TITLE
Add explanation about date storage and range

### DIFF
--- a/source/core/shell-types.txt
+++ b/source/core/shell-types.txt
@@ -30,6 +30,11 @@ either as a string or as an object:
 
 - ``ISODate()`` constructor which returns an ``ISODate`` object when
   used with *or* without the ``new`` operator.
+  
+Internally, an ``ISODate`` is stored as a 64 bit integer representing
+the number of milliseconds since the Unix epoch (Jan 1, 1970), which results
+in a representable date range of about 290 millions years into the past and
+future.
 
 Consider the following examples:
 


### PR DESCRIPTION
This is the page that comes up when you google "mongodb date". The information about possible date range is now also on http://docs.mongodb.org/manual/reference/bson-types/#date, but that page is a lot harder to find. Alternatively, a link from this page to that page could be added.
