### PR TITLE
Fixed possible incorrect result in $unwind docs

### DIFF
--- a/source/reference/operator/aggregation/unwind.txt
+++ b/source/reference/operator/aggregation/unwind.txt
@@ -56,7 +56,7 @@ $unwind (aggregation)
                            "_id" : ObjectId("4e6e4ef557b77501a49233f6"),
                            "title" : "this is my title",
                            "author" : "bob",
-                           "tags" : "fun"
+                           "tags" : "awesome"
                    }
            ],
            "OK" : 1


### PR DESCRIPTION
The original result implies that the "tags" field was set to the unintuitive `["fun", "good", "fun"]`, would be better to imply it was set to `["fun", "good", "awesome"]` instead — which is what this change does.

Alternatively, and perhaps more usefully, it would be good to see two blog posts, the first using fun and good, the second using just fun.
