### PR TITLE
Don't show twice the table of contents in certain 2.2 doc pages

### DIFF
--- a/source/applications/create.txt
+++ b/source/applications/create.txt
@@ -11,10 +11,6 @@ operations and the factors that affect their performance, see
 :doc:`/core/write-operations`; for documentation of the other CRUD
 operations, see the :doc:`/crud` page.
 
-.. contents::
-   :backlinks: none
-   :local:
-
 Overview
 --------
 

--- a/source/applications/delete.txt
+++ b/source/applications/delete.txt
@@ -11,10 +11,6 @@ For general information about write operations and the factors that affect
 their performance, see :doc:`/core/write-operations`; for documentation
 of other CRUD operations, see the :doc:`/crud` page.
 
-.. contents::
-   :backlinks: none
-   :local:
-
 .. _crud-delete-remove:
 
 Overview

--- a/source/applications/read.txt
+++ b/source/applications/read.txt
@@ -11,10 +11,6 @@ operations and the factors that affect their performance, see
 :doc:`/core/read-operations`; for documentation of the other CRUD
 operations, see the :doc:`/crud` page.
 
-.. contents::
-   :backlinks: none
-   :local:
-
 Overview
 --------
 

--- a/source/applications/update.txt
+++ b/source/applications/update.txt
@@ -11,10 +11,6 @@ operations and the factors that affect their performance, see
 :doc:`/core/write-operations`; for documentation of other CRUD
 operations, see the :doc:`/crud` page.
 
-.. contents::
-   :backlinks: none
-   :local:
-
 Overview
 --------
 


### PR DESCRIPTION
For example:
http://docs.mongodb.org/v2.2/applications/read/
