### PR TITLE
Fix SSL option syntax

### DIFF
--- a/source/tutorial/configure-ssl.txt
+++ b/source/tutorial/configure-ssl.txt
@@ -462,7 +462,7 @@ connect to a :program:`mongod` or :program:`mongos` instance via SSL:
 .. code-block:: javascript
 
    var db1 = new Db(MONGODB, new Server("127.0.0.1", 27017,
-                                        { auto_reconnect: false, poolSize:4, ssl:ssl } );
+                                        { auto_reconnect: false, poolSize:4, ssl:true } );
 
 To connect to a replica set via SSL, use the following form:
 
@@ -472,7 +472,7 @@ To connect to a replica set via SSL, use the following form:
        new Server( RS.host, RS.ports[1], { auto_reconnect: true } ),
        new Server( RS.host, RS.ports[0], { auto_reconnect: true } ),
        ],
-     {rs_name:RS.name, ssl:ssl}
+     {rs_name:RS.name, ssl:true}
    );
 
 .. _`node-mongodb-native`: https://github.com/mongodb/node-mongodb-native


### PR DESCRIPTION
{ ssl: ssl } inside an option hash does not work as described; the correct syntax is { ssl: true }
