### PR TITLE
Update split.txt wrt splitting empty chunks

### DIFF
--- a/source/reference/command/split.txt
+++ b/source/reference/command/split.txt
@@ -32,9 +32,10 @@ Definition
 Considerations
 --------------
 
-:dbcommand:`split` does *not* support splitting an chunk that does not
-contain documents. Use :dbcommand:`splitAt` to create splits in chunks
-that do not contain documents.
+The `find` and `bounds` forms of :dbcommand:`split` do *not* support splitting 
+a chunk that does not contain documents (because these forms split along the median,
+and there is no median when the chunk is empty). Use the `middle` form of `split`,
+or use :dbcommand:`splitAt` to create splits in chunks that do not contain documents.
 
 Command Formats
 ---------------


### PR DESCRIPTION
This used to say that `split` doesn't support splitting empty chunks, but elsewhere (later in this document and in http://docs.mongodb.org/manual/tutorial/create-chunks-in-sharded-cluster/) we recommend using `split` to pre-split an empty sharded collection.
