### PR TITLE
mongoimport --drop does not drop all the collections

### DIFF
--- a/source/includes/options-mongoimport.yaml
+++ b/source/includes/options-mongoimport.yaml
@@ -234,7 +234,7 @@ directive: option
 args: null
 description: |
   Modifies the import process so that the target instance drops
-  every collection before importing the collection from the input.
+  the collection before importing the data from the input.
 optional: true
 ---
 program: mongoimport


### PR DESCRIPTION
For example in 2.6.4

If you specify the collection it will only drop that.

```
$ mongoimport -d test2 -c test --drop test.js
connected to: 127.0.0.1
2014-09-22T16:44:01.692+0100 dropping: test2.test
2014-09-22T16:44:01.715+0100 imported 1 objects
```

If you don't specify it. It will only drop the collection with the same name as the file you're importing.

```
$mongoimport -d test2 --drop test.js
connected to: 127.0.0.1
no collection specified!
using filename 'test' as collection.
2014-09-22T16:44:32.534+0100 dropping: test2.test
2014-09-22T16:44:32.537+0100 imported 1 objects
```

I had another collection in the test2 database and that was never dropped.
