### PR TITLE
DOCS-4678: documents --type for mongoexport

### DIFF
--- a/source/includes/options-mongoexport.yaml
+++ b/source/includes/options-mongoexport.yaml
@@ -176,7 +176,7 @@ description: |
   Specifies a field or fields to *include* in the export. Use a comma
   separated list of fields to specify multiple fields.
 
-  For :option:`--csv <mongoexport --csv>` output formats,
+  For :option:`csv <mongoexport --type>` output formats,
   :program:`mongoexport` includes only the specified field(s), and the
   specified field(s) can be a field within a sub-document.
 
@@ -195,7 +195,8 @@ description: |
   An alternative to :option:`--fields <mongoexport --fields>`. The
   {{role}} option allows you to
   specify in a file the field or fields to *include* in the export and is
-  **only valid** with the :option:`--csv <mongoexport --csv>` option. The
+  **only valid** with the :option:`--type <mongoexport --type>` option
+  with value ``csv``. The
   file must have only one field per line, and the line(s) must end with
   the LF character (``0x0A``).
 
@@ -244,18 +245,21 @@ description: |
 optional: true
 ---
 program: mongoexport
-name: csv
+name: type
 directive: option
-args: null
+args: <string>
 description: |
-  Changes the export format to a comma-separated-values (CSV)
-  format. By default :program:`mongoexport` writes data using one
-  :term:`JSON` document for every MongoDB document.
 
-  If you specify {{role}}, then you must also use either
+  .. versionadded:: 2.8.0
+ 
+  Specifies the file type to export. The default format is :term:`JSON`,
+  bit it is possible to export :term:`csv` files.
+     
+  If you specify ``csv``, then you must also use either
   the :option:`--fields` or the :option:`--fieldFile` option to
   declare the fields to export from the collection.
 optional: true
+default: json
 ---
 program: mongoexport
 name: out

--- a/source/reference/program/mongoexport.txt
+++ b/source/reference/program/mongoexport.txt
@@ -92,7 +92,7 @@ Options
 
 .. include:: /includes/option/option-mongoexport-query.rst
 
-.. include:: /includes/option/option-mongoexport-csv.rst
+.. include:: /includes/option/option-mongoexport-type.rst
 
 .. include:: /includes/option/option-mongoexport-out.rst
 

--- a/source/release-notes/2.8-compatibility.txt
+++ b/source/release-notes/2.8-compatibility.txt
@@ -107,7 +107,7 @@ Version Compatibility
 ~~~~~~~~~~~~~~~~~~~~~
 
 :program:`mongod` instances before 2.6.6 cannot perform an initial sync
-against 2.8 replica set members. Do not add :program:`mongod 2.6.6
+against 2.8 replica set members. Do not add :program:`mongod` 2.6.6
 members to a replica set that has 2.8 members.
 
 .. _2.8-oplog-format-change:
@@ -213,6 +213,10 @@ Removed Options
   :program:`mongoexport`, and :program:`bsondump`.
 
 - Removed ``--locks`` option for :program:`mongotop`.
+
+- Remove ``--csv`` option for :program:`mongoexport`. Replaced with
+  :option:`--type <mongoexport --type>`, which specifies the
+  export type (``csv`` or ``json``).
 
 .. seealso:: :ref:`2.8-tools-enhancements`
 


### PR DESCRIPTION
and deprecation of --csv.

LGTM'd by Kyle Erf.