### PR TITLE
Removed spurious 'a' in documentation.

### DIFF
--- a/source/core/replica-set-arbiter.txt
+++ b/source/core/replica-set-arbiter.txt
@@ -7,7 +7,7 @@ Replica Set Arbiter
 
 .. default-domain:: mongodb
 
-.. start-contenta
+.. start-content
 
 An arbiter does **not** have a copy of data set and **cannot** become
 a primary. Replica sets may have arbiters to add a vote in


### PR DESCRIPTION
There was an extra, unwanted 'a' in the documentation on arbiters in replica sets. The extra 'a' looks pretty benign in the source code, but generates an extra paragraph with a lonely 'a' in the [online documentation](http://docs.mongodb.org/manual/core/replica-set-members/#arbiter).
