### PR TITLE
uses desired link for enterprise downloads

### DIFF
--- a/source/includes/steps-install-mongodb-enterprise-on-linux.yaml
+++ b/source/includes/steps-install-mongodb-enterprise-on-linux.yaml
@@ -8,7 +8,7 @@ ref: sequence
 pre: |
   After you have installed the required prerequisite packages, download
   and install the MongoDB Enterprise packages from
-  `<http://www.mongodb.com/thank-you/download/mongodb-enterprise>`_. The MongoDB
+  `<http://mongodb.com/download/>`_. The MongoDB
   binaries are located in the ``bin/`` directory of the archive. To download
   and install, use the following sequence of commands.
 ---


### PR DESCRIPTION
Needs backporting to 2.6 as well.