### PR TITLE
Removed quiet: true option - not recommended for normal install

### DIFF
--- a/source/reference/configuration-options.txt
+++ b/source/reference/configuration-options.txt
@@ -55,7 +55,6 @@ The following is an example of several settings in a configuration file:
    systemLog:
       destination: file
       path: "/var/log/mongodb/mongodb.log"
-      quiet: true
       logAppend: true
    storage:
       journal:


### PR DESCRIPTION
Removing "quiet: true" option from the sample configuration provided on this page. This aligns with our general recommendation of not running in quiet mode.
