### PR TITLE
made the $unwind example more intuitive

### DIFF
--- a/source/reference/operator/aggregation/unwind.txt
+++ b/source/reference/operator/aggregation/unwind.txt
@@ -42,21 +42,21 @@ $unwind (aggregation)
            "result" : [
                    {
                            "_id" : ObjectId("4e6e4ef557b77501a49233f6"),
-                           "title" : "this is my title",
-                           "author" : "bob",
-                           "tags" : "fun"
+                           "title" : "the ultimate guide of leaves and trees",
+                           "author" : "bob green",
+                           "tags" : "gardening"
                    },
                    {
                            "_id" : ObjectId("4e6e4ef557b77501a49233f6"),
-                           "title" : "this is my title",
-                           "author" : "bob",
-                           "tags" : "good"
+                           "title" : "the ultimate guide of leaves and trees",
+                           "author" : "bob green",
+                           "tags" : "hobby"
                    },
                    {
                            "_id" : ObjectId("4e6e4ef557b77501a49233f6"),
-                           "title" : "this is my title",
-                           "author" : "bob",
-                           "tags" : "fun"
+                           "title" : "the ultimate guide of leaves and trees",
+                           "author" : "bob green",
+                           "tags" : "nature"
                    }
            ],
            "OK" : 1


### PR DESCRIPTION
having the same label twice ("fun") is possible, but not really intuitive, especially since we mention in the next sentence "each document is identical except for the value of the tags field".

also made a bit more realistic example matching the books/author theme.
