### PR TITLE
DOCS-3188: clarified update index entry

### DIFF
--- a/source/includes/fact-index-key-length-operation-behaviors.rst
+++ b/source/includes/fact-index-key-length-operation-behaviors.rst
@@ -1,7 +1,7 @@
 .. index-field-limit-ensureIndex
 
 MongoDB will **not** :method:`create an index
-<db.collection.ensureIndex()>` on a collection if the value of the
+<db.collection.ensureIndex()>` on a collection if the 
 index field in an existing document exceeds the |limit|. Previous
 versions of MongoDB would create the index but not index such documents.
 
@@ -21,43 +21,43 @@ from continuing with the remainder of the process.
 .. index-field-limit-insert
 
 MongoDB will not insert into an indexed collection any document with an
-indexed field value that exceeds the |limit|, and instead, will return
+indexed field that exceeds the |limit|, and instead, will return
 an error. Previous versions of MongoDB would insert but not index such
 documents.
 
 .. index-field-limit-update
 
-Updates to the indexed field will error if the new value for the field
+Updates to the indexed field will error if the indexed field
 exceeds the |limit|.
 
-If an existing document contains a value for the indexed field that
+If an existing document contains an indexed field that
 exceeds the limit, *any* update that results in the relocation of that
 document on disk will error.
 
 .. index-field-limit-restore-import
 
 :program:`mongorestore` and :program:`mongoimport` will not insert
-documents that contain indexed field value that exceeds the
+documents that contain indexed field that exceeds the
 |limit|.
 
 .. index-field-limit-rs-secondary
 
 In MongoDB 2.6, secondary members of replica sets will continue to
-replicate documents with an indexed field value that exceeds the
+replicate documents with an indexed field that exceeds the
 |limit| on initial sync but will print warnings in the logs.
 
 Secondary members also allow index build and rebuild operations on a
-collection that contains an indexed field value that exceeds the
+collection that contains an indexed field that exceeds the
 |limit| but with warnings in the logs.
 
 With *mixed version* replica sets where the secondaries are version 2.6
 and the primary is version 2.4, secondaries will replicate documents
 inserted or updated on the 2.4 primary, but will print error messages
-in the log if the documents contain indexed field value that exceeds the
+in the log if the documents contain an indexed field that exceeds the
 |limit|.
 
 .. index-field-limit-chunk-migration
 
 For existing sharded collections, :doc:`chunk migration
 </core/sharding-chunk-migration>` will fail if the chunk has a document
-that contains an indexed field value that exceeds the |limit|.
+that contains an indexed field that exceeds the |limit|.

--- a/source/includes/list-index-field-limit-behaviors.rst
+++ b/source/includes/list-index-field-limit-behaviors.rst
@@ -1,5 +1,5 @@
 MongoDB 2.6 implements a stronger enforcement of the limit on
-:limit:`index key length <Index Key>`:
+:limit:`index key <Index Key Limit>`:
 
 - .. include:: /includes/fact-index-key-length-operation-behaviors.rst
      :start-after: index-field-limit-ensureIndex

--- a/source/reference/limits.txt
+++ b/source/reference/limits.txt
@@ -57,14 +57,14 @@ Indexes
 -------
 
 .. _limit-index-size:
-.. limit:: Index Key
+.. limit:: Index Key Limit
 
-   The *total size* of an index key entry, which can include structural
+   The *total size* of an index entry, which can include structural
    overhead depending on the BSON type, must be *less than* 1024 bytes.
 
    .. COMMENT refer to src/mongo/db/structure/btree/key.cpp (KeyV1Owned::KeyV1Owned)
 
-   .. |limit| replace:: :limit:`index key limit <Index Key>`
+   .. |limit| replace:: :limit:`index entry <Index Key Limit>`
 
    .. versionchanged:: 2.6
 


### PR DESCRIPTION
The definition of "Index key limits" might be clearer if it referred to "Index Value limits" as its a limit on the value of the key.
