### PR TITLE
DOCS-1362

### DIFF
--- a/source/reference/command/fsync.txt
+++ b/source/reference/command/fsync.txt
@@ -48,8 +48,6 @@ block. As a result, :dbcommand:`fsync`,
 with lock, is not a reliable mechanism for making
 a :program:`mongod` instance operate in a read-only mode.
 
-.. include:: /includes/note-disable-profiling-fsynclock.rst
-
 Examples
 --------
 

--- a/source/reference/command/profile.txt
+++ b/source/reference/command/profile.txt
@@ -50,8 +50,6 @@ profile
                 around this functionality in the :program:`mongo`
                 shell.
 
-   .. include:: /includes/note-disable-profiling-fsynclock.rst
-
    .. note::
 
       This command obtains a write lock on the affected database and will

--- a/source/reference/method/db.fsyncLock.txt
+++ b/source/reference/method/db.fsyncLock.txt
@@ -22,5 +22,3 @@ db.fsyncLock()
 
    This function locks the database and create a window for
    :doc:`backup operations </core/backups>`.
-
-   .. include:: /includes/note-disable-profiling-fsynclock.rst

--- a/source/reference/method/db.setProfilingLevel.txt
+++ b/source/reference/method/db.setProfilingLevel.txt
@@ -31,4 +31,3 @@ Definition
    the :setting:`~operationProfiling.slowOpThresholdMs` to the log even when the database profiler is
    not active.
 
-   .. include:: /includes/note-disable-profiling-fsynclock.rst

--- a/source/tutorial/backup-with-filesystem-snapshots.txt
+++ b/source/tutorial/backup-with-filesystem-snapshots.txt
@@ -318,6 +318,4 @@ member`).
          db.runCommand( { fsync: 1, lock: true } );
          db.runCommand( { fsync: 1, lock: false } );
 
-   .. include:: /includes/note-disable-profiling-fsynclock.rst
-
    .. include:: /includes/warning-fsync-lock-mongodump.rst


### PR DESCRIPTION
 removing references to necessity of disabling profiling before using db.fsyncLock()
