### PR TITLE
Explain what --oplogReplay really does.

### DIFF
--- a/source/includes/options-mongorestore.yaml
+++ b/source/includes/options-mongorestore.yaml
@@ -258,7 +258,7 @@ description: |
   with the ":option:`mongodump --oplog`" command. For an example of
   {{role}}, see :ref:`backup-restore-oplogreplay`.
   
-  The find the oplog entries it should replay, mongorestore looks for a
+  To find the oplog entries it should replay, mongorestore looks for a
   file named oplog.bson immediately below the dump directory.  This is
   where ":option:`mongodump --oplog`" places the oplog that it generates,
   but you can place any oplog there, for example a dump of an existing

--- a/source/includes/options-mongorestore.yaml
+++ b/source/includes/options-mongorestore.yaml
@@ -257,6 +257,15 @@ description: |
   current state of the database reflects the point-in-time backup captured
   with the ":option:`mongodump --oplog`" command. For an example of
   {{role}}, see :ref:`backup-restore-oplogreplay`.
+  
+  The find the oplog entries it should replay, mongorestore looks for a
+  file named oplog.bson immediately below the dump directory.  This is
+  where ":option:`mongodump --oplog`" places the oplog that it generates,
+  but you can place any oplog there, for example a dump of an existing
+  oplog that you created with mongodump (in this case, the oplog will likely
+  be dumped under the name oplog.rs.bson, and you will have to rename it to
+  oplog.bson and place it into the top-level directory of the dump in
+  order for mongorestore to replay it).
 optional: true
 ---
 program: mongorestore


### PR DESCRIPTION
This information is needed if you want to replay an arbitrary oplog, not just an oplog slice that was generated by mongodump --oplog.