### PR TITLE
Update monitor-with-snmp.txt

### DIFF
--- a/source/tutorial/monitor-with-snmp.txt
+++ b/source/tutorial/monitor-with-snmp.txt
@@ -16,8 +16,8 @@ Monitor MongoDB With SNMP on Linux
 Overview
 --------
 
-MongoDB Enterprise can report system information into SNMP traps, to
-support centralized data collection and aggregation. This procedure
+MongoDB Enterprise can provide database metrics via SNMP, in
+support of centralized data collection and aggregation. This procedure
 explains the setup and configuration of a |mongod-program| instance
 as an SNMP subagent, as well as initializing and testing of SNMP
 support with MongoDB Enterprise.


### PR DESCRIPTION
The mongod SNMP interface does not send traps. It provides a "get" interface for metric retrieval. Proposed changes above are meant to correct.
