### PR TITLE
Document upper and lower bounds of chunk size.

### DIFF
--- a/source/tutorial/modify-chunk-size-in-sharded-cluster.txt
+++ b/source/tutorial/modify-chunk-size-in-sharded-cluster.txt
@@ -10,7 +10,8 @@ default chunk size of 64 megabytes. This default chunk size works well
 for most deployments; however, if you notice that automatic migrations
 have more I/O than your hardware can handle, you may want to reduce the
 chunk size. For automatic splits and migrations, a small chunk size
-leads to more rapid and frequent migrations.
+leads to more rapid and frequent migrations. The allowed range of the
+chunk size is between 1 and 1024 megabytes.
 
 To modify the chunk size, use the following procedure:
 
@@ -52,3 +53,5 @@ Modifying the chunk size has several limitations:
 
 - If you increase the chunk size, existing chunks grow only through
   insertion or updates until they reach the new size.
+  
+- The allowed range of the chunk size is between 1 and 1024 megabytes.


### PR DESCRIPTION
This is hardcoded in s/chunk.cpp:

   bool Chunk::setMaxChunkSizeSizeMB( int newMaxChunkSize ) {
        if ( newMaxChunkSize < 1 )
            return false;
        if ( newMaxChunkSize > 1024 )
            return false;
        MaxChunkSize = newMaxChunkSize \* 1024 \* 1024;
        return true;
    }
