### PR TITLE
Added drop of temporary database as per 2.4 and 2.6 oplog resize docs.

### DIFF
--- a/source/tutorial/change-oplog-size.txt
+++ b/source/tutorial/change-oplog-size.txt
@@ -96,6 +96,11 @@ procedure for every member of the set that may become primary.
 
          use local
 
+   #. Ensure that the temp temporary collection is empty by dropping the collection:
+      .. code-block:: javascript
+
+         db.temp.drop()
+
    #. Use the :method:`db.collection.save()` operation to save the last
       entry in the oplog to a temporary collection:
 


### PR DESCRIPTION
Replica of https://github.com/mongodb/docs/pull/1780 but for 2.2 docs
