### PR TITLE
Fixed $strcasecmp comparison to match output

### DIFF
--- a/source/reference/operator/aggregation/strcasecmp.txt
+++ b/source/reference/operator/aggregation/strcasecmp.txt
@@ -49,7 +49,7 @@ Consider a ``inventory`` collection with the following documents:
 
 The following operation uses the :expression:`$strcasecmp` operator to
 perform case-insensitive comparison of the ``quarter`` field value to
-the string ``"13q3"``:
+the string ``"13q4"``:
 
 .. code-block:: javascript
 
@@ -59,7 +59,7 @@ the string ``"13q3"``:
           $project:
              {
                item: 1,
-               comparisonResult: { $strcasecmp: [ "$quarter", "13q3" ] }
+               comparisonResult: { $strcasecmp: [ "$quarter", "13q4" ] }
              }
          }
       ]


### PR DESCRIPTION
`13q4` should have been used, not `13q3`.