### PR TITLE
Clarify when $elemMatch is not necessary

### DIFF
--- a/source/reference/operator/query/elemMatch.txt
+++ b/source/reference/operator/query/elemMatch.txt
@@ -30,8 +30,8 @@ for :query:`$elemMatch`.
 Examples
 --------
 
-Element Match
-~~~~~~~~~~~~~
+Primitive type element match
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Given the following documents in the ``scores`` collection:
 
@@ -86,6 +86,24 @@ Specifically, the query matches the following document:
 .. code-block:: javascript
 
    { "_id" : 3, "results" : [ { "product" : "abc", "score" : 7 }, { "product" : "xyz", "score" : 8 } ] }
+
+
+Single embedded document field
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you only want to find documents with an array containing one (as
+opposed to multiple) embedded document fields that satisfy a condition,
+then ``$elemMatch`` is not necessary, and you can just write ``array.field``:
+
+   db.survey.find( 
+      { results: { $elemMatch: { product: "xyz" } } }
+   )
+
+is equivalent to:
+
+   db.survey.find( 
+      { "results.product": "xyz" } } }
+   )
 
 For more information on querying arrays, see
 :ref:`read-operations-arrays`, including


### PR DESCRIPTION
Please correct if wrong. Other nuances of $elemMatch vs. array.field would be helpful.