### PR TITLE
Remove reference to distributed mongosniff.

### DIFF
--- a/source/reference/program/mongosniff.txt
+++ b/source/reference/program/mongosniff.txt
@@ -20,18 +20,7 @@ development.
 .. note::
 
    :program:`mongosniff` requires ``libpcap`` and is only available for
-   Unix-like systems. Furthermore, the version distributed with the
-   MongoDB binaries is dynamically linked against aversion 0.9 of
-   ``libpcap``. If your system has a different version of ``libpcap``, you
-   will need to compile :program:`mongosniff` yourself or create a
-   symbolic link pointing to ``libpcap.so.0.9`` to your local version
-   of ``libpcap``. Use an operation that resembles the following:
-
-   .. code-block:: sh
-
-      ln -s /usr/lib/libpcap.so.1.1.1 /usr/lib/libpcap.so.0.9
-
-   Change the path's and name of the shared library as needed.
+   Unix-like systems. 
 
 As an alternative to :program:`mongosniff`, Wireshark, a popular
 network sniffing tool is capable of inspecting and parsing the MongoDB


### PR DESCRIPTION
We don't distribute mongosniff any more as of 2.6.0. 
Related info - 
https://jira.mongodb.org/browse/HELP-685
https://groups.google.com/d/msg/mongodb-dev/dmnm0i1g-NE/QCIAZp6nBGQJ
