### PR TITLE
Fix echo command for creating config file on Windows

### DIFF
--- a/source/includes/steps-configure-windows-service-for-mongodb.yaml
+++ b/source/includes/steps-configure-windows-service-for-mongodb.yaml
@@ -15,7 +15,7 @@ action:
       the :setting:`logpath` option for MongoDB:
     language: powershell
     code: |
-      echo logpath="C:\Program Files\MongoDB\log\mongo.log" > "C:\Program Files\MongoDB\mongod.cfg"
+      echo logpath=C:\Program Files\MongoDB\log\mongo.log > "C:\Program Files\MongoDB\mongod.cfg"
 ---
 title: Run the MongoDB service.
 stepnum: 2


### PR DESCRIPTION
Previous command was creating a file with content (literally):
```
logpath="C:\Program Files\MongoDB\log\mongo.log"
```
which was invalid, as reported by `mongod` at startup.
Should be
```
logpath=C:\Program Files\MongoDB\log\mongo.log
```