### PR TITLE
The cloneCollection command uses a namespace ("db.collection") not a collection

### DIFF
--- a/source/reference/command/cloneCollection-field.yaml
+++ b/source/reference/command/cloneCollection-field.yaml
@@ -7,7 +7,9 @@ field:
 name: cloneCollection
 type: string
 position: 1
-description: "The name of the collection to clone."
+description: |
+  The :term:`namespace` of the collection to rename. The namespace is a
+  combination of the database name and the name of the collection.
 ---
 object:
   name: cloneCollection

--- a/source/reference/command/cloneCollection.txt
+++ b/source/reference/command/cloneCollection.txt
@@ -17,7 +17,7 @@ Definition
 
    .. code-block:: javascript
 
-      { cloneCollection: "<collection>", from: "<hostname>", query: { <query> } }
+      { cloneCollection: "<namespace>", from: "<hostname>", query: { <query> } }
 
    .. important:: You cannot clone a collection through a
       :program:`mongos` but must connect directly to the


### PR DESCRIPTION
Using the same terminology as in `renameCollection`
