### PR TITLE
Fix GPG key reference in Debian/Ubuntu install instructions.

### DIFF
--- a/source/includes/steps-install-mongodb-on-debian.yaml
+++ b/source/includes/steps-install-mongodb-on-debian.yaml
@@ -7,7 +7,7 @@ action:
     <https://docs.mongodb.org/10gen-gpg-key.asc>`_ to the system key ring.
   language: sh
   code: |
-    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv 7F0CEB10
+    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv 24F3C978
 ---
 title: Create a ``/etc/apt/sources.list.d/mongodb-org-3.0.list`` file for MongoDB.
 stepnum: 2

--- a/source/includes/steps-install-mongodb-on-ubuntu.yaml
+++ b/source/includes/steps-install-mongodb-on-ubuntu.yaml
@@ -9,7 +9,7 @@ action:
     `MongoDB public GPG Key <https://docs.mongodb.org/10gen-gpg-key.asc>`_:
   language: sh
   code: |
-    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 24F3C978
 ---
 title: Create a list file for MongoDB.
 stepnum: 2


### PR DESCRIPTION
This was updated in the Verify Integrity of MongoDB Packages but not
here.  Without this fix the installation instructions fail.