### PR TITLE
Update production-notes.txt

### DIFF
--- a/source/administration/production-notes.txt
+++ b/source/administration/production-notes.txt
@@ -31,7 +31,7 @@ Supported Platforms
 ~~~~~~~~~~~~~~~~~~~
 
 MongoDB distributions are currently available for Mac OS X, Linux,
-Windows Server 2008 R2 64bit, Windows 7 (64 bit), Windows Vista, and
+Windows Server 2012, Windows Server 2008 R2 64bit, Windows 7 (64 bit), Windows Vista, and
 Solaris. The MongoDB distribution for Solaris does not include support
 for the :ref:`WiredTiger storage engine <storage-wiredtiger>`.
 


### PR DESCRIPTION
Windows Server 2012 is listed as a recommended operating system for production deployments, and it should appear on the production notes page next to Windows Server 2008 R2.