### PR TITLE
Update diagnostics commands

### DIFF
--- a/source/core/master-slave.txt
+++ b/source/core/master-slave.txt
@@ -144,7 +144,7 @@ perspective of the master:
 
 .. code-block:: javascript
 
-   rs.printReplicationInfo()
+   db.printReplicationInfo()
 
 On a :term:`slave` instance, use the following operation in the
 :program:`mongo` shell to return the replication status from the
@@ -152,7 +152,7 @@ perspective of the slave:
 
 .. code-block:: javascript
 
-   rs.printSlaveReplicationInfo()
+   db.printSlaveReplicationInfo()
 
 Use the :dbcommand:`serverStatus` as in the following operation, to
 return status of the replication:


### PR DESCRIPTION
Document said that printReplicationInfo() and printSlaveReplicationInfo() diagnostic methods are accessible via "rs" object. However they are in "db" object.
