### PR TITLE
DOCS-5246: adds reference page for setVerboseShell() method

### DIFF
--- a/source/includes/ref-toc-method-native.yaml
+++ b/source/includes/ref-toc-method-native.yaml
@@ -78,6 +78,10 @@ name: ":method:`removeFile()`"
 file: /reference/method/removeFile
 description: "Removes the specified file from the local file system."
 ---
+name: ":method:`setVerboseShell()`"
+file: /reference/method/setVerboseShell
+description: "Configures the :program:`mongo` shell to report operation timing."
+---
 name: ":method:`_srand()`"
 file: /reference/method/srand
 description: "For internal use."

--- a/source/reference/method/setVerboseShell.txt
+++ b/source/reference/method/setVerboseShell.txt
@@ -1,0 +1,55 @@
+=================
+setVerboseShell()
+=================
+
+.. default-domain:: mongodb
+
+.. method:: setVerboseShell()
+
+   The :method:`setVerboseShell()` method configures the :program:`mongo`
+   shell to print the duration of each operation.
+
+   :method:`setVerboseShell()` has the form:
+   
+   .. code-block:: javascript
+   
+      setVerboseShell(true)
+
+   :method:`setVerboseShell()` takes one boolean parameter. Specify
+   ``true`` or leave the parameter blank to activate the verbose shell.
+   Specify ``false`` to deactivate.
+
+Example
+-------
+
+The following example demonstrates the behavior of the verbose shell:
+
+#. From the :program:`mongo` shell, set verbose shell to ``true``:
+
+   .. code-block:: sh
+   
+      setVerboseShell(true)
+
+#. With verbose shell set to ``true``, run :method:`db.collection.aggregate()`:
+
+   .. code-block:: sh
+
+      db.restaurants.aggregate(
+         [
+            { $match: { "borough": "Queens", "cuisine": "Brazilian" } },
+            { $group: { "_id": "$address.zipcode" , "count": { $sum: 1 } } }
+         ]
+      );
+
+#. In addition to returning the results of the operation, the
+   :program:`mongo` shell now displays information about the duration of
+   the operation:
+
+   .. code-block:: sh
+
+      { "_id" : "11377", "count" : 1 }
+      { "_id" : "11368", "count" : 1 }
+      { "_id" : "11101", "count" : 2 }
+      { "_id" : "11106", "count" : 3 }
+      { "_id" : "11103", "count" : 1 }
+      Fetched 5 record(s) in 0ms


### PR DESCRIPTION
This will either need redirects or to be backported to 2.4 / 2.6, if it existed in 2.4 (which I think it did?).