### PR TITLE
Minor documentation fix

### DIFF
--- a/source/reference/connection-string.txt
+++ b/source/reference/connection-string.txt
@@ -44,7 +44,7 @@ The components of this string are:
 
 #. ``host1``
 
-   This the only required part of the URI. It identifies a server
+   This is the second and final required part of the URI. It identifies a server
    address to connect to. It identifies either a hostname, IP address,
    or UNIX domain socket.
 


### PR DESCRIPTION
"is" was missing and since the prefix is a required part of the URI, "host" isn't the only required part.