### PR TITLE
DOCS-4522: adds new mongotop error message for 2.8

### DIFF
--- a/source/includes/options-mongotop.yaml
+++ b/source/includes/options-mongotop.yaml
@@ -36,6 +36,17 @@ inherit:
   name: host
   program: _shared
   file: options-shared.yaml
+post: |
+
+
+  .. versionchanged:: 2.8.0
+     If connected to a replica set, {{program}} only reports activity
+     on the :term:`primary`. {{program}} will not include activity on
+     the :term:`secondaries <secondary>`.
+     If the :term:`primary` is not reachable, {{program}} returns an
+     error message. See:
+     :ref:`Use with Replica Sets <mongotop-use-replicasets>`
+     for more information.
 ---
 program: mongotop
 name: port

--- a/source/includes/options-mongotop.yaml
+++ b/source/includes/options-mongotop.yaml
@@ -37,16 +37,8 @@ inherit:
   program: _shared
   file: options-shared.yaml
 post: |
-
-
-  .. versionchanged:: 2.8.0
-     If connected to a replica set, {{program}} only reports activity
-     on the :term:`primary`. {{program}} will not include activity on
-     the :term:`secondaries <secondary>`.
-     If the :term:`primary` is not reachable, {{program}} returns an
-     error message. See:
-     :ref:`Use with Replica Sets <mongotop-use-replicasets>`
-     for more information.
+     If connected to a replica set where the :term:`primary` is not
+     reachable, {{program}} returns an error message.
 ---
 program: mongotop
 name: port
@@ -139,8 +131,11 @@ inherit:
   program: _shared
   file: options-shared.yaml
 post: |
-  {{role}} is required for :program:`mongod`
-  and :program:`mongos` instances that use :ref:`authentication`.
+
+
+  .. versionchanged:: 2.8.0
+     {{role}} is required for :program:`mongod`
+     and :program:`mongos` instances that use :ref:`authentication`.
 ---
 program: mongotop
 name: authenticationMechanism
@@ -178,6 +173,9 @@ description: |
   Toggles the mode of :program:`mongotop` to report on use of per-database
   :ref:`locks <locks>`. These data are useful for measuring concurrent
   operations and lock percentage.
+post: |
+  {{role}} returns an error when called against a :program:`mongod` instance
+  that does not report lock usage.
 optional: true
 ---
 program: mongotop

--- a/source/includes/options-shared.yaml
+++ b/source/includes/options-shared.yaml
@@ -67,9 +67,9 @@ description: |
   connect. By default, the {{program}} attempts to connect to a MongoDB
   instance running on the localhost on port number ``27017``.
 
-  To connect to a replica set, specify the :setting:`replica set name
-  <~replication.replSetName>` and a seed list of set members. Use the
-  following form:
+  To connect to a replica set, specify the
+  :setting:`~replication.replSetName` and a seed list of set members, as in
+  the following:
 
   .. code-block:: none
 
@@ -79,7 +79,7 @@ description: |
   specifying the host and port number directly.
 
   .. versionchanged:: 2.8.0
-     If you use IPv6 and use the ``<address>:<port >`` format, you must
+     If you use IPv6 and use the ``<address>:<port>`` format, you must
      enclose the portion of an address and port combination in
      brackets (e.g. ``[<address>]``).
 optional: false

--- a/source/reference/program/mongotop.txt
+++ b/source/reference/program/mongotop.txt
@@ -121,7 +121,7 @@ affect the output of :program:`mongotop`.
    and collection.
 
    .. versionchanged:: 2.2
-      If you use the :option:`--locks`, the :data:`~mongotop.ns` field does not
+      If you use the :option:`mongotop --locks`, the :data:`~mongotop.ns` field does not
       appear in the :program:`mongotop` output.
 
 .. data:: mongotop.db
@@ -153,6 +153,8 @@ affect the output of :program:`mongotop`.
 
    Provides a time stamp for the returned data.
 
+.. _mongotop-use:
+
 Use
 ---
 
@@ -174,22 +176,27 @@ This command produces the following output:
 
 .. code-block:: sh
 
-   connected to: 127.0.0.1
+                       ns    total    read    write          2014-12-19T15:32:01-05:00
+       admin.system.roles      0ms     0ms      0ms
+     admin.system.version      0ms     0ms      0ms
+                 local.me      0ms     0ms      0ms
+           local.oplog.rs      0ms     0ms      0ms
+   local.replset.minvalid      0ms     0ms      0ms
+        local.startup_log      0ms     0ms      0ms
+     local.system.indexes      0ms     0ms      0ms
+  local.system.namespaces      0ms     0ms      0ms
+     local.system.replset      0ms     0ms      0ms
 
-                       ns       total        read       write           2012-08-13T15:45:40
-   test.system.namespaces         0ms         0ms         0ms
-     local.system.replset         0ms         0ms         0ms
-     local.system.indexes         0ms         0ms         0ms
-     admin.system.indexes         0ms         0ms         0ms
-                   admin.         0ms         0ms         0ms
-
-                       ns       total        read       write           2012-08-13T15:45:55
-   test.system.namespaces         0ms         0ms         0ms
-     local.system.replset         0ms         0ms         0ms
-     local.system.indexes         0ms         0ms         0ms
-     admin.system.indexes         0ms         0ms         0ms
-                   admin.         0ms         0ms         0ms
-
+                       ns    total    read    write          2014-12-19T15:47:01-05:00
+       admin.system.roles      0ms     0ms      0ms
+     admin.system.version      0ms     0ms      0ms
+                 local.me      0ms     0ms      0ms
+           local.oplog.rs      0ms     0ms      0ms
+   local.replset.minvalid      0ms     0ms      0ms
+        local.startup_log      0ms     0ms      0ms
+     local.system.indexes      0ms     0ms      0ms
+  local.system.namespaces      0ms     0ms      0ms
+     local.system.replset      0ms     0ms      0ms
 
 To return a :program:`mongotop` report every 5 minutes, use the
 following command:
