### PR TITLE
Fix geo indexes limitation. Regression from 2.2 docs

### DIFF
--- a/source/core/geospatial-indexes.txt
+++ b/source/core/geospatial-indexes.txt
@@ -9,7 +9,11 @@ This document provides a more in-depth explanation of the internals of MongoDB's
 or application development but may be useful for troubleshooting and for
 further understanding.
 
+.. important:: MongoDB only supports *one* geospatial index per
+   collection.
+
 .. _geospatial-indexes-geohash:
+
 
 Calculation of Geohash Values for ``2d`` Indexes
 ------------------------------------------------


### PR DESCRIPTION
I think this was removed in the migration (ac3ad133)

Please also commit this in the 2.4 branch as well.

Related ticket: https://jira.mongodb.org/browse/SERVER-2331
