### PR TITLE
correcting sentence

### DIFF
--- a/source/core/replica-set-elections.txt
+++ b/source/core/replica-set-elections.txt
@@ -52,10 +52,11 @@ not seek election. For details, see
 :doc:`/core/replica-set-priority-0-member`.
 
 A replica set does *not* hold an election as long as the current primary has the
-highest priority value and is within 10 seconds of the latest
-:term:`oplog` entry in the set. If a higher-priority member catches up to within 10 seconds of the
-latest oplog entry of the current primary, the set holds an election in order to provide the
-higher-priority node a chance to become primary.
+highest priority value or no secondary with higher priority is within 10 seconds
+of the latest :term:`oplog` entry in the set. If a higher-priority member catches 
+up to within 10 seconds of the latest oplog entry of the current primary, the set 
+holds an election in order to provide the higher-priority node a chance to become 
+primary.
 
 Optime
 ~~~~~~


### PR DESCRIPTION
which was implying primary can be not-most-up-to-date in a set, which it can't be.
