### PR TITLE
steps-install-mongodb-on-osx-with-homebrew old version

### DIFF
--- a/source/includes/steps-install-mongodb-on-osx-with-homebrew.yaml
+++ b/source/includes/steps-install-mongodb-on-osx-with-homebrew.yaml
@@ -21,7 +21,7 @@ action:
       system shell:
     language: sh
     code: |
-      brew install mongodb
+      brew install homebrew/versions/mongodb26
   - heading: Build MongoDB from Source with TLS/SSL Support
     pre: |
       To build MongoDB from the source files and include TLS/SSL support,


### PR DESCRIPTION
At this moment, if you want to install an older version with homebrew you have to manually specify the version.
