### PR TITLE
Fix various warnings

### DIFF
--- a/source/meta/includes.txt
+++ b/source/meta/includes.txt
@@ -1,8 +1,0 @@
-:orphan:
-
-.. This is entirely generated as to provide an introspective aid into
-   our generated content. See ``rstcloth/includes.py`` in the
-   docs-tools repository and ``/includes/metadata.yaml`` in this
-   repository for more information.
-
-.. include:: /includes/generated/overview.rst

--- a/source/release-notes/2.2.txt
+++ b/source/release-notes/2.2.txt
@@ -175,10 +175,8 @@ operations with the following improvements:
 #. :issue:`Improved Page Fault Detection on Windows <SERVER-4538>`
 
 To reflect these changes, MongoDB now provides changed and improved
-reporting for concurrency and use, see :ref:`locks` and
-:ref:`server-status-record-stats` in :doc:`server status
-</reference/command/serverStatus>` and see
-:method:`db.currentOp()`,
+reporting for concurrency and use. See :ref:`locks`, :v2.2:`recordStats
+</reference/server-status>`, :method:`db.currentOp()`,
 :doc:`mongotop </reference/program/mongotop>`, and :doc:`mongostat
 </reference/program/mongostat>`.
 


### PR DESCRIPTION
* Remove meta/includes.txt; we don't use it, and it clutters the log with an error and a warning
* Fix broken link in the 2.2 release notes