### PR TITLE
Update deploy-geographically-distributed-replica-set.txt

### DIFF
--- a/source/tutorial/deploy-geographically-distributed-replica-set.txt
+++ b/source/tutorial/deploy-geographically-distributed-replica-set.txt
@@ -92,7 +92,7 @@ Deploy a Geographically Redundant Four-Member Replica Set
 A geographically redundant four-member deployment has two additional
 considerations:
 
-- One host (e.g. ``mongodb3.example.net``) must be an :term:`arbiter`.
+- One host (e.g. ``mongodb4.example.net``) must be an :term:`arbiter`.
   This host can run on a system that is also used for an application server
   or on the same machine as another MongoDB process.
 


### PR DESCRIPTION
Added typo correction. The nodes 0-3 are data bearing whilst node 4 in the example should be the arbiter rather than node 3.
