### PR TITLE
DOCS-6120 Missing 'metrics' from serverStatus storage fields

### DIFF
--- a/source/reference/command/serverStatus.txt
+++ b/source/reference/command/serverStatus.txt
@@ -1470,21 +1470,21 @@ page.
    reports the total amount of time spent loading index entries as
    part of the *pre-fetch* stage of replication.
 
-.. data:: serverStatus.storage.freelist.search.bucketExhausted
+.. data:: serverStatus.metrics.storage.freelist.search.bucketExhausted
 
-   :data:`~serverStatus.storage.freelist.search.bucketExhausted` reports the
+   :data:`~serverStatus.metrics.storage.freelist.search.bucketExhausted` reports the
    number of times that :program:`mongod` has checked the free list without finding
    a suitably large record allocation.
 
-.. data:: serverStatus.storage.freelist.search.requests
+.. data:: serverStatus.metrics.storage.freelist.search.requests
 
-   :data:`~serverStatus.storage.freelist.search.requests` reports the
+   :data:`~serverStatus.metrics.storage.freelist.search.requests` reports the
    number of times :program:`mongod` has searched for available record
    allocations.
 
-.. data:: serverStatus.storage.freelist.search.scanned
+.. data:: serverStatus.metrics.storage.freelist.search.scanned
 
-   :data:`~serverStatus.storage.freelist.search.scanned` reports the number of
+   :data:`~serverStatus.metrics.storage.freelist.search.scanned` reports the number of
    available record allocations :program:`mongod` has searched.
 
 .. data:: serverStatus.metrics.ttl


### PR DESCRIPTION
DONE
-----
Added '.metrics' missing from serverStatus.'metrics'.storage.freelist.search.bucketExhausted
Added '.metrics' missing from serverStatus.'metrics'.storage.freelist.search.requests
Added '.metrics' missing from serverstatus.'metrics'.storage.freelist.search.scanned