### PR TITLE
`zypper addrepo` requires sudo

### DIFF
--- a/source/includes/steps-install-mongodb-on-suse.yaml
+++ b/source/includes/steps-install-mongodb-on-suse.yaml
@@ -14,7 +14,7 @@ action:
       Use the following command:
     language: sh
     code: |
-      zypper addrepo --no-gpgcheck https://repo.mongodb.org/zypper/suse/11/mongodb-org/3.0/x86_64/ mongodb
+      sudo zypper addrepo --no-gpgcheck https://repo.mongodb.org/zypper/suse/11/mongodb-org/3.0/x86_64/ mongodb
   - heading: For versions of MongoDB *earlier* than 3.0
     pre: |
       To install MongoDB packages from a previous :ref:`release
@@ -24,7 +24,7 @@ action:
       use the following command:
     language: sh
     code: |
-      zypper addrepo --no-gpgcheck http://downloads-distro.mongodb.org/repo/suse/os/x86_64/ mongodb
+      sudo zypper addrepo --no-gpgcheck http://downloads-distro.mongodb.org/repo/suse/os/x86_64/ mongodb
 ---
 title: Install the MongoDB packages and associated tools.
 stepnum: 2


### PR DESCRIPTION
The docs for enterprise (steps-install-mongodb-enterprise-on-suse.yaml) correctly state this.