### PR TITLE
Update query-optimization.txt

### DIFF
--- a/source/core/query-optimization.txt
+++ b/source/core/query-optimization.txt
@@ -141,7 +141,7 @@ An index **cannot** cover a query if:
 
 - any of the indexed fields in any of the documents in the collection
   includes an array. If an indexed field is an array, the index becomes
-  a :ref:`multi-key index <index-type-multikey>` index and cannot
+  a :ref:`multi-key index <index-type-multikey>` and cannot
   support a covered query.
 
 - any of the indexed field in the query predicate or returned in the


### PR DESCRIPTION
The reference ends with the word "index". The word "index" becomes redundant.