### PR TITLE
Any balancing may be a problem for sharded secondary reads

### DIFF
--- a/source/core/read-preference.txt
+++ b/source/core/read-preference.txt
@@ -81,9 +81,9 @@ reads, because:
   members of the set will need to be able to handle all application
   requests.
 
-- For queries of sharded collections, for clusters with the
-  :ref:`balancer <sharding-internals-balancing>` active, secondaries
-  may return stale
+- For queries of sharded collections, for clusters where the
+  :ref:`balancer <sharding-internals-balancing>` has at any time been
+  active, secondaries may return stale
   results with missing or duplicated data because of incomplete or
   terminated chunk migrations.
 


### PR DESCRIPTION
This means that sharded secondary reads are also a problem for systems where the balancer has been enabled and active in the past, even if it has subsequently been disabled.  In this case, all orphaned documents must be scanned for and removed (eg. via the cleanupOrphaned command).