### PR TITLE
DOCS-6306 - explain().aggregate() functionality clarification

### DIFF
--- a/source/includes/apiargs-method-db.collection.explain-param.yaml
+++ b/source/includes/apiargs-method-db.collection.explain-param.yaml
@@ -10,7 +10,10 @@ description: |
   For backwards compatibility with earlier versions of
   :method:`cursor.explain()`, MongoDB interprets ``true`` as
   ``"allPlansExecution"`` and ``false`` as ``"queryPlanner"``.
-
+  
+  :method:`aggregate() <db.collection.aggregate()>` ignores the verbosity
+  parameter and executes in ``queryPlanner`` mode.
+  
   For more information on the modes, see
   :ref:`explain-method-verbosity`.
 interface: method

--- a/source/reference/method/db.collection.explain.txt
+++ b/source/reference/method/db.collection.explain.txt
@@ -58,6 +58,9 @@ Verbosity Modes
 The behavior of :method:`db.collection.explain()` and the amount of
 information returned depend on the ``verbosity`` mode.
 
+:method:`~db.collection.aggregate()` ignores the verbosity 
+parameter and executes in ``queryPlanner`` mode.
+
 .. |explain| replace:: :method:`db.collection.explain()`
 .. |operation| replace:: method
 


### PR DESCRIPTION
explain().aggregate() only returns queryPlanner verbosity mode at this time