### PR TITLE
as of 2.6 that note shouldn't be there

### DIFF
--- a/source/core/aggregation-introduction.txt
+++ b/source/core/aggregation-introduction.txt
@@ -64,9 +64,6 @@ the custom JavaScript provide great flexibility compared to the
 aggregation pipeline, in general, map-reduce is less efficient and more
 complex than the aggregation pipeline.
 
-Additionally, map-reduce operations can have output sets that
-exceed the 16 megabyte output limitation of the aggregation pipeline.
-
 .. note:: Starting in MongoDB 2.4, certain :program:`mongo` shell
    functions and properties are inaccessible in map-reduce
    operations. MongoDB 2.4 also provides support for multiple


### PR DESCRIPTION
Removing thing referencing 16MB limit for agg.
