### PR TITLE
DOCS-5167: Move 3.0 dot notation change example out of API reference

### DIFF
--- a/source/includes/apiargs-method-db.collection.update-param.yaml
+++ b/source/includes/apiargs-method-db.collection.update-param.yaml
@@ -8,6 +8,8 @@ description: |
 
      .. include:: /includes/fact-mongodb30-upsert-id.rst
 
+     For an example, see :ref:`mongodb30-upsert-id`.
+
 interface: method
 name: query
 operation: db.collection.update

--- a/source/includes/fact-mongodb30-upsert-id-example.rst
+++ b/source/includes/fact-mongodb30-upsert-id-example.rst
@@ -1,0 +1,7 @@
+For example, the following will raise an error:
+
+.. code-block:: javascript
+
+   db.collection.update( { "_id.authorID": 1 },
+      { "name": "Robert Frost" },
+      { upsert: true } )

--- a/source/includes/fact-mongodb30-upsert-id.rst
+++ b/source/includes/fact-mongodb30-upsert-id.rst
@@ -1,9 +1,3 @@
 When you execute an :method:`~db.collection.update()` with the ``upsert``
-option, you can no longer use :ref:`document-dot-notation` to select only on
-part of the ``_id`` field. For example, the following will raise an error:
-
-.. code-block:: javascript
-
-   db.collection.update( { "_id.authorID": 1 },
-      { "name": "Robert Frost" },
-      { upsert: true } )
+option, you can not use :ref:`dot notation <document-dot-notation>` to select only
+part of the ``_id`` field.

--- a/source/reference/method/db.collection.update.txt
+++ b/source/reference/method/db.collection.update.txt
@@ -211,6 +211,15 @@ Sharded Collections
 
 .. _update-method-examples:
 
+.. _mongodb30-upsert-id:
+
+Upsert with Query on ``_id``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/fact-mongodb30-upsert-id.rst
+
+.. include:: /includes/fact-mongodb30-upsert-id-example.rst
+
 Examples
 --------
 

--- a/source/release-notes/3.0-compatibility.txt
+++ b/source/release-notes/3.0-compatibility.txt
@@ -458,6 +458,8 @@ General Compatibility Changes
 
 .. include:: /includes/fact-mongodb30-upsert-id.rst
 
+.. include:: /includes/fact-mongodb30-upsert-id-example.rst
+
 Deprecate Access to ``system.indexes`` and ``system.namespaces``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Fix of 00860578