### PR TITLE
DOCS-1891: clarifies 'reasonable' pool sizes

### DIFF
--- a/source/administration/production-notes.txt
+++ b/source/administration/production-notes.txt
@@ -171,7 +171,9 @@ Manage Connection Pool Sizes
 
 To avoid overloading the connection resources of a single
 :program:`mongod` or :program:`mongos` instance, ensure that clients
-maintain reasonable connection pool sizes.
+maintain reasonable connection pool sizes. Adjust the connection pool
+size to suit your use case, beginning at 110-115% of the typical number
+of concurrent database requests.
 
 When using the :ref:`WiredTiger storage engine <storage-wiredtiger>`,
 the number of incoming connections to Wired Tiger should be less than


### PR DESCRIPTION
Adds note about what a good starting point for the 'reasonable pool size' is, as specified in the Production Checklist.