### PR TITLE
Update configure-sharded-cluster-balancer.txt

### DIFF
--- a/source/tutorial/configure-sharded-cluster-balancer.txt
+++ b/source/tutorial/configure-sharded-cluster-balancer.txt
@@ -128,7 +128,7 @@ The ``_secondaryThrottle`` parameter of the balancer and the
 ``_secondaryThrottle`` is ``true``, which means each document move
 during chunk migration propagates to at least one secondary before the
 balancer proceeds with its next operation: this is equivalent to a write
-concern of ``{ w: 1 }``.
+concern of ``{ w: 2 }``.
 
 You can also configure the ``writeConcern`` for the
 ``_secondaryThrottle`` operation, to configure how migrations will


### PR DESCRIPTION
_secondaryThrottle is true by default in 2.8, which is equivalent to { w: 2 }.