### PR TITLE
DOCS-5129 Update CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -14,7 +14,7 @@ complete a `MongoDB Contributor Agreement`_ before we can accept your
 pull request.
 
 .. _`Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported`: http://creativecommons.org/licenses/by-nc-sa/3.0/
-.. _`MongoDB/10gen Contributor Agreement`: http://www.mongodb.com/legal/contributor-agreement
+.. _`MongoDB Contributor Agreement`: http://www.mongodb.com/legal/contributor-agreement
 
 Please review the following documents for our style, conventions,
 processes and practices for the MongoDB Documentation:


### PR DESCRIPTION
Correct the link for the contributor agreement. Previously,
the reference text was different from the intended text to be
linked. The reference text was not updated when 10gen
changed its name to MongoDB. The link in the README.rst
is correct, but when submitting a pull request, users are
directed by GitHub to the CONTRIBUTING.rst file by default.

When merging my previous pull request, the text "Signed-off-by: kay <kay.kim@10gen.com>" changed the SHA of the commit which meant that GitHub did not recognize it as the commit that I had in my repository. This meant that when I created the commit I am currently pull requesting, GitHub believed my repository was 1 commit behind and 2 commits ahead of the mongodb/docs repository. The easiest way that I know of for solving this is to do

    git diff HEAD~1 HEAD > ../patch.diff
    git remote add upstream git@github.com:mongodb/docs.git
    git fetch --all
    git reset --hard upstream/master
    git push origin master --force
    git apply ../patch.diff
    git add .
    git commit -m "(Rewrite the commit message here)"
    git push

A rebase would have doubled my first commit, but the solution above requires rewriting history on a public repository.

I understand completely that MongoDB needs to keep track of who signed off on community contributions and I am glad and honored to be able to contribute to the MongoDB project. Is there a different way to sign off on the commit so that it doesn't require so much repository maintenance on the part of contributors to make a second pull request?
Thank you!