### PR TITLE
Fixed: E: Unable to locate package mongodb-org

### DIFF
--- a/source/includes/steps-install-mongodb-on-ubuntu.yaml
+++ b/source/includes/steps-install-mongodb-on-ubuntu.yaml
@@ -45,7 +45,7 @@ action:
     pre: "Issue the following command:"
     language: sh
     code: |
-      sudo apt-get install -y mongodb-org
+      sudo apt-get install -y mongodb
   - heading:
       text: Install a specific release of MongoDB.
       character: "'"


### PR DESCRIPTION
Hi Team

I was going through official docs and could not install MongoDB on Ubuntu.

The only way I was able to get past was to change mongodb-org to mongodb and hence updated document.

Here are couple of SO post, where people want this change to be in official installation instructions. 
- https://stackoverflow.com/questions/29287915/mongodb-installation-in-ubuntu-14-04-falied/29298325#29298325
- http://stackoverflow.com/questions/28945921/e-unable-to-locate-package-mongodb-org/29756397#29756397