### PR TITLE
DOCS-4066 Typo in sharding-introduction.txt

### DIFF
--- a/source/core/sharding-introduction.txt
+++ b/source/core/sharding-introduction.txt
@@ -197,7 +197,7 @@ Splitting
 Splitting is a background process that keeps chunks from growing too
 large. When a chunk grows beyond a :ref:`specified chunk size
 <sharding-chunk-size>`, MongoDB splits the chunk in half. Inserts and
-updates triggers splits. Splits are a efficient meta-data change. To
+updates triggers splits. Splits are an efficient meta-data change. To
 create splits, MongoDB does *not* migrate any data or affect the
 shards.
 


### PR DESCRIPTION
This is a pull request for fixing https://jira.mongodb.org/browse/DOCS-4066

I'm a github novice, so let me know if I've made any mistakes.  This is a pretty trivial bug.  
