### PR TITLE
Via + With cannot go together

### DIFF
--- a/source/includes/steps-install-mongodb-on-osx-with-homebrew.yaml
+++ b/source/includes/steps-install-mongodb-on-osx-with-homebrew.yaml
@@ -12,7 +12,7 @@ title: Install MongoDB.
 stepnum: 2
 ref: install
 pre: |
-  You can install MongoDB with via ``brew`` with several different options. Use
+  You can install MongoDB via ``brew`` with several different options. Use
   one of the following operations:
 action:
   - heading: Install the MongoDB Binaries


### PR DESCRIPTION
Removed "with" from "You can install MongoDB with via ``brew`` with several different options. Use"