@@ -198,7 +205,7 @@ following command:
 
    mongotop 300
 
-To report the use of per-database locks, use :option:`mongotop --locks`,
+To report the use of per-database locks, use :option:`--locks`,
 which produces the following output:
 
 .. code-block:: sh
@@ -210,3 +217,40 @@ which produces the following output:
                   local         0ms         0ms         0ms
                   admin         0ms         0ms         0ms
                       .         0ms         0ms         0ms
+
+.. _mongotop-use-replicasets:
+
+.. versionchanged:: 2.8.0
+   When connected to a replica set, :program:`mongotop` only reports activity
+   on the :term:`primary`. :program:`mongotop` will not include activity on
+   the :term:`secondaries <secondary>`.
+
+   If the :term:`primary` is not reachable or no members of the seed list
+   are part of the specified replica set, :program:`mongotop` returns an
+   error, as in the following output:
+
+   .. code-block:: sh
+
+                          ns    total    read    write    2014-12-19T15:31:45-05:00
+          admin.system.roles      0ms     0ms      0ms
+        admin.system.version      0ms     0ms      0ms
+                    local.me      0ms     0ms      0ms
+              local.oplog.rs      0ms     0ms      0ms
+      local.replset.minvalid      0ms     0ms      0ms
+           local.startup_log      0ms     0ms      0ms
+        local.system.replset      0ms     0ms      0ms
+
+      2014-12-19T15:31:51.824-0500    Error: no reachable servers
+
+      2014-12-19T15:31:57.834-0500    Error: no reachable servers
+
+                           ns    total    read    write    2014-12-19T15:32:01-05:00
+           admin.system.roles      0ms     0ms      0ms
+         admin.system.version      0ms     0ms      0ms
+                     local.me      0ms     0ms      0ms
+               local.oplog.rs      0ms     0ms      0ms
+       local.replset.minvalid      0ms     0ms      0ms
+            local.startup_log      0ms     0ms      0ms
+         local.system.indexes      0ms     0ms      0ms
+      local.system.namespaces      0ms     0ms      0ms
+         local.system.replset      0ms     0ms      0ms

--- a/source/reference/program/mongotop.txt
+++ b/source/reference/program/mongotop.txt
@@ -198,6 +198,11 @@ This command produces the following output:
   local.system.namespaces      0ms     0ms      0ms
      local.system.replset      0ms     0ms      0ms
 
+The output varies depending on your MongoDB setup. For example,
+``local.system.indexes`` and ``local.system.namespaces`` only appear
+for :program:`mongod` instances using the :ref:`MMAPv1 <storage-mmapv1>`
+storage engine.
+
 To return a :program:`mongotop` report every 5 minutes, use the
 following command:
 
@@ -218,39 +223,7 @@ which produces the following output:
                   admin         0ms         0ms         0ms
                       .         0ms         0ms         0ms
 
-.. _mongotop-use-replicasets:
-
 .. versionchanged:: 2.8.0
-   When connected to a replica set, :program:`mongotop` only reports activity
-   on the :term:`primary`. :program:`mongotop` will not include activity on
-   the :term:`secondaries <secondary>`.
-
-   If the :term:`primary` is not reachable or no members of the seed list
-   are part of the specified replica set, :program:`mongotop` returns an
-   error, as in the following output:
-
-   .. code-block:: sh
-
-                          ns    total    read    write    2014-12-19T15:31:45-05:00
-          admin.system.roles      0ms     0ms      0ms
-        admin.system.version      0ms     0ms      0ms
-                    local.me      0ms     0ms      0ms
-              local.oplog.rs      0ms     0ms      0ms
-      local.replset.minvalid      0ms     0ms      0ms
-           local.startup_log      0ms     0ms      0ms
-        local.system.replset      0ms     0ms      0ms
-
-      2014-12-19T15:31:51.824-0500    Error: no reachable servers
-
-      2014-12-19T15:31:57.834-0500    Error: no reachable servers
-
-                           ns    total    read    write    2014-12-19T15:32:01-05:00
-           admin.system.roles      0ms     0ms      0ms
-         admin.system.version      0ms     0ms      0ms
-                     local.me      0ms     0ms      0ms
-               local.oplog.rs      0ms     0ms      0ms
-       local.replset.minvalid      0ms     0ms      0ms
-            local.startup_log      0ms     0ms      0ms
-         local.system.indexes      0ms     0ms      0ms
-      local.system.namespaces      0ms     0ms      0ms
-         local.system.replset      0ms     0ms      0ms
+   When called against a :program:`mongod` that does not report lock
+   usage, :option:`--locks` will return a ``Failed: Server does not
+   support reporting locking information`` error.


### PR DESCRIPTION
Also adds a general note that mongotop throws an error when the primary isn't available and it's connected to   replica set.

LGTM'd by Wisdom.