### PR TITLE
DOCS-4974: removes reference to reading datafiles directly

### DIFF
--- a/source/reference/program/mongodump.txt
+++ b/source/reference/program/mongodump.txt
@@ -18,8 +18,7 @@ effective :doc:`backup strategy </core/backups>`. Use
 restore databases.
 
 :program:`mongodump` can read data from either :program:`mongod` or :program:`mongos`
-instances, in addition to reading directly from MongoDB data files
-without an active :program:`mongod`.
+instances.
 
 .. seealso:: :program:`mongorestore`,
    :doc:`/tutorial/backup-sharded-cluster-with-database-dumps`
@@ -125,6 +124,8 @@ Options
 
 .. include:: /includes/option/option-mongodump-excludeCollectionsWithPrefix.rst
 
+.. _mongodump-behavior:
+
 Use
 ---
 
@@ -152,5 +153,3 @@ authenticating using the username ``user`` and the password
 .. code-block:: sh
 
    mongodump --host mongodb1.example.net --port 37017 --username user --password pass --out /opt/backup/mongodump-2011-10-24
-
-.. _mongodump-behavior:


### PR DESCRIPTION
Also moves the mongodump-behavior reference to above the Use header, rather than below it, because that was weird.