### PR TITLE
DOCS-6108: Make Ubuntu installation instructions more explicit

### DIFF
--- a/source/includes/steps-install-mongodb-enterprise-on-ubuntu.yaml
+++ b/source/includes/steps-install-mongodb-enterprise-on-ubuntu.yaml
@@ -9,10 +9,21 @@ stepnum: 2
 ref: sources-list
 action:
   - pre: |
-      Create the list file using the following command:
-    language: sh
-    code: |
-      echo "deb http://repo.mongodb.com/apt/ubuntu "$(lsb_release -sc)"/mongodb-enterprise/stable multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+      Create the list file using the command appropriate for your version of
+      Ubuntu:
+
+      Ubuntu 12.04
+
+      .. code-block:: sh
+
+          echo "deb http://repo.mongodb.com/apt/ubuntu precise/mongodb-enterprise/stable multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+
+      Ubuntu 14.04
+
+      .. code-block:: sh
+
+         echo "deb http://repo.mongodb.com/apt/ubuntu trusty/mongodb-enterprise/stable multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+
   - pre: |
       If you'd like to install MongoDB Enterprise packages from a
       particular :ref:`release series <release-version-numbers>`, such as

--- a/source/includes/steps-install-mongodb-on-ubuntu.yaml
+++ b/source/includes/steps-install-mongodb-on-ubuntu.yaml
@@ -17,10 +17,19 @@ ref: sources-list
 action:
   pre: |
     Create the ``/etc/apt/sources.list.d/mongodb-org-3.0.list`` list file using
-    the following command:
-  language: sh
-  code: |
-    echo "deb http://repo.mongodb.org/apt/ubuntu "$(lsb_release -sc)"/mongodb-org/3.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.0.list
+    the command appropriate for your version of Ubuntu:
+
+    Ubuntu 12.04
+
+    .. code-block:: sh
+
+        echo "deb http://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.0.list
+
+    Ubuntu 14.04
+
+    .. code-block:: sh
+
+       echo "deb http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.0.list
 ---
 title: Reload local package database.
 stepnum: 3


### PR DESCRIPTION
Deliberately left the enterprise "specific branch" instructions as-is; they're more "power-user" oriented, and I didn't want to clutter the step.