### PR TITLE
No need to created hashed index before sharding

### DIFF
--- a/source/tutorial/deploy-shard-cluster.txt
+++ b/source/tutorial/deploy-shard-cluster.txt
@@ -245,8 +245,6 @@ You enable sharding on a per-collection basis.
          sh.shardCollection("records.people", { "zipcode": 1, "name": 1 } )
          sh.shardCollection("people.addresses", { "state": 1, "_id": 1 } )
          sh.shardCollection("assets.chairs", { "type": 1, "_id": 1 } )
-
-         db.alerts.ensureIndex( { _id : "hashed" } )
          sh.shardCollection("events.alerts", { "_id": "hashed" } )
 
    In order, these operations shard:


### PR DESCRIPTION
It is not necessary to create a hashed index before defining a hashed shard key on it; the index is created automatically, just as with any other kind of shard key. The example proved confusing for a customer who thought that you always had to create the index first.
