### PR TITLE
production-notes: tweak Linux NUMA disable

### DIFF
--- a/source/administration/production-notes.txt
+++ b/source/administration/production-notes.txt
@@ -284,21 +284,28 @@ Please consult your system documentation for details.
 Configuring NUMA on Linux
 `````````````````````````
 
-When running MongoDB on Linux, you may instead use the ``numactl``
-command and start the MongoDB programs (:program:`mongod`, including
-the :doc:`config servers </core/sharded-cluster-config-servers>`;
-:program:`mongos`; or clients) in the following manner:
+When running MongoDB on Linux, you should disable *zone reclaim* in the
+``sysctl`` settings using one of the following commands:
 
 .. code-block:: sh
 
-   numactl --interleave=all <path>
-
-where ``<path>`` is the path to the program you are starting. Then,
-disable *zone reclaim* in the ``proc`` settings using the following command:
+   echo 0 | sudo tee /proc/sys/vm/zone_reclaim_mode
 
 .. code-block:: sh
 
-   echo 0 > /proc/sys/vm/zone_reclaim_mode
+   sudo sysctl -w vm.zone_reclaim_mode=0
+
+Then, you should use the ``numactl`` command to start the MongoDB programs
+(:program:`mongod`, including the :doc:`config servers
+</core/sharded-cluster-config-servers>`; :program:`mongos`; and clients) in
+the following manner:
+
+.. code-block:: sh
+
+   numactl --interleave=all <path> <options>
+
+where ``<path>`` is the path to the program you are starting, and ``<options>``
+are any optional arguments to pass to the program.
 
 To fully disable NUMA behavior, you must perform both operations. For more
 information, see the `Documentation for /proc/sys/vm/*


### PR DESCRIPTION
1. Swap the order of the `numactl` and `zone_reclaim_mode` commands. This is better because if a user manually follows the old steps, they may run `numactl --interleave=all mongod` *before* fixing `zone_reclaim_mode`, and thereby still receive `zone_reclaim_mode` startup warnings.

2. Adjust the `zone_reclaim_mode` command to be an appropriate sudo-style command (simply prepending `sudo` won't work), indicating that the command needs to be run as root (and how).  Also provide a more modern `sysctl` based variant (again with sudo).

3. Add `<options>` to the `numactl` command to indicate that these can be specified if desired.

4. "may" -> "should"

5. "including ..., or clients" -> "including ..., and clients"