### PR TITLE
DOCS-5125 Fix syntax for maxTimeMS

### DIFF
--- a/source/reference/operator/meta/maxTimeMS.txt
+++ b/source/reference/operator/meta/maxTimeMS.txt
@@ -22,7 +22,7 @@ $maxTimeMS
 
    .. code-block:: javascript
 
-      db.collection.find( { } , { $maxTimeMS: 100 } )
+      db.collection.find( { $query: { }, $maxTimeMS: 100 } )
       db.collection.find( { } )._addSpecial("$maxTimeMS", 100)
 
    Interrupted operations return an error message similar to the


### PR DESCRIPTION
Description of maxTimeMS included an alternative to the
shortcut which used incorrect syntax. The incorrect command
did not limit the time for retrieving results and instead
created a inclusive projection on a field named '$maxTimeMS'
which would hopefully not be an actual field in the user
database.