### PR TITLE
suggested change for visual clarity

### DIFF
--- a/source/reference/server-status.txt
+++ b/source/reference/server-status.txt
@@ -31,15 +31,14 @@ information regarding the specific :program:`mongod` and
 
 .. code-block:: javascript
 
-   {
-           "host" : "<hostname>",
-           "version" : "<version>",
-           "process" : "<mongod|mongos>",
-           "pid" : <num>,
-           "uptime" : <num>,
-           "uptimeMillis" : <num>,
-           "uptimeEstimate" : <num>,
-           "localTime" : ISODate(""),
+   "host" : "<hostname>",
+   "version" : "<version>",
+   "process" : "<mongod|mongos>",
+   "pid" : <num>,
+   "uptime" : <num>,
+   "uptimeMillis" : <num>,
+   "uptimeEstimate" : <num>,
+   "localTime" : ISODate(""),
 
 .. _server-status-example-locks:
 
@@ -458,5 +457,4 @@ The final ``ok`` field holds the return status for the
 
 .. code-block:: javascript
 
-           "ok" : 1
-   }
+   "ok" : 1


### PR DESCRIPTION
In the published output, the inclusion of the outerbrackets gives the first and last fields greater indents than the other sibling fields. My thinking is that readers might more likely be thrown off (for a moment) by the uneven indents than by the lack of the outermost brackets.  
