### PR TITLE
Changelog for 2.6

### DIFF
--- a/source/release-notes/2.6-changelog.txt
+++ b/source/release-notes/2.6-changelog.txt
@@ -20,6 +20,7 @@ Build and Packaging
 
 - :issue:`SERVER-13287` Addition of debug symbols has doubled compile time
 - :issue:`SERVER-13563` Upgrading from 2.4.x to 2.6.0 via ``yum`` clobbers configuration file
+- :issue:`SERVER-13691` yum and apt "stable" repositories contain release candidate 2.6.1-rc0 packages
 
 
 Geo


### PR DESCRIPTION
Adding 2.6 changelog file and changes for the upcoming 2.6.1 release. See DOCS-3251.
