### PR TITLE
DOCS-5601: 3.0.4-rc0 release notes

### DIFF
--- a/config/build_conf.yaml
+++ b/config/build_conf.yaml
@@ -10,7 +10,7 @@ project:
   branched: true
   siteroot: true
 version:
-  release: '3.0.3'
+  release: '3.0.4-rc0'
   branch: '3.0'
 system:
   files:

--- a/source/release-notes/3.0-changelog.txt
+++ b/source/release-notes/3.0-changelog.txt
@@ -4,6 +4,90 @@
 
 .. default-domain:: mongodb
 
+.. _3.0.4-changelog:
+
+3.0.4 Changelog
+---------------
+
+Security
+~~~~~~~~
+
+- :issue:`SERVER-18475` \ :dbcommand:`authSchemaUpgrade` fails when the :data:`system.users <admin.system.users>` contains non ``MONGODB-CR`` users
+- :issue:`SERVER-18312` Upgrade PCRE to latest
+
+Querying
+~~~~~~~~
+
+- :issue:`SERVER-18364` Ensure non-negation predicates get chosen over negation predicates for multikey index bounds construction
+- :issue:`SERVER-16265` Add query details to getmore entry in profiler and :method:`db.currentOp()`
+- :issue:`SERVER-15225` ``CachedPlanStage`` should execute for trial period and re-plan if query performs poorly
+- :issue:`SERVER-13875` \ :method:`~db.collection.ensureIndex()` of ``2dsphere`` index breaks after upgrading to 2.6 (with the new :dbcommand:`createIndex` command)
+
+Replication
+~~~~~~~~~~~
+
+- :issue:`SERVER-18566` Primary member can trip fatal assertion if stepping down while running findAndModify op resulting in an upsert
+- :issue:`SERVER-18511` Report upstream progress when initial sync completes
+- :issue:`SERVER-18409` Retry failed heartbeats before marking a node as DOWN
+- :issue:`SERVER-18326` Rollback attempted during initial sync is fatal
+- :issue:`SERVER-17923` Creating/dropping multiple background indexes on the same collection can cause fatal error on secondaries
+- :issue:`SERVER-17913` New primary should log voters at default log level
+- :issue:`SERVER-17807` drain ops before restarting initial sync
+- :issue:`SERVER-15252` Write unit tests of ScatterGatherRunner
+- :issue:`SERVER-15192` Make all logOp listeners rollback-safe
+- :issue:`SERVER-18190` Secondary reads block replication
+- :issue:`SERVER-18566` Primary member can trip fatal assertion if stepping down while running :dbcommand:`findAndModify` op resulting in an upsert
+
+Sharding
+~~~~~~~~
+
+- :issue:`SERVER-18822` Sharded clusters with WiredTiger primaries may lose writes during chunk migration
+- :issue:`SERVER-18246` getmore on secondary in recovery mode can crash :program:`mongos`
+
+Storage
+~~~~~~~
+
+:issue:`SERVER-18442` better error message when attempting to change storage engine metadata options
+
+WiredTiger
+~~~~~~~~~~
+
+- :issue:`SERVER-18647` WiredTiger changes for MongoDB 3.0.4
+- :issue:`SERVER-18646` Avoid WiredTiger checkpointing dead handles
+- :issue:`SERVER-18629` WiredTiger journal system syncs wrong directory
+- :issue:`SERVER-18460` Segfault during eviction under load
+- :issue:`SERVER-18316` Database with WT engine fails to recover after system crash
+- :issue:`SERVER-18315` Throughput drop during transaction pinned phase of checkpoints under WiredTiger
+- :issue:`SERVER-18213` Lots of ``WriteConflict`` during multi-upsert with WiredTiger storage engine
+- :issue:`SERVER-18079` Large performance drop with documents > 16k on Windows
+- :issue:`SERVER-17944` ``WiredTigerRecordStore::truncate`` spends a lot of time sleeping
+
+HTTP Console
+~~~~~~~~~~~~
+
+:issue:`SERVER-18117` Bring back the _replSet page in the html interface
+
+Build and Packaging
+~~~~~~~~~~~~~~~~~~~
+
+- :issue:`SERVER-18894` OSX SSL builds should use unique filename
+- :issue:`SERVER-18421` Create SSL Builder for OS X
+- :issue:`SERVER-18312` Upgrade PCRE to latest
+- :issue:`SERVER-13596` Support --prefix rpm installation
+
+Internal Code
+~~~~~~~~~~~~~
+
+:issue:`SERVER-6826` Potential memory leak in ``ConnectionString::connect``
+
+Testing
+~~~~~~~
+
+- :issue:`SERVER-18318` Disable ``jsCore_small_oplog`` suite in Windows
+- :issue:`SERVER-17336` fix ``core/compact_keeps_indexes.js`` in a master/slave test configuration
+- :issue:`SERVER-13237` ``benchRun`` should use a thread-safe random number generator
+- :issue:`SERVER-18097` Remove ``mongosTest_auth`` and ``mongosTest_WT`` tasks from evergreen.yml
+
 .. _3.0.3-changelog:
 
 3.0.3 Changelog

--- a/source/release-notes/3.0.txt
+++ b/source/release-notes/3.0.txt
@@ -27,6 +27,30 @@ Minor Releases
 
       /release-notes/3.0-changelog
 
+.. _3.0.4-release-notes:
+
+3.0.4-rc0 -- June 10, 2015
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Fix missed writes with concurrent inserts during chunk migration
+  from shards with WiredTiger primaries: :issue:`SERVER-18822`
+
+- Resolve write conflicts with multi-update updates with
+  ``upsert=true`` with the Wired Tiger Storage engine:
+  :issue:`SERVER-18213`
+
+- Fix case where secondary reads could block replication:
+  :issue:`SERVER-18190`
+
+- Improve performance on Windows with WiredTiger and documents larger
+  than 16kb: :issue:`SERVER-18079`
+
+- Fix issue where WiredTiger data files are not correctly recovered
+  following unexpected system restarts: :issue:`SERVER-18316`
+
+- `All issues closed in 3.0.4
+  <https://jira.mongodb.org/issues/?jql=fixVersion%20%3D%20%223.0.4%22%20AND%20project%20%3D%20SERVER>`_
+
 .. _3.0.3-release-notes:
 
 3.0.3 -- May 12, 2015


### PR DESCRIPTION
Should probably update the version from 3.0.3 to 3.04-rc0 in the version
config, and then change the dates and version when GA goes out.