### PR TITLE
Fix upgrade notes

### DIFF
--- a/source/includes/2.4-2.6-upgrade-downgrade-procedure.rst
+++ b/source/includes/2.4-2.6-upgrade-downgrade-procedure.rst
@@ -4,8 +4,8 @@
 ------------------
 
 Once upgraded to MongoDB 2.6, you **cannot** downgrade to **any** version
-earlier than MongoDB 2.4. If you have ``text`` indexes, you can only
-downgrade to MongoDB 2.4.10 or later.
+earlier than MongoDB 2.4. If you have ``text`` or ``2dsphere`` indexes,
+you can only downgrade to MongoDB 2.4.10 or later.
 
 **Except** as described on this page, moving between 2.4 and 2.6 is a
 drop-in replacement:


### PR DESCRIPTION
In the same page (http://docs.mongodb.org/manual/release-notes/2.6-upgrade/#action-procedure) we say a different things (https://github.com/mongodb/docs/blob/master/source/release-notes/2.6-upgrade.txt#L87).
