### PR TITLE
Update shardCollection.txt

### DIFF
--- a/source/reference/command/shardCollection.txt
+++ b/source/reference/command/shardCollection.txt
@@ -49,6 +49,11 @@ Hashed Shard Keys
 :ref:`Hashed shard keys <sharding-hashed-sharding>` use a
 hashed index of a single field as the shard key.
 
+.. note:: If chunk migrations are in progress while creating a hashed
+   shard key collection, the initial chunk distribution may be
+   uneven until the balancer automatically balances the
+   collection.
+
 Example
 -------
 


### PR DESCRIPTION
Add note on distribution of hash-shard-key chunks to shardCollection command. This currently exists in http://docs.mongodb.org/manual/tutorial/shard-collection-with-a-hashed-shard-key/ but should live here as well. MongoDB users who are familiar with hashed shard keys are more likely to view this page than the tutorial.
