### PR TITLE
Updates to movePrimary command page

### DIFF
--- a/source/reference/command/movePrimary.txt
+++ b/source/reference/command/movePrimary.txt
@@ -41,5 +41,5 @@ movePrimary
    or the :dbcommand:`flushRouterConfig` command needs to be invoked on all
    :program:`mongos` instances before writing any data, to notify them of the 
    primary shard change. If this process is not followed, data may end up being 
-   written to the incorrect shard and effectively "missing" without manual 
+   written to the incorrect shard and appears to be missing without manual 
    efforts to correct this.


### PR DESCRIPTION
The conditions when it is safe to call movePrimary need to be tighter than mentioned, and we should mention that the other mongos do not know about the change until restarted/flushRouterConfig'ed.
