### PR TITLE
cloneCollection is not a viable alternative to copyTo

### DIFF
--- a/source/includes/warning-copyto-loss-of-type-fidelity.rst
+++ b/source/includes/warning-copyto-loss-of-type-fidelity.rst
@@ -3,8 +3,7 @@
    When using :method:`db.collection.copyTo()` check field types to
    ensure that the operation does not remove type information from
    documents during the translation from :term:`BSON` to
-   :term:`JSON`. Consider using :method:`~db.cloneCollection()`
-   to maintain type fidelity.
+   :term:`JSON`.
 
    The :method:`db.collection.copyTo()` method uses the :dbcommand:`eval`
    command internally. As a result, the :method:`db.collection.copyTo()`


### PR DESCRIPTION
cloneCollection requires that the source and destination collections are on different mongods.  copyTo only works to copy a collection within a database on a single mongod.

Therefore, it is not possible to use cloneCollection instead of copyTo.  As such, we should not suggest the use of cloneCollection where copyTo does not behave as desired, since cloneCollection cannot work for that purpose and it is misleading to suggest that it can.