### PR TITLE
Update fact-selinux-redhat-options.rst

### DIFF
--- a/source/includes/fact-selinux-redhat-options.rst
+++ b/source/includes/fact-selinux-redhat-options.rst
@@ -8,7 +8,7 @@ options:
 
   .. code-block:: sh
 
-     semanage port -a -t mongodb_port_t -p tcp 27017
+     semanage port -a -t mongod_port_t -p tcp 27017
 
 - set SELinux to ``permissive`` mode in ``/etc/selinux.conf``. The line
 


### PR DESCRIPTION
semanage port -a -t mongodb_port_t -p tcp 27017   is incorrect
it should be semanage port -a -t mongod_port_t -p tcp 27017
