### PR TITLE
improves description of `mongodump` options

### DIFF
--- a/source/tutorial/backup-with-mongodump.txt
+++ b/source/tutorial/backup-with-mongodump.txt
@@ -56,14 +56,16 @@ use the following command:
 
 .. include:: /includes/warning-mongodump-compatibility-2.2.rst
 
-To limit the amount of data included in the database dump, you can
-specify :option:`--db <mongodump --db>` and
-:option:`--collection <mongodump --collection>` as options to the
-:program:`mongodump` command. For example:
+You can use :option:`--dbpath <mongodump --dbpath>` and 
+:option:`--out <mongodump --out>` as options to the :program:`mongodump`
+command to specify the input and output directories:
 
 .. code-block:: sh
 
    mongodump --dbpath /data/db/ --out /data/backup/
+
+You can also use :option:`--host <mongodump --host>` and 
+:option:`--port <mongodump --port>`:
 
 .. code-block:: sh
 
@@ -72,6 +74,11 @@ specify :option:`--db <mongodump --db>` and
 :program:`mongodump` will write :term:`BSON` files that hold a copy of
 data accessible via the :program:`mongod` listening on port ``27017`` of
 the ``mongodb.example.net`` host.
+
+To limit the amount of data included in the database dump, you can
+specify :option:`--db <mongodump --db>` and
+:option:`--collection <mongodump --collection>` as options to the
+:program:`mongodump` command. For example:
 
 .. code-block:: sh
 


### PR DESCRIPTION
- moves textual description of `--db` and `--collection` to example code
- adds more verbose descriptions of `--dbpath` and `--out`

I'm new to mongo, and the way these descriptions and examples were laid out confused me, so I've fixed it.
