### PR TITLE
Update production-notes.txt

### DIFF
--- a/source/administration/production-notes.txt
+++ b/source/administration/production-notes.txt
@@ -298,6 +298,11 @@ To fully disable NUMA behavior, you must perform both operations. For more
 information, see the `Documentation for /proc/sys/vm/*
 <http://www.kernel.org/doc/Documentation/sysctl/vm.txt>`_.
 
+Configuring NUMA on Ubunutu
+```````````````````````````
+On Ubuntu, simply install "numactl" package and restart mongod. Upstart script will automatically 
+start mongo with correct parameters.
+
 Disk and Storage Systems
 ~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Received warning:
*\* WARNING: You are running on a NUMA machine.
*\*          We suggest launching mongod like this to avoid performance problems:
*\*              numactl --interleave=all mongod [other options]

After installation mongod 3.0.3 on Ubuntu 14.04. After checking how to enable it - found that upstart script (/etc/init/mongod.conf) taken care of it themself if package "numactl" is installed.

So, "apt-get install numactl && service mongod restart" fixed this warning, but I spend 10-20 minutes to dig it in... So, would like to save time to somebody else =)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2303)

<!-- Reviewable:end -->
