### PR TITLE
Add warning to killOp() tutorial

### DIFF
--- a/source/tutorial/terminate-running-operations.txt
+++ b/source/tutorial/terminate-running-operations.txt
@@ -79,5 +79,7 @@ the target operation by operation ID.
 
    db.killOp(<opId>)
 
+.. include:: /includes/warning-terminating-operations.rst
+
 .. related:: To return a list of running operations see
    :method:`db.currentOp()`.


### PR DESCRIPTION
The same warning found here:
http://docs.mongodb.org/manual/reference/method/db.killOp/

to be added here:
http://docs.mongodb.org/manual/tutorial/terminate-running-operations/