### PR TITLE
Update capped-collections.txt

### DIFF
--- a/source/core/capped-collections.txt
+++ b/source/core/capped-collections.txt
@@ -5,8 +5,8 @@ Capped Collections
 .. default-domain:: mongodb
 
 :term:`Capped collections <capped collection>` are fixed-size
-collections that support high-throughput operations that insert,
-retrieve, and delete documents based on insertion order. Capped
+collections that support high-throughput operations that insert
+and retrieve documents based on insertion order. Capped
 collections work in a way similar to circular buffers: once a
 collection fills its allocated space, it makes room for new documents
 by overwriting the oldest documents in the collection.


### PR DESCRIPTION
Removal of 'delete operations' from intro wording since delete operation is not supported in capped collections