### PR TITLE
Reorder backup hyperlinks to match text.

### DIFF
--- a/source/core/backups.txt
+++ b/source/core/backups.txt
@@ -8,9 +8,9 @@ When deploying MongoDB in production, you should have a strategy for
 capturing and restoring backups in the case of data loss
 events. There are several ways to back up MongoDB clusters:
 
-- :ref:`backup-with-mms`
 - :ref:`backup-with-file-copies`
 - :ref:`backup-with-mongodump`
+- :ref:`backup-with-mms`
 - :ref:`backup-with-mms-onprem`
 
 .. _backup-with-file-copies:


### PR DESCRIPTION
The hyperlinks at the top do not match the text - MMS Cloud Backups are the first option, but they're the second-last option in the text.

I'm fixing the hyperlinks to match the text.
