### PR TITLE
Hashed key supports min-max

### DIFF
--- a/source/core/tag-aware-sharding.txt
+++ b/source/core/tag-aware-sharding.txt
@@ -27,8 +27,8 @@ Considerations
 - :term:`Shard key` range tags are distinct from :ref:`replica set
   member tags <replica-set-read-preference-tag-sets>`.
 
-- :term:`Hash-based sharding <hashed shard key>` does not support
-  tag-aware sharding.
+- :term:`Hash-based sharding <hashed shard key>` only supports
+  tag-aware sharding on entire collection.
 
 - .. include:: /includes/fact-shard-ranges-inclusive-exclusive.rst 
 


### PR DESCRIPTION
You can add range on hashed shard key - you just can't split the collection into multiple ranges.
