### PR TITLE
Adjust URL for repo to use https:// over git://

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,9 +6,9 @@ This repository contains a major revision of the MongoDB
 documentation, currently accessible at <http://docs.mongodb.org/manual/>.
 You can download and build locally if you already have `Sphinx
 <http://sphinx.pocoo.org/>`_ and other dependencies installed, with
-the following command: ::
+the following command::
 
-     git clone git://github.com/mongodb/docs
+     git clone https://github.com/mongodb/docs.git
      cd docs/
      python bootstrap.py
      make html


### PR DESCRIPTION
HTTPS is GitHub's recommended clone method for security.
