### PR TITLE
Update apiargs-option-connection-string-w-param.yaml

### DIFF
--- a/source/includes/apiargs-option-connection-string-w-param.yaml
+++ b/source/includes/apiargs-option-connection-string-w-param.yaml
@@ -1,16 +1,5 @@
 arg_name: option
 description: |
-  The driver will *not* acknowledge write operations and will suppress
-  all network or socket errors.
-interface: option
-name: '-1'
-operation: connection-string-w
-optional: false
-position: 1
-type: number
----
-arg_name: option
-description: |
   The driver will *not* acknowledge write operations but will pass or
   handle any network and socket errors that it receives to the client.
 


### PR DESCRIPTION
Removed -1 option for w, as drivers have either deprecated it or never supported it in the first place.