### PR TITLE
changing findAndModify to update

### DIFF
--- a/source/tutorial/model-data-for-atomic-operations.txt
+++ b/source/tutorial/model-data-for-atomic-operations.txt
@@ -32,21 +32,19 @@ available copies for checkout and the current checkout information:
              checkout: [ { by: "joe", date: ISODate("2012-10-15") } ]
            }
 
-You can use the :method:`db.collection.findAndModify()` method to
+You can use the :method:`db.collection.update()` method to
 atomically determine if a book is available for checkout and update
 with the new checkout information. Embedding the ``available`` field
 and the ``checkout`` field within the same document ensures that the
-updates to these fields are in sync:
+updates to these fields are done atomically:
 
 .. code-block:: javascript
 
-   db.books.findAndModify ( {
-      query: {
+   db.books.update ( {
                _id: 123456789,
                available: { $gt: 0 }
              },
-      update: {
+             {
                 $inc: { available: -1 },
                 $push: { checkout: { by: "abc", date: new Date() } }
-              }
    } )


### PR DESCRIPTION
See DOCS-3308 - changing findAndModify to update to hopefully reduce confusion out in the world that you need findAndModify to make an atomic update.   Obviously findAndModify could be added to this as a note that it is also atomic, but it returns the document that has been changed (which doesn't seem necessary in this case, since we have the _id for it).
