### PR TITLE
Addded Examples for $pull'ing Objects

### DIFF
--- a/source/reference/operator/update/pull.txt
+++ b/source/reference/operator/update/pull.txt
@@ -49,6 +49,42 @@ After the operation, the documents no longer have ``"msr"`` values:
    { _id: 1, flags: [  "vme",  "de",  "tsc",  "pse" ] }
    { _id: 2, flags: [  "pse",  "tsc" ] }
 
+Remove All Items Equaling Something Inside an Array of Objects
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Given the following documents in the ``tvShows`` collection:
+
+.. code-block:: javascript
+
+   { _id: 1, shows: [
+      { name: "Spongebob",       time: "8:00PM"  },
+      { name: "CatDog",          time: "6:00AM"  },
+      { name: "Powerpuff Girls": time: "12:00PM" } ] }
+   { _id: 2, shows: [
+      { name: "Dexter's Lab",    time: "6:00AM"  },
+      { name: "Power Rangers"    time: "8:00PM"  } ] }
+
+The following operation removes any entry whose ``time`` property equals ``"8:00PM"`` in the ``shows`` array:
+
+.. code-block:: javascript
+
+   db.tvShows.update(
+                      { "shows.time": "8:00PM" },
+                      { $pull: { shows: { time: "8:00PM" } } },
+                      { multi: true }
+                    )
+
+After the operation, no documents contain shows with an ``"8:00PM"`` ``time``:
+
+.. code-block:: javascript
+
+   { _id: 1, shows: [
+      { name: "CatDog",          time: "6:00AM" },
+      { name: "Powerpuff Girls": time: "12:00PM" } ] }
+   { _id: 2, shows: [
+      { name: "Dexter's Lab",    time: "6:00AM"  } ] }
+
+
 Remove All Items Greater Than a Specified Value
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -70,3 +106,38 @@ After the update operation, the document only has values less than 6:
 .. code-block:: javascript
 
    { _id: 1, votes: [  3,  5 ] }
+
+
+Remove All Items Greater Than a Specified Value Inside an Array of Objects
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Given the following documents in the ``tvShows`` collection:
+
+.. code-block:: javascript
+
+   { _id: 1, shows: [
+      { name: "Spongebob",       time: 8  },
+      { name: "CatDog",          time: 6  },
+      { name: "Powerpuff Girls": time: 12 } ] }
+   { _id: 2, shows: [
+      { name: "Dexter's Lab",    time: 6  },
+      { name: "Power Rangers"    time: 8  } ] }
+
+The following operation removes any entry whose ``time`` property is greater than ``8``:
+
+.. code-block:: javascript
+
+   db.tvShows.update(
+                      { "shows.time": "8:00PM" },
+                      { $pull: { shows: { time: { $gte: 8 } } } },
+                      { multi: true }
+                    )
+
+After the operation, no documents contain shows starting at or after 8:
+
+.. code-block:: javascript
+
+   { _id: 1, shows: [
+      { name: "CatDog",          time: 6  } ] }
+   { _id: 2, shows: [
+      { name: "Dexter's Lab",    time: 6  } ] }


### PR DESCRIPTION
There wasn't any documentation on how to `$pull` a specific entry
in an array of objects.

I've added a couple examples showing how you can do so.  I'm 
not 100% about the `$gte` example, but I'm 99% sure that is
correctly done.

Example Link:
http://stackoverflow.com/questions/9048424/removing-specific-items-from-array-with-mongodb
