### PR TITLE
Update db.collection.update.txt

### DIFF
--- a/source/reference/method/db.collection.update.txt
+++ b/source/reference/method/db.collection.update.txt
@@ -7,12 +7,12 @@ db.collection.update()
 Definition
 ----------
 
-.. method:: db.collection.update(query, update, options)
+.. method:: db.collection.update(<query>, <update>, <options>)
 
    Modifies an existing document or documents in a collection. The
    method can modify specific fields of an existing document or documents
-   or replace an existing document entirely, depending on the
-   :ref:`update parameter <update-parameter>`.
+   or replace an existing document entirely, depending on which operators
+   are used in the :ref:`update parameter <update-parameter>`.
 
    By default, the :method:`~db.collection.update()` method updates a
    **single** document. Set the :ref:`multi-parameter` to update all


### PR DESCRIPTION
reword ambiguous sentence on update parameters. Also add "<>" around to update method parameters in synopsis, inline with (most) other synopsis.