### PR TITLE
Minor fix for missing parenthesis in runCommand

### DIFF
--- a/source/reference/command/planCacheListQueryShapes.txt
+++ b/source/reference/command/planCacheListQueryShapes.txt
@@ -27,6 +27,7 @@ Definition
          {
             planCacheListQueryShapes: <collection>
          }
+      )
 
    The :dbcommand:`planCacheListQueryShapes` command has the following field:
 


### PR DESCRIPTION
All the other Query Plan Cache commands look good:
http://docs.mongodb.org/manual/reference/command/nav-plan-cache/