### PR TITLE
minor: clarify directory naming

### DIFF
--- a/source/reference/program/mongod.txt
+++ b/source/reference/program/mongod.txt
@@ -286,7 +286,7 @@ Core Options
 
    Alters the storage pattern of the data directory to store each
    database's files in a distinct folder. This option will create
-   directories within the :option:`--dbpath` named for each directory.
+   directories within the :option:`--dbpath` named for each database.
 
    Use this option in conjunction with your file system and device
    configuration so that MongoDB will store data on a number of


### PR DESCRIPTION
directories are named for each database, not each directory with the --directoryperdb option
