### PR TITLE
Update getting-started.txt

### DIFF
--- a/source/tutorial/getting-started.txt
+++ b/source/tutorial/getting-started.txt
@@ -46,9 +46,9 @@ options.
 Select a Database
 ~~~~~~~~~~~~~~~~~
 
-After starting the :program:`mongo` shell your session will use the
+After starting the :program:`mongo` shell, your session will use the
 ``test`` database by default. At any time, issue the following operation
-at the :program:`mongo` to report the name of the current database:
+at the :program:`mongo` shell to report the name of the current database:
 
 .. code-block:: javascript
 


### PR DESCRIPTION
I added the word 'shell' after 'mongo' on line 28 for consistency. Everywhere else in the document where the mongo command line is referenced it is referred to as the 'mongo shell', but on line 28 it is being referred to as simply 'mongo'. This makes it difficult to understand without rereading it.

I added a comma on line 26 for increased readability.