### PR TITLE
Update steps-install-mongodb-on-debian.yaml

### DIFF
--- a/source/includes/steps-install-mongodb-on-debian.yaml
+++ b/source/includes/steps-install-mongodb-on-debian.yaml
@@ -17,7 +17,7 @@ action:
     Create the list file using the following command:
   language: sh
   code: |
-    echo "deb http://repo.mongodb.org/apt/debian "$(lsb_release -sc)"/mongodb-org/3.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.0.list
+    echo "deb http://repo.mongodb.org/apt/debian "$(lsb_release -sc)"/mongodb-org/testing main" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.0.list
 ---
 stepnum: 3
 source:


### PR DESCRIPTION
The Url of the repo is http://repo.mongodb.org/apt/debian/dists/wheezy/mongodb-org/testing/
And Only wheezy distro is available.