### PR TITLE
FATAL is no longer a valid state in 3.0

### DIFF
--- a/source/reference/replica-states.txt
+++ b/source/reference/replica-states.txt
@@ -111,8 +111,3 @@ Members in any error state can't vote.
    members. In this case, the old primary member reverts those writes. During
    :doc:`rollback </core/replica-set-rollbacks>`, the member will have
    :replstate:`ROLLBACK` state.
-
-.. replstate:: FATAL
-
-   A member in :replstate:`FATAL` encountered an unrecoverable error.  The member must be shut down
-   and restarted; a resync may be required as well.


### PR DESCRIPTION
FATAL is no longer a valid state in 3.0. It does not need to be defined here since it is not mentioned as a valid state at the top in this page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2380)
<!-- Reviewable:end -->
