### PR TITLE
replSetStepDown: it's secondaryCatchUpPeriodSecs, not secondaryCatchupPeriodSecs

### DIFF
--- a/source/includes/apiargs-command-replSetStepDown-field.yaml
+++ b/source/includes/apiargs-command-replSetStepDown-field.yaml
@@ -6,7 +6,7 @@ description: |
 
   The stepdown period starts from the time that the
   :program:`mongod` receives the command. The stepdown period must
-  be greater than the ``secondaryCatchupPeriodSecs``.
+  be greater than the ``secondaryCatchUpPeriodSecs``.
 interface: command
 name: replSetStepDown
 operation: replSetStepDown
@@ -19,11 +19,11 @@ description: |
   The number of seconds that the :program:`mongod` will wait for
   an electable secondary to catch up to the primary.
 
-  When specified, ``secondaryCatchupPeriodSecs`` overrides the default
+  When specified, ``secondaryCatchUpPeriodSecs`` overrides the default
   wait time of either ``10`` seconds or if ``force: true``, ``0``
   seconds.
 interface: command
-name: secondaryCatchupPeriodSecs
+name: secondaryCatchUpPeriodSecs
 operation: replSetStepDown
 optional: true
 position: 2

--- a/source/reference/command/replSetStepDown.txt
+++ b/source/reference/command/replSetStepDown.txt
@@ -29,7 +29,7 @@ Description
 
       db.runCommand( { 
           replSetStepDown: <seconds>,
-          secondaryCatchupPeriodSecs: <seconds>,
+          secondaryCatchUpPeriodSecs: <seconds>,
           force: <true|false>
       } )
 
@@ -50,7 +50,7 @@ map-reduce job.
 To avoid rollbacks, :dbcommand:`replSetStepDown`, by default, only
 steps down the primary if an electable secondary is completely caught up
 with the primary. The command will wait up to the
-``secondaryCatchupPeriodSecs`` for a secondary to catch up.
+``secondaryCatchUpPeriodSecs`` for a secondary to catch up.
 
 If no electable secondary meets this criterion by the waiting period,
 the primary does not step down and the command errors. However, you can
@@ -93,8 +93,8 @@ does not step down and the command errors.
    use admin
    db.runCommand( { replSetStepDown: 120 } )
 
-Specify Wait Time for Secondary Catchup
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Specify Wait Time for Secondary Catch Up
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following example, run on the current primary, attempts to step
 down the member for ``120`` seconds, waiting up to ``15`` seconds for
@@ -108,10 +108,10 @@ the primary does not step down and the command errors.
 .. code-block:: javascript
 
    use admin
-   db.runCommand( { replSetStepDown: 120, secondaryCatchupPeriodSecs: 15 } )
+   db.runCommand( { replSetStepDown: 120, secondaryCatchUpPeriodSecs: 15 } )
 
-Specify Secondary Catchup with Force Step Down
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Specify Secondary Catch Up with Force Step Down
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following example, run on the current primary, attempts to step
 down the member for ``120`` seconds, waiting up to ``15`` seconds for
@@ -125,7 +125,7 @@ option, the primary steps down even if no suitable secondary exists.
 .. code-block:: javascript
 
    use admin
-   db.runCommand( { replSetStepDown: 120, secondaryCatchupPeriodSecs: 15, force: true } )
+   db.runCommand( { replSetStepDown: 120, secondaryCatchUpPeriodSecs: 15, force: true } )
 
 .. seealso:: :method:`rs.stepDown()`
 


### PR DESCRIPTION
This might seem minor, but the effect is that after copy-pasting the option, it apparently has no effect on the command.  This makes it seem like the option is broken in the server, when in fact it's just a small typo in the docs.