### PR TITLE
example usage of $sum operator

### DIFF
--- a/source/reference/operator/aggregation/sum.txt
+++ b/source/reference/operator/aggregation/sum.txt
@@ -14,3 +14,27 @@ $sum (aggregation)
    for every document in the grouping. Typically,
    specify a value of ``1`` in order to count members of the
    group.
+
+Lets consider the following data. 
+{ "_id" : 1, "city" : "Seattle", "state" : "WA", "pop" : 10}
+{ "_id" : 2, "city" : "Los Angeles", "state" : "CA", "pop" : 10}
+{ "_id" : 3, "city" : "Seattle", "state" : "WA", "pop" : 10}
+{ "_id" : 4, "city" : "Seattle", "state" : "WA", "pop" : 10}
+{ "_id" : 5, "city" : "Los Angeles", "state" : "CA", "pop" : 10}
+{ "_id" : 6, "city" : "Tampa", "state" : "FL", "pop" : 10}
+
+Running the following query on the collection named population
+db.population.aggregate([
+	{ $group : { _id : "$state", total_population : { $sum : "$pop"}, count : { $sum : 1}}},
+	{ $sort : {total_population: 1}}
+])
+
+results in
+{ "_id" : "FL", "total_population" : 10, "count" : 1 }
+{ "_id" : "CA", "total_population" : 20, "count" : 2 }
+{ "_id" : "WA", "total_population" : 30, "count" : 3 }
+
+{ $sum : "$pop"} calculates the total population of each state.
+{ $sum : 1} calculates the count of document for each state.
+
+Note : $sort operator arranges data in ascending order. 


### PR DESCRIPTION
This example illustrates the usage of $sum operator in two different ways. 
1. sum as total
2. sum as count.

Similar to other pages on operators, this page will be consistent and comprehensive with the example.
