### PR TITLE
aggregation $sort clarification

### DIFF
--- a/source/reference/operator/aggregation/sort.txt
+++ b/source/reference/operator/aggregation/sort.txt
@@ -117,8 +117,11 @@ option in :method:`db.collection.aggregate()` method and the
 
 :pipeline:`$sort` operator can take advantage of an index when
 placed at the **beginning** of the pipeline or placed **before**
-the following aggregation operators: :pipeline:`$project`,
-:pipeline:`$unwind`, and :pipeline:`$group`.
-
+the :pipeline:`$project`,
+:pipeline:`$unwind`, and :pipeline:`$group` aggregation operators.
+If :pipeline:`$project`, :pipeline:`$unwind`, or :pipeline:`$group`
+occur prior to the :pipeline:`$sort` operation, :pipeline:`$sort` 
+cannot use any indexes.
+          
 .. todo:: if a sort precedes the first $group in a sharded system,
    all documents must go to the mongos for sorting.


### PR DESCRIPTION
- Clarifies that $sort cannot use the index if $group, $unwind, or
  $project occur before $sort.

- Should probably be backported to v2.6