### PR TITLE
Update query-optimization.txt

### DIFF
--- a/source/core/query-optimization.txt
+++ b/source/core/query-optimization.txt
@@ -28,8 +28,8 @@ indexes in MongoDB </core/indexes>`.
       var typeValue = <someUserInput>;
       db.inventory.find( { type: typeValue } );
 
-   To improve the performance of this query, add an ascending, or a
-   descending, index to the ``inventory`` collection on the ``type``
+   To improve the performance of this query, add an ascending or a
+   descending index to the ``inventory`` collection on the ``type``
    field. [#ensureIndexOrder]_ In the :program:`mongo` shell, you can
    create indexes using the :method:`db.collection.createIndex()`
    method:


### PR DESCRIPTION
Comma usage was confusing before removing them.

Specifically, you do not separate two related items by a comma.  I don't know a rule for the other one, but imagine 'ascending index' without the series, it's an unnatural pause.