### PR TITLE
Update replica-set-elections.txt

### DIFF
--- a/source/core/replica-set-elections.txt
+++ b/source/core/replica-set-elections.txt
@@ -153,7 +153,7 @@ eligibility to become a :term:`primary`. In an election, the replica
 set elects an eligible member with the highest
 :data:`~local.system.replset.members[n].priority` value as primary. By
 default, all members have a priority of ``1`` and have an equal chance
-of becoming primary. In the default, all members also can trigger an
+of becoming primary. In the default, all members except Priority 0 members can trigger an
 election.
 
 You can set the :data:`~local.system.replset.members[n].priority`


### PR DESCRIPTION
added except Priority 0 members as priority 0 cannot trigger an election and the line "In the default, all members also can trigger an election" seems to suggest otherwise. Hope this is correct understanding.  Do review and edit if i am right about this..