### PR TITLE
DOCS-3202 exclude new package names to install pre-2.6 RPMs

### DIFF
--- a/source/tutorial/install-mongodb-on-red-hat-centos-or-fedora-linux.txt
+++ b/source/tutorial/install-mongodb-on-red-hat-centos-or-fedora-linux.txt
@@ -73,7 +73,7 @@ the latest stable version of MongoDB and the associated tools:
 
 .. code-block:: sh
 
-   yum install mongo-10gen mongo-10gen-server
+   yum install mongo-10gen mongo-10gen-server --exclude mongodb-org,mongodb-org-server
 
 When this command completes, you have successfully installed MongoDB!
 
@@ -88,7 +88,7 @@ version number, as in the following example:
 
 .. code-block:: sh
 
-   yum install mongo-10gen-2.2.3 mongo-10gen-server-2.2.3
+   yum install mongo-10gen-2.2.3 mongo-10gen-server-2.2.3 --exclude mongodb-org,mongodb-org-server
 
 This installs the ``mongo-10gen`` and ``mongo-10gen-server`` packages
 with the ``2.2.3`` release. You can specify any available version of


### PR DESCRIPTION
As of 2.6.1 and SERVER-13563, we identify old RPM package names as
being obsoleted by new RPMs. This means that in order to install
RPM's using the old names (mongo-10gen, mongo-10gen-server,
mongo-10gen-enterprise, mongo-10gen-enterprise-server) requires
telling yum to ignore the new packages so it doesn't see that they
obsolete the old ones.
