### PR TITLE
removed --oplog from mongodump command

### DIFF
--- a/source/includes/steps-backup-sharded-clusters-dumps.yaml
+++ b/source/includes/steps-backup-sharded-clusters-dumps.yaml
@@ -52,7 +52,7 @@ pre: |
 action:
    language: sh
    code: |
-      mongodump --oplog --db config
+      mongodump --db config
 ---
 title: Backup replica set members.
 stepnum: 4


### PR DESCRIPTION
http://docs.mongodb.org/manual/tutorial/backup-sharded-cluster-with-database-dumps/

remove '--oplog' from command 'mongodump --oplog --db config'  as its not applicable to config dumps.

DOCS-5114