### PR TITLE
Note that mongod --shutdown not available in latest version

### DIFF
--- a/source/tutorial/manage-mongodb-processes.txt
+++ b/source/tutorial/manage-mongodb-processes.txt
@@ -139,6 +139,7 @@ authentication enabled.
 Use ``--shutdown``
 ~~~~~~~~~~~~~~~~~~
 
+Note: this is not available in the latest version.
 From the Linux command line, shut down the :program:`mongod` using the
 :option:`--shutdown <mongod --shutdown>` option in the following command:
 


### PR DESCRIPTION
Per http://stackoverflow.com/questions/18835603/mongodb-shutdown-option-unavailable this option has been unavailable since at least v2.4.5.

Maybe we're missing something but I get the same message. If it is truly removed, it seems reasonable to remove the text entirely and I can update the pull request accordingly.