### PR TITLE
Non-interactive SUSE installation

### DIFF
--- a/source/includes/steps-install-mongodb-enterprise-on-suse.yaml
+++ b/source/includes/steps-install-mongodb-enterprise-on-suse.yaml
@@ -31,7 +31,7 @@ action:
       command:
     language: sh
     code: |
-      sudo zypper install mongodb-enterprise
+      sudo zypper -n install mongodb-enterprise
   - pre: |
       To install a specific release of MongoDB, specify each
       component package individually and append the version number to the

--- a/source/includes/steps-install-mongodb-on-suse.yaml
+++ b/source/includes/steps-install-mongodb-on-suse.yaml
@@ -38,7 +38,7 @@ action:
       command:
     language: sh
     code: |
-      sudo zypper install mongodb-org
+      sudo zypper -n install mongodb-org
   - pre: |
       To install a specific release of MongoDB, specify each
       component package individually and append the version number to the


### PR DESCRIPTION
Installation instructions for other distros are non-interactive, so the SUSE ones should be also.  For zypper, this is `-n` aka `--non-interactive` (*before* the `install` sub-command).