### PR TITLE
DOCS-4809: updates behavior for -j alias and adds stopOnError to mongorestore

### DIFF
--- a/source/includes/options-mongoimport.yaml
+++ b/source/includes/options-mongoimport.yaml
@@ -340,13 +340,9 @@ args: null
 description: |
   .. versionadded:: 2.2
 
-  Forces :program:`mongoimport` to halt the import operation at the
+  Forces {{program}} to halt the insert operation at the
   first error rather than continuing the operation despite errors.
 
-  .. versionchanged:: 3.0.0
-     {{role}} interrupts the import operation when {{program}} encounters
-     an insert or upsert error. Other error types will not stop
-     the import.
 optional: true
 ---
 program: mongoimport
@@ -370,6 +366,7 @@ description: |
   .. versionadded:: 3.0.0
   
   Specifies the number of insertion workers to run concurrently.
+post: |
   For large imports, increasing the number of insertion workers
   may increase the speed of the import.
 optional: true

--- a/source/includes/options-mongorestore.yaml
+++ b/source/includes/options-mongorestore.yaml
@@ -356,6 +356,18 @@ description: |
 optional: true
 ---
 program: mongorestore
+name: numInsertionWorkersPerCollection
+inherit:
+  name: numInsertionWorkers
+  program: mongoimport
+  file: options-mongoimport.yaml
+description: |
+  .. versionadded:: 3.0.0
+
+  Specifies the number of insertion workers to run concurrently per collection.
+default: 1
+---
+program: mongorestore
 name: numParallelCollections
 aliases: -j
 args: int
@@ -363,6 +375,21 @@ directive: option
 description: |
   Number of collections {{program}} should restore
   in parallel.
+
+  If you specify ``-j`` when restoring a *single* collection, ``-j``
+  maps to the :option:`--numInsertionWorkersPerCollection` option rather than
+  {{role}}.
 optional: true
 default: 4
+---
+program: mongorestore
+name: stopOnError
+directive: option
+args: null
+description: |
+  .. versionadded:: 3.0.0
+
+  Forces {{program}} to halt the restore when it encounters an
+  error.
+optional: true
 ...

--- a/source/reference/program/mongorestore.txt
+++ b/source/reference/program/mongorestore.txt
@@ -142,6 +142,10 @@ Options
 
 .. include:: /includes/option/option-mongorestore-numParallelCollections.rst
 
+.. include:: /includes/option/option-mongorestore-numInsertionWorkersPerCollection.rst
+
+.. include:: /includes/option/option-mongorestore-stopOnError.rst
+
 .. _mongorestore-path-option:
 
 .. include:: /includes/option/option-mongorestore-<path>.rst


### PR DESCRIPTION
Also pulls out note on mongoimport that indicates that `--stopOnError` doesn't stop for some types of errors, as that is no longer true.