### PR TITLE
Visually highlight the warning about using $min xor $max

### DIFF
--- a/source/includes/fact-query-min-max.rst
+++ b/source/includes/fact-query-min-max.rst
@@ -3,7 +3,9 @@ should avoid normal query planning. Instead they construct an index scan where
 the index bounds are explicitly specified by the values given in
 :operator:`min` and :operator:`max`.
 
-If one of the two boundaries is not specified, then the query plan will be
-an index scan that is unbounded on one side. This may degrade performance
-compared to a query containing neither operator, or one that uses both
-operators to more tightly constrain the index scan.
+.. warning::
+
+   If one of the two boundaries is not specified, then the query plan will be
+   an index scan that is unbounded on one side. This may degrade performance
+   compared to a query containing neither operator, or one that uses both
+   operators to more tightly constrain the index scan.


### PR DESCRIPTION
Following up from DOCS-4015, the second paragraph in the "$min without $max" and "$max within $min" sections should be more noticable, since it is warning the user of hazardous usage that is best avoided.

If it's not appropriate to have such a warning box inside a "fact" file (rather than a "warning" file), then it should be easy enough to rearrange as necessary.