### PR TITLE
Disable balancer while indexes are inconsistent

### DIFF
--- a/source/reference/operator/meta/orderby.txt
+++ b/source/reference/operator/meta/orderby.txt
@@ -35,3 +35,12 @@ $orderby
    large in-memory sort. The :method:`cursor.limit()` increases the
    speed and reduces the amount of memory required to return this query
    by way of an optimized algorithm.
+
+.. warning::
+
+   The sort function requires that the entire sort be able to
+   complete within 32 megabytes. When the sort option consumes more
+   than 32 megabytes, MongoDB will return an error. Use :operator:`$maxScan`
+   and/or :method:`~cursor.limit()`, or create an index on the field that you're
+   sorting to avoid this error.
+

--- a/source/reference/operator/meta/orderby.txt
+++ b/source/reference/operator/meta/orderby.txt
@@ -29,18 +29,16 @@ $orderby
    ``-1``, as above) to sort in descending order or a positive value
    (e.g. ``1``) to sort in ascending order.
 
-   Unless you have an index for the specified key pattern, use
-   :operator:`$orderby` in conjunction with :operator:`$maxScan` and/or
-   :method:`cursor.limit()` to avoid requiring MongoDB to perform a
-   large in-memory sort. The :method:`cursor.limit()` increases the
-   speed and reduces the amount of memory required to return this query
-   by way of an optimized algorithm.
+Behavior
+--------
 
-.. warning::
+The sort function requires that the entire sort be able to complete
+within 32 megabytes. When the sort option consumes more than 32
+megabytes, MongoDB will return an error.
 
-   The sort function requires that the entire sort be able to
-   complete within 32 megabytes. When the sort option consumes more
-   than 32 megabytes, MongoDB will return an error. Use :operator:`$maxScan`
-   and/or :method:`~cursor.limit()`, or create an index on the field that you're
-   sorting to avoid this error.
-
+To avoid this error, create an index to support the sort operation or
+use :operator:`$orderby` in conjunction with :operator:`$maxScan`
+and/or :method:`cursor.limit()`. The :method:`cursor.limit()` increases
+the speed and reduces the amount of memory required to return this
+query by way of an optimized algorithm. The specified limit must result
+in a number of documents that fall within the 32 megabyte limit.

--- a/source/tutorial/build-indexes-on-replica-sets.txt
+++ b/source/tutorial/build-indexes-on-replica-sets.txt
@@ -51,7 +51,15 @@ Procedure
 
    If you need to build an index in a :term:`sharded cluster`, repeat
    the following procedure for each replica set that provides each
-   :term:`shard`.
+   :term:`shard`. Also ensure the balancer has been disabled for all
+   collections on which you'll be creating an new index. This will prevent 
+   an automatic index build as chunks are migrated. The balancer should be 
+   enabled after the indexes have been updated on all shards.
+
+.. code-block:: sh
+
+  sh.disableBalancing("dbName.collectionName");
+   
 
 .. _tutorial-index-on-replica-sets-stop-one-member:
 

--- a/source/tutorial/restore-sharded-cluster.txt
+++ b/source/tutorial/restore-sharded-cluster.txt
@@ -28,21 +28,26 @@ Procedure
 #. Stop all :program:`mongos` and :program:`mongod` processes,
    including all shards *and* all config servers.
 
-#. If shard hostnames have changed, you must manually update the
-   ``shards`` collection in the :ref:`config-database` to use the new
-   hostnames. Do the following:
+Procedure
+---------
 
-   a. Start the three :ref:`config servers <sharding-config-server>` by
+#. Stop all :program:`mongos` and :program:`mongod` processes,
+   including all shards *and* all config servers.
+
+# If shard hostnames have *not* changed, skip to step 3. Otherwise:
+
+   #. Restore the config database on each config server
+   
+   b. Start the three :ref:`config servers <sharding-config-server>` by
       issuing commands similar to the following, using values appropriate
       to your configuration:
