### PR TITLE
manage-sharded-cluster.txt: Clarify stopping the balancer

### DIFF
--- a/source/tutorial/manage-sharded-cluster-balancer.txt
+++ b/source/tutorial/manage-sharded-cluster-balancer.txt
@@ -169,13 +169,13 @@ all migration, use the following procedure:
 
    .. code-block:: javascript
 
-      sh.setBalancerState(false)
+      sh.stopBalancer()
 
    If a migration is in progress, the system will complete the
    in-progress migration before stopping.
 
-#. To verify that the balancer has stopped, issue the following command,
-   which returns ``false`` if the balancer is stopped:
+#. To verify that the balancer will not start, issue the following command,
+   which returns ``false`` if the balancer is disabled:
 
    .. code-block:: javascript
 
@@ -195,8 +195,8 @@ all migration, use the following procedure:
 .. note::
 
    To disable the balancer from a driver that does not have the
-   :method:`sh.startBalancer()` helper, issue the following command from
-   the ``config`` database:
+   :method:`sh.stopBalancer()` or :method:`sh.setBalancerState()` helpers,
+   issue the following command from the ``config`` database:
 
    .. code-block:: javascript
 


### PR DESCRIPTION
Strictly speaking, the statement after "sh.setBalancerState(false)" is correct.  However it is extremely misleading, because it implies that the setBalancerState command will wait for any current balancing round to finish, which is not true.  The "sh.stopBalancer()" helper is the safest way to disable the balancer.
