### PR TITLE
Minimum osx version is 10.7 for mongodb 3.0

### DIFF
--- a/source/tutorial/install-mongodb-on-os-x.txt
+++ b/source/tutorial/install-mongodb-on-os-x.txt
@@ -11,8 +11,8 @@ Use this tutorial to install MongoDB on OS X systems.
 
 .. admonition:: Platform Support
 
-   Starting in version 2.4, MongoDB only supports OS X versions 10.6 (Snow
-   Leopard) on Intel x86-64 and later.
+   Starting in version 3.0, MongoDB only supports OS X versions 10.7 (Lion)
+   on Intel x86-64 and later.
 
 MongoDB is available through the popular OS X package manager `Homebrew
 <http://brew.sh/>`_ or through the `MongoDB Download site


### PR DESCRIPTION
As of https://jira.mongodb.org/browse/SERVER-15889 / https://github.com/mongodb/mongo/commit/87480a2a2c12a75745ecc890aa7e01ff639b4c82, the minimum osx version is 10.7.