### PR TITLE
DOCS-4447: updates profiler for WT changes

### DIFF
--- a/source/reference/database-profiler.txt
+++ b/source/reference/database-profiler.txt
@@ -207,7 +207,14 @@ operation.
    data that MongoDB has not yet fully read into memory. This allows
    other operations that have data in memory to complete while MongoDB
    reads in data for the yielding operation. For more information,
-   see :ref:`the FAQ on when operations yield <faq-concurrency-yielding>`.
+   see :ref:`the FAQ on when operations yield
+   <faq-concurrency-yielding>`.
+
+   .. versionchanged:: 2.8.0
+      :data:`system.profile.numYeild` does not apply to databases
+      using the :doc:`WiredTiger </core/storage>` storage engine, and
+      as such, is not included in the profiler output for
+      those databases.
 
 .. data:: system.profile.lockStats
 
@@ -233,6 +240,12 @@ operation.
 
       The time in microseconds the operation spent waiting to acquire a
       specific lock.
+   
+   .. versionchanged:: 2.8.0
+      :data:`system.profile.lockStats` does not apply to databases
+      using the :doc:`WiredTiger </core/storage>` storage engine, and
+      as such, is not included in the profiler output for
+      those databases.
 
 .. data:: system.profile.nreturned
 


### PR DESCRIPTION
- notes that numYield and lockStats are not output for WT databases
- does not change the profiler example, since the example is already just a 'this is what the document looks like', and notes that it will vary depending on the operation/database