-
+      
       .. code-block:: sh
 
          mongod --configsvr --dbpath /data/configdb --port 27019
 
-   #. Restore the :ref:`config-database` on each config server.
-
-   #. Start one :program:`mongos` instance.
+   #. Start one :program:`mongos` instance, making sure you have updated the 
+      config string with the new configdb hostnames and ports
 
    #. Update the :ref:`config-database` collection named ``shards`` to reflect the
       new hostnames.
@@ -59,11 +64,11 @@ Procedure
    - Data files for each :ref:`config server <sharding-config-server>`,
      if you have not already done so in the previous step.
 
-#. Restart all the :program:`mongos` instances.
+#. Restart all the config servers :program:`mongod` instances.
+
+#. Restart all the :program:`mongos` instances, making sure to use the updated config string.
 
 #. Restart all the shard :program:`mongod` instances.
-
-#. Restart all the config servers :program:`mongod` instances.
 
 #. Connect to a :program:`mongos` instance from a :program:`mongo` shell
    and use the :method:`db.printShardingStatus()` method to ensure

--- a/source/tutorial/restore-sharded-cluster.txt
+++ b/source/tutorial/restore-sharded-cluster.txt
@@ -58,9 +58,9 @@ Procedure
 
    #. Stop the :program:`mongos` instance.
 
-#. Restart all the :program:`mongos` instances, making sure to use the updated config string.
-
 #. Restart all the shard :program:`mongod` instances.
+
+#. Restart all the :program:`mongos` instances, making sure to use the updated config string.
 
 #. Connect to a :program:`mongos` instance from a :program:`mongo` shell
    and use the :method:`db.printShardingStatus()` method to ensure

--- a/source/tutorial/restore-sharded-cluster.txt
+++ b/source/tutorial/restore-sharded-cluster.txt
@@ -28,30 +28,6 @@ Procedure
 #. Stop all :program:`mongos` and :program:`mongod` processes,
    including all shards *and* all config servers.
 
-Procedure
----------
-
-#. Stop all :program:`mongos` and :program:`mongod` processes,
-   including all shards *and* all config servers.
-
-# If shard hostnames have *not* changed, skip to step 3. Otherwise:
-
-   #. Restore the config database on each config server
-   
-   b. Start the three :ref:`config servers <sharding-config-server>` by
-      issuing commands similar to the following, using values appropriate
-      to your configuration:
-      
-      .. code-block:: sh
-
-         mongod --configsvr --dbpath /data/configdb --port 27019
-
-   #. Start one :program:`mongos` instance, making sure you have updated the 
-      config string with the new configdb hostnames and ports
-
-   #. Update the :ref:`config-database` collection named ``shards`` to reflect the
-      new hostnames.
-
 #. Restore the following:
 
    - Data files for each server in each :term:`shard`. Because replica
@@ -61,10 +37,26 @@ Procedure
      :ref:`backup-restore-snapshot` and :ref:`backup-restore-dump`
      sections for details on these procedures.
 
-   - Data files for each :ref:`config server <sharding-config-server>`,
-     if you have not already done so in the previous step.
+   - Data files for each :ref:`config server <sharding-config-server>`.
 
-#. Restart all the config servers :program:`mongod` instances.
+#. Restart all the :ref:`config servers <sharding-config-server>`
+   :program:`mongod` instances by issuing command similar to the
+   following, using values appropriate
+   to your configuration:
+
+   .. code-block:: sh
+
+      mongod --configsvr --dbpath /data/configdb --port 27019
+
+#. If shard hostnames **have changed**:
+
+   a. Start one :program:`mongos` instance, using the updated
+      config string with the new ``configdb`` hostnames and ports.
+
+   #. Update the ``shards`` collection in the :ref:`config-database` to
+      reflect the new hostnames.
+
+   #. Stop the :program:`mongos` instance.
 
 #. Restart all the :program:`mongos` instances, making sure to use the updated config string.
 


### PR DESCRIPTION
A chunk migration can cause an index build, so we should advise to disable the balancer to avoid performance issues.