### PR TITLE
Improvements to map-reduce command reference

### DIFF
--- a/source/includes/parameters-map-reduce.rst
+++ b/source/includes/parameters-map-reduce.rst
@@ -145,8 +145,9 @@ members of replica sets.
 Output to a Collection with an Action
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This option is only available when passing ``out`` a collection that
-already exists. It is not available on secondary members of replica sets.
+This option is only available when passing a collection that
+already exists to ``out``. It is not available 
+on secondary members of replica sets.
 
 .. code-block:: javascript
 
@@ -182,7 +183,7 @@ following parameters:
 
 - ``db``:
 
-  Optional.The name of the database that you want the map-reduce
+  Optional. The name of the database that you want the map-reduce
   operation to write its output. By default this will be the same
   database as the input collection.
 
@@ -196,15 +197,16 @@ following parameters:
 
   .. versionadded:: 2.2
 
-  Optional. Specify output operation as non-atomic and is valid *only*
-  for ``merge`` and ``reduce`` output modes which may take minutes to
+  Optional. Specify output operation as non-atomic. This applies **only**
+  to the ``merge`` and ``reduce`` output modes, which may take minutes to
   execute.
 
-  If ``nonAtomic`` is ``true``, the post-processing step will prevent
-  MongoDB from locking the database; however, other clients will be
-  able to read intermediate states of the output collection. Otherwise
-  the map reduce operation must lock the database during
-  post-processing.
+  By default ``nonAtomic`` is ``false``, and the map-reduce
+  operation locks the database during post-processing.
+
+  If ``nonAtomic`` is ``true``, the post-processing step prevents
+  MongoDB from locking the database: during this time, other clients
+  will be able to read intermediate states of the output collection.
 
 Output Inline
 ~~~~~~~~~~~~~~

--- a/source/reference/command/mapReduce-field.yaml
+++ b/source/reference/command/mapReduce-field.yaml
@@ -47,6 +47,20 @@ object:
   name: mapReduce
   type: command
 field:
+  optional: true
+  type: field
+name: finalize
+type: Javascript function
+position: 7
+description: |
+  Follows the ``reduce`` method and modifies the output.
+
+  See :ref:`mapReduce-finalize-cmd` for more information.
+---
+object:
+  name: mapReduce
+  type: command
+field:
   optional: false
   type: field
 name: out
@@ -102,20 +116,6 @@ position: 6
 description: |
   Specifies a maximum number of documents for the input into the
   ``map`` function.
----
-object:
-  name: mapReduce
-  type: command
-field:
-  optional: true
-  type: field
-name: finalize
-type: Javascript function
-position: 7
-description: |
-  Follows the ``reduce`` method and modifies the output.
-
-  See :ref:`mapReduce-finalize-cmd` for more information.
 ---
 object:
   name: mapReduce

--- a/source/reference/command/mapReduce.txt
+++ b/source/reference/command/mapReduce.txt
@@ -18,11 +18,11 @@ mapReduce
                        mapReduce: <collection>,
                        map: <function>,
                        reduce: <function>,
+                       finalize: <function>,
                        out: <output>,
                        query: <document>,
                        sort: <document>,
                        limit: <number>,
-                       finalize: <function>,
                        scope: <document>,
                        jsMode: <boolean>,
                        verbose: <boolean>
@@ -75,17 +75,18 @@ mapReduce
    :start-after: start-reduce
    :end-before: end-reduce
 
+.. _mapreduce-finalize-cmd:
+
+.. include:: /includes/parameters-map-reduce.rst
+   :start-after: start-finalize
+   :end-before: end-finalize
+
 .. _mapreduce-out-cmd:
 
 .. include:: /includes/parameters-map-reduce.rst
    :start-after: start-out
    :end-before: end-out
 
-.. _mapreduce-finalize-cmd:
-
-.. include:: /includes/parameters-map-reduce.rst
-   :start-after: start-finalize
-   :end-before: end-finalize
 
 Map-Reduce Examples
 -------------------


### PR DESCRIPTION
- Reorders to put functions together
- Minor phrasing edits
- Adds default value for 'nonAtomic'
- Clarifies sharding behavior
