### PR TITLE
Create stronger warning for db.foo.copyTo()

### DIFF
--- a/source/includes/warning-copyto-loss-of-type-fidelity.rst
+++ b/source/includes/warning-copyto-loss-of-type-fidelity.rst
@@ -5,3 +5,9 @@
    documents during the translation from :term:`BSON` to
    :term:`JSON`. Consider using :method:`~db.cloneCollection()`
    to maintain type fidelity.
+
+   The :method:`db.collection.copyTo()` command uses the :dbcommand:`eval`
+   command internally. As a result, the :method:`db.collection.copyTo()`
+   command takes a global lock that blocks all other read and write
+   operations until the :method:`db.collection.copyTo()` command completes.
+


### PR DESCRIPTION
DOCS-3916
