### PR TITLE
Be more precise about in-memory sorting limit

### DIFF
--- a/source/reference/limits.txt
+++ b/source/reference/limits.txt
@@ -316,8 +316,9 @@ Operations
 .. limit:: Sorted Documents
 
    MongoDB will only return sorted results on fields without an index
-   *if* the sort operation uses less than 32 megabytes of memory.
-
+   *if* the combined size of all documents to be sorted (plus some overhead)
+   is less than 32 megabytes.
+   
 .. _limit-agg-sort:
 
 .. limit:: Aggregation Pipeline Operation


### PR DESCRIPTION
I asked kernel engineering what exactly the size limit for in-memory sort was, and it turns out it's the size of all sorted documents combined.
