### PR TITLE
spelling error

### DIFF
--- a/source/reference/method/WriteResult.txt
+++ b/source/reference/method/WriteResult.txt
@@ -85,7 +85,7 @@ The :method:`WriteResult` has the following properties:
       A document identifying the write concern setting related to the
       error.
 
-   .. data:: WriteResult.writeError.errmsg
+   .. data:: WriteResult.writeConcernError.errmsg
 
       A description of the error.
 


### PR DESCRIPTION
changed second WriteResult.writeError.errmsg to WriteResult.writeConcernError.errmsg