### PR TITLE
avgObjSize is not affected by the scale

### DIFF
--- a/source/reference/command/collStats.txt
+++ b/source/reference/command/collStats.txt
@@ -88,7 +88,7 @@ Output
 .. data:: collStats.avgObjSize
 
    The average size of an object in the collection. The ``scale``
-   argument affects this value.
+   argument does not affect this value.
 
 .. data:: collStats.storageSize
 


### PR DESCRIPTION
```diff
--- db.test.stats()
+++ db.test.stats(1024)
@@ -1,18 +1,18 @@
 {
   "ns": "test.test",
   "count": 53,
-  "size": 50331120,
+  "size": 49151,
   "avgObjSize": 949643,
-  "storageSize": 70017024,
+  "storageSize": 68376,
   "numExtents": 4,
   "nindexes": 1,
-  "lastExtentSize": 30580736,
+  "lastExtentSize": 29864,
   "paddingFactor": 1,
   "systemFlags": 1,
   "userFlags": 1,
-  "totalIndexSize": 8176,
+  "totalIndexSize": 7,
   "indexSizes": {
-    "_id_": 8176
+    "_id_": 7
   },
   "ok": 1
 }
```
Please fix the over branches as well.