### PR TITLE
findAndModify remove field removes query

### DIFF
--- a/source/reference/method/db.collection.findAndModify-param.yaml
+++ b/source/reference/method/db.collection.findAndModify-param.yaml
@@ -39,7 +39,7 @@ type: Boolean
 position: 3
 description: |
   Must specify either the ``remove`` or the ``update`` field. Removes
-  the document specified in the ``update`` field. Set this to ``true``
+  the document specified in the ``query`` field. Set this to ``true``
   to remove the selected document . The default is ``false``.
 ---
 object:


### PR DESCRIPTION
When remove is true we remove the first document that matches the query field not the update field.
