### PR TITLE
cleaning up left over verbiage

### DIFF
--- a/source/reference/command/cloneCollection.txt
+++ b/source/reference/command/cloneCollection.txt
@@ -36,9 +36,7 @@ Example
 
 This operation copies the ``profiles`` collection from the ``users``
 database on the server at ``mongodb.example.net``. The operation only
-copies documents that satisfy the query ``{ active: true }`` and does
-not copy indexes. :dbcommand:`cloneCollection` copies indexes by
-default. The ``query`` arguments is optional.
+copies documents that satisfy the query ``{ active: true }``. :dbcommand:`cloneCollection` always copies indexes. The ``query`` arguments is optional.
 
 If, in the above example, the ``profiles`` collection exists in the
 ``users`` database, then MongoDB appends documents from the remote


### PR DESCRIPTION
from copyindexes option which isn't implemented.
