### PR TITLE
Change example to set secondaryThrottle to false

### DIFF
--- a/source/tutorial/configure-sharded-cluster-balancer.txt
+++ b/source/tutorial/configure-sharded-cluster-balancer.txt
@@ -143,6 +143,6 @@ following command:
    )
 
 The effects of changing the ``_secondaryThrottle`` value may not be
-immediate. To ensure an immediate effect, stop the balancer and restart
-it with the selected value of ``_secondaryThrottle``. See
+immediate. To ensure an immediate effect, stop and restart the balancer 
+to enable the selected value of ``_secondaryThrottle``. See
 :doc:`/tutorial/manage-sharded-cluster-balancer` for details.


### PR DESCRIPTION
Since secondary throttle default is true since 2.4, example should show how to set it to false (or off) since the page that explains when to to turn it off links to here.
