### PR TITLE
Add one step to drop old entires when recreating oplog

### DIFF
--- a/source/tutorial/change-oplog-size.txt
+++ b/source/tutorial/change-oplog-size.txt
@@ -93,6 +93,11 @@ to set the ``db`` object:
 
    db = db.getSiblingDB('local')
 
+Drop the temporary collection to remove any previous oplog entries.
+.. code-block:: javascript
+
+   db.temp.drop()
+
 Use the :method:`db.collection.save()` method and a sort on
 reverse :term:`natural order` to find the last entry and save it
 to a temporary collection:


### PR DESCRIPTION
It turns out that if you follow our docs then there could be old oplog entries that might be accidentally used.
