### PR TITLE
Chunks can still migrate from a maxSize shard

### DIFF
--- a/source/tutorial/configure-sharded-cluster-balancer.txt
+++ b/source/tutorial/configure-sharded-cluster-balancer.txt
@@ -57,9 +57,9 @@ The ``maxSize`` field in the :data:`~config.shards` collection in the
 :ref:`config database <config-database>` sets the maximum size for a
 shard, allowing you to control whether the balancer will migrate chunks
 to a shard. If :data:`~serverStatus.mem.mapped` size [#local-limitation]_ is above a shard's
-``maxSize``, the balancer will not move chunks to the shard. Also, the
-balancer will not move chunks off an overloaded shard. This must happen
-manually. The ``maxSize`` value only affects the balancer's selection of
+``maxSize``, the balancer will not move chunks to the shard. The
+balancer will still move chunks off an overloaded shard, since the
+``maxSize`` value only affects the balancer's selection of
 destination shards.
 
 By default, ``maxSize`` is not specified, allowing shards to consume the


### PR DESCRIPTION
It is untrue that a shard which is over its maxSize value will _not_ have chunks migrated away from it.

This is correctly stated in the docs for the maxSize parameter for [addShard](http://docs.mongodb.org/manual/reference/command/addShard/), which says:

> The maxSize constraint prevents the balancer from migrating chunks to the shard when the value of mem.mapped exceeds the value of maxSize.

It is also easy to check empirically: start a 2 shard cluster, shard a collection, add `maxSize: 1` to the primary shard, then split once so there are 2 chunks, and observe that the balancer still migrates a chunk away from the primary (so that it's now 1 chunk on each shard).  If you manually move both chunks onto the _non-maxSize_ shard, the balancer will not move a chunk onto the maxSize shard (which is correct).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2312)
<!-- Reviewable:end -->
