### PR TITLE
DOCS-5041: release notes for 2.6.9

### DIFF
--- a/source/release-notes/2.6-changelog.txt
+++ b/source/release-notes/2.6-changelog.txt
@@ -4,6 +4,53 @@
 
 .. default-domain:: mongodb
 
+.. _2.6.9-changelog:
+
+2.6.9 -- Changes
+----------------
+
+Security
+~~~~~~~~
+
+:issue:`SERVER-16073` Create hidden :setting:`net.ssl.sslCipherConfig` flag
+
+Querying
+~~~~~~~~
+
+- :issue:`SERVER-14723` Crash during query planning for :dbcommand:`geoNear` with multiple ``2dsphere`` indexes
+- :issue:`SERVER-14071` For queries with :method:`~cursor.sort()`, bad non-blocking plan can be cached if there are zero results
+- :issue:`SERVER-8188` Configurable idle cursor timeout
+
+Replication and Sharding
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+- :issue:`SERVER-17429` the message logged when changing sync target due to stale data should format OpTimes in a consistent way
+- :issue:`SERVER-17441` \ :program:`mongos` crash right after "not master" error
+
+Storage
+~~~~~~~
+
+:issue:`SERVER-15907` Use ``ftruncate`` rather than ``fallocate`` when running on ``tmpfs``
+
+Aggregation Framework
+~~~~~~~~~~~~~~~~~~~~~
+
+- :issue:`SERVER-17426` Aggregation framework query by ``_id`` returns duplicates in sharded cluster (orphan documents)
+- :issue:`SERVER-17224` Aggregation pipeline with 64MB document can terminate server
+
+Build and Platform
+~~~~~~~~~~~~~~~~~~
+
+- :issue:`SERVER-17484` Migrate server MCI config into server repo
+- :issue:`SERVER-17252` Upgrade PCRE Version from 8.30 to Latest
+
+Diagnostics and Internal Code
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- :issue:`SERVER-17226` \ :dbcommand:`top` command with 64MB result document can terminate server
+- :issue:`SERVER-17338` NULL pointer crash when running :dbcommand:`copydb` against stepped-down 2.6 primary
+- :issue:`SERVER-14992` Query for Windows 7 File Allocation Fix, and other hotfixes
+
 .. _2.6.8-changelog:
 
 2.6.8 -- Changes

--- a/source/release-notes/2.6.txt
+++ b/source/release-notes/2.6.txt
@@ -25,6 +25,24 @@ Minor Releases
 
       /release-notes/2.6-changelog
 
+2.6.9 -- March 24, 2015
+~~~~~~~~~~~~~~~~~~~~~~~
+
+- Resolve connection handling related crash with :program:`mongos`
+  instances :issue:`SERVER-17441`
+
+- Add server parameter to configure idle cursor timeout
+  :issue:`SERVER-8188`
+
+- Remove duplicated (orphan) documents from aggregation pipelines with
+  ``_id`` queries in sharded clusters :issue:`SERVER-17426`
+
+- Fixed crash in :dbcommand:`geoNear` queries with multiple
+  ``2dsphere` indexes :issue:`SERVER-14723`
+
+- `All issues closed in 2.6.9
+  <https://jira.mongodb.org/issues/?jql=fixVersion%20%3D%20%222.6.9%22%20AND%20project%20%3D%20SERVER>`_
+
 2.6.8 -- February 25, 2015
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -42,7 +60,6 @@ Minor Releases
 
 - `All issues closed in 2.6.8
   <https://jira.mongodb.org/issues/?jql=fixVersion%20%3D%20%222.6.8%22%20AND%20project%20%3D%20SERVER>`_
-
 
 2.6.7 -- January 13, 2015
 ~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
merge and backport to v2.6 branch, bump release version in `config/build_conf.yaml` on 2.6 branch. 

release scheduled for 3/24, it's safe to hold this patch back until the release day to minimize code freeze window. 