### PR TITLE
Remove extra slash from Python and Ruby DBRef docs

### DIFF
--- a/source/reference/database-references.txt
+++ b/source/reference/database-references.txt
@@ -211,11 +211,11 @@ Driver Support for DBRefs
    `the MongoDBRef <http://www.php.net/manual/en/class.mongodbref.php/>`_ class.
 
 **Python**
-   The Python driver supports DBRefs using the :api:`DBRef <python/current/api/bson/dbref.html>` class and the :api:`dereference </python/current/api/pymongo/database.html#pymongo.database.Database.dereference>` method.
+   The Python driver supports DBRefs using the :api:`DBRef <python/current/api/bson/dbref.html>` class and the :api:`dereference <python/current/api/pymongo/database.html#pymongo.database.Database.dereference>` method.
 
 **Ruby**
-   The Ruby driver supports DBRefs using the :api:`DBRef </ruby/current/BSON/DBRef.html>` class
-   and the :api:`dereference </ruby/current/Mongo/DB.html#dereference-instance_method>` method.
+   The Ruby driver supports DBRefs using the :api:`DBRef <ruby/current/BSON/DBRef.html>` class
+   and the :api:`dereference <ruby/current/Mongo/DB.html#dereference-instance_method>` method.
 
 **Scala**
    The Scala driver contains no support for DBRefs. You can traverse


### PR DESCRIPTION
With the extra slash, the Ruby link would redirect to a jewelry website:

 * http://api.mongodb.org//ruby/current/BSON/DBRef.html?_ga=1.172381537.31321324.1389025525
 * http://www.kay.com/SearchResultsView?No=0&catalogId=10001&Ntk=Products&viewTaskName=SearchResultsView&Ne=1&globalSearchText=ruby&langId=-1&storeId=10101&N=0&Ntt=ruby