### PR TITLE
DOCS-5986 : Remove documentation of $query and $<options>

### DIFF
--- a/source/includes/ref-toc-method-cursor.yaml
+++ b/source/includes/ref-toc-method-cursor.yaml
@@ -1,7 +1,3 @@
-name: ":method:`cursor.addOption()`"
-file: /reference/method/cursor.addOption
-description: "Adds special wire protocol flags that modify the behavior of the query.'"
----
 name: ":method:`cursor.batchSize()`"
 file: /reference/method/cursor.batchSize
 description: "Controls the number of documents MongoDB will return to the client in a single network message."

--- a/source/reference/method/cursor.addOption.txt
+++ b/source/reference/method/cursor.addOption.txt
@@ -4,6 +4,12 @@ cursor.addOption()
 
 .. default-domain:: mongodb
 
+.. deprecated:: 3.2
+
+   :method:`cursor.addOption()` is deprecated.
+   Use the available :doc:`cursor methods </reference/method/js-cursor>` to 
+   change the behavior of a query.
+
 Definition
 ----------
 
@@ -11,68 +17,3 @@ Definition
 
    Adds ``OP_QUERY`` wire protocol flags, such as the ``tailable``
    flag, to change the behavior of queries.
-
-   The :method:`cursor.addOption()` method has the following parameter:
-
-   .. include:: /includes/apiargs/method-cursor.addOption-param.rst
-
-.. _cursor-flags:
-
-Flags
------
-
-The :program:`mongo` shell provides several additional cursor flags to
-modify the behavior of the cursor.
-
-.. list-table::
-   :header-rows: 1
-   :widths: 30 70
-
-   * - Flag
-     - Description
-
-   * - .. data:: DBQuery.Option.tailable
-     - Sets the cursor not to close once the last data is
-       received, allowing the query to continue returning data added
-       after the initial results were exhausted.
-
-   * - .. data:: DBQuery.Option.slaveOk
-     - Allows querying of a replica slave.
-
-   * - .. data:: DBQuery.Option.noTimeout
-     - Prevents the server from timing out idle cursors.
-
-   * - .. data:: DBQuery.Option.awaitData
-     - For use with .. data:: DBQuery.Option.tailable; sets the cursor
-       to block and await data for a while rather than returning no
-       data. The cursor will return no data once the timeout has
-       expired.
-
-   * - .. data:: DBQuery.Option.exhaust
-     - Sets the cursor to return all data returned by the
-       query at once rather than splitting the results into batches.
-
-   * - .. data:: DBQuery.Option.partial
-     - Sets the cursor to return partial data from a query against a
-       sharded cluster in which some shards do not respond rather than
-       throwing an error.
-
-Example
--------
-
-The following example adds the ``DBQuery.Option.tailable`` flag and the
-``DBQuery.Option.awaitData`` flag to ensure that the query returns a
-:term:`tailable cursor`. The sequence creates a cursor that will wait for few
-seconds after returning the full result set so that it can capture and
-return additional data added during the query:
-
-.. code-block:: javascript
-
-   var t = db.myCappedCollection;
-   var cursor = t.find().addOption(DBQuery.Option.tailable).
-                         addOption(DBQuery.Option.awaitData)
-
-.. warning::
-
-   Adding incorrect wire protocol flags can cause problems and/or
-   extra server load.

--- a/source/reference/operator/meta/comment.txt
+++ b/source/reference/operator/meta/comment.txt
@@ -6,21 +6,12 @@ $comment
 
 .. operator:: $comment
 
+   .. deprecated:: 3.2
+
+      The :operator:`$comment` operator is deprecated.
+      Use :method:`cursor.comment()` instead.
+
    The :operator:`$comment` meta-operator makes it possible to attach a comment
    to a query in any context that :operator:`$query` may appear.
 
    .. include:: /includes/fact-comment-reason.rst
-
-   Use :operator:`$comment` in one of the following ways:
-
-   .. code-block:: javascript
-
-      db.collection.find( { <query> } )._addSpecial( "$comment", <comment> )
-      db.collection.find( { <query> } ).comment( <comment> )
-      db.collection.find( { $query: { <query> }, $comment: <comment> } )
-
-   To attach comments to query expressions in other contexts, such as
-   :method:`db.collection.update()`, use the :query:`$comment` query
-   operator instead of the meta-operator.
-
-.. seealso:: :query:`$comment` query operator

--- a/source/reference/operator/meta/explain.txt
+++ b/source/reference/operator/meta/explain.txt
@@ -3,61 +3,19 @@ $explain
 ========
 
 .. default-domain:: mongodb
-
-.. EDITS to explain.txt must be carried over to the method
-   cursor.explain.txt and vice versa
+   
 
 .. operator:: $explain
 
    .. deprecated:: 3.0
+
+      The :operator:`$explain` operator is deprecated.
       Use :method:`db.collection.explain()` or
-      :method:`cursor.explain()` instead
+      :method:`cursor.explain()` instead.
+   
 
    The :operator:`$explain` operator provides information on the query
    plan. It returns a document that describes
    the process and indexes used to return the query. This may provide
    useful insight when attempting to optimize a query.
    For details on the output, see :doc:`/reference/method/cursor.explain`.
-
-   You can specify the :operator:`$explain` operator in either of the
-   following forms:
-
-   .. code-block:: javascript
-
-       db.collection.find()._addSpecial( "$explain", 1 )
-       db.collection.find( { $query: {}, $explain: 1 } )
-
-   In the :program:`mongo` shell, you also can retrieve query plan
-   information through the :method:`~cursor.explain()` method:
-
-   .. code-block:: javascript
-
-      db.collection.find().explain()
-
-Behavior
---------
-
-:operator:`$explain` runs the actual query to determine the result.
-Although there are some differences between running the query with
-:operator:`$explain` and running without, generally, the performance
-will be similar between the two. So, if the query is slow, the
-:operator:`$explain` operation is also slow.
-
-Additionally, the :operator:`$explain` operation reevaluates a set
-of candidate query plans, which may cause the :operator:`$explain`
-operation to perform differently than a normal query. As a result,
-these operations generally provide an accurate account of *how*
-MongoDB would perform the query, but do not reflect the length of
-these queries.
-
-.. seealso::
-
-   - :method:`~cursor.explain()`
-
-   - :doc:`/administration/optimization` page for information
-     regarding optimization strategies.
-
-   - :doc:`/tutorial/manage-the-database-profiler` tutorial for
-     information regarding the database profile.
-
-   - :doc:`Current Operation Reporting </reference/method/db.currentOp>`

--- a/source/reference/operator/meta/hint.txt
+++ b/source/reference/operator/meta/hint.txt
@@ -6,6 +6,11 @@ $hint
 
 .. operator:: $hint
 
+   .. deprecated:: 3.2
+
+      The :operator:`$hint` operator is deprecated. 
+      Use :method:`cursor.hint()` instead.
+
    The :operator:`$hint` operator forces the :ref:`query optimizer
    <read-operations-query-optimization>` to use a specific index to
    fulfill the query. Specify the index either by the index name or by
@@ -14,39 +19,3 @@ $hint
    Use :operator:`$hint` for testing query performance and indexing
    strategies. The :program:`mongo` shell provides a helper method
    :method:`~cursor.hint()` for the :operator:`$hint` operator.
-
-   Consider the following operation:
-
-   .. code-block:: javascript
-
-      db.users.find().hint( { age: 1 } )
-
-   This operation returns all documents in the collection named
-   ``users`` using the index on the ``age`` field.
-
-   You can also specify a hint using either of the following forms:
-
-   .. code-block:: javascript
-
-      db.users.find()._addSpecial( "$hint", { age : 1 } )
-      db.users.find( { $query: {}, $hint: { age : 1 } } )
-
-   .. note::
-
-      When the query specifies the :operator:`$hint` in the following
-      form:
-
-      .. code-block:: javascript
-
-         db.users.find( { $query: {}, $hint: { age : 1 } } )
-
-      Then, in order to include the :operator:`$explain` option, you
-      must add the :operator:`$explain` option to the document, as in
-      the following:
-
-      .. code-block:: javascript
-
-         db.users.find( { $query: {}, $hint: { age : 1 }, $explain: 1 } )
-
-   When an :ref:`index filter <index-filters>` exists for the query
-   shape, MongoDB ignores the :operator:`$hint`.

--- a/source/reference/operator/meta/max.txt
+++ b/source/reference/operator/meta/max.txt
@@ -9,105 +9,15 @@ Definition
 
 .. operator:: $max
 
+   .. deprecated:: 3.2
+
+      The :operator:`$max` operator is deprecated.
+      Use :method:`cursor.max()` instead.
+
    Specify a :operator:`$max` value to specify the *exclusive* upper
    bound for a specific index in order to constrain the results of
    :method:`~db.collection.find()`. The :operator:`$max` specifies the
    upper bound for *all* keys of a specific index *in order*.
 
    The :program:`mongo` shell provides the :method:`~cursor.max()`
-   wrapper method:
-
-   .. code-block:: javascript
-
-      db.collection.find( { <query> } ).max( { field1: <max value>, ... fieldN: <max valueN> } )
-
-   You can also specify :operator:`$max` with either of the two forms:
-
-   .. code-block:: javascript
-
-      db.collection.find( { <query> } )._addSpecial( "$max", { field1: <max value1>, ... fieldN: <max valueN> } )
-      db.collection.find( { $query: { <query> }, $max: { field1: <max value1>, ... fieldN: <max valueN> } } )
-
-Behavior
---------
-
-Interaction with Index Selection
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Because :method:`~cursor.max()` requires an index on a field, and
-forces the query to use this index, you may prefer the
-:query:`$lt` operator for the query if possible. Consider the
-following example:
-
-.. code-block:: javascript
-
-   db.collection.find( { _id: 7 } ).max( { age: 25 } )
-
-The query uses the index on the ``age`` field, even if the
-index on ``_id`` may be better.
-
-Index Bounds
-~~~~~~~~~~~~
-
-If you use :operator:`$max` with :operator:`$min` to specify a range,
-the index bounds specified in :operator:`$min` and :operator:`$max`
-must both refer to the keys of the same index.
-
-``$max`` without ``$min``
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. include:: /includes/fact-query-min-max.rst
-
-Examples
---------
-
-The following examples use the :program:`mongo` shell wrappers.
-
-Specify Exclusive Upper Bound
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Consider the following operations on a collection named
-``collection`` that has an index ``{ age: 1 }``:
-
-.. code-block:: javascript
-
-   db.collection.find( { <query> } ).max( { age: 100 } )
-
-This operation limits the query to those documents where the
-field ``age`` is less than ``100`` and forces a query plan which scans the
-``{ age: 1 }`` index from :bsontype:`MinKey <data_minkey>` to 100.
-
-Index Selection
-~~~~~~~~~~~~~~~
-
-You can explicitly specify the corresponding index with
-:method:`~cursor.hint()`. Otherwise, MongoDB selects the index using
-the fields in the :operator:`$max` and :operator:`$min` bounds;
-however, if multiple indexes exist on same fields with different sort
-orders, the selection of the index may be ambiguous.
-
-Consider a collection named ``collection`` that has the following
-two indexes:
-
-.. code-block:: javascript
-
-   { age: 1, type: -1 }
-   { age: 1, type: 1 }
-
-Without explicitly using :method:`~cursor.hint()`, MongoDB may
-select either index for the following operation:
-
-.. code-block:: javascript
-
-   db.collection.find().max( { age: 50, type: 'B' } )
-
-Use with ``$min``
-~~~~~~~~~~~~~~~~~
-
-Use :operator:`$max` alone or in conjunction with :operator:`$min` to
-limit results to a specific range for the *same* index, as in the
-following example:
-
-.. code-block:: javascript
-
-   db.collection.find().min( { age: 20 } ).max( { age: 25 } )
+   wrapper method.

--- a/source/reference/operator/meta/maxScan.txt
+++ b/source/reference/operator/meta/maxScan.txt
@@ -6,13 +6,10 @@ $maxScan
 
 .. operator:: $maxScan
 
+   .. deprecated:: 3.2
+
+      The :operator:`$maxScan` operator is deprecated.
+      Use :method:`cursor.maxScan()` instead.
+
    Constrains the query to only scan the specified number of documents
-   when fulfilling the query. Use one of the following forms:
-
-   .. code-block:: javascript
-
-      db.collection.find( { <query> } )._addSpecial( "$maxScan" , <number> )
-      db.collection.find( { $query: { <query> }, $maxScan: <number> } )
-
-   Use this modifier to prevent potentially long running queries from
-   disrupting performance by scanning through too much data.
+   when fulfilling the query.

--- a/source/reference/operator/meta/maxTimeMS.txt
+++ b/source/reference/operator/meta/maxTimeMS.txt
@@ -6,6 +6,11 @@ $maxTimeMS
 
 .. operator:: $maxTimeMS
 
+   .. deprecated:: 3.2
+
+      The :operator:`$maxTimeMS` operator is deprecated.
+      Use :method:`cursor.maxTimeMS()` instead.
+
    .. versionadded:: 2.6
       The :operator:`$maxTimeMS` operator specifies a cumulative
       time limit in milliseconds for processing operations on the
@@ -13,21 +18,3 @@ $maxTimeMS
       following :term:`interrupt point`.
 
    The :program:`mongo` shell provides the :method:`cursor.maxTimeMS()` method
-
-   .. code-block:: javascript
-
-      db.collection.find().maxTimeMS(100)
-
-   You can also specify the option in either of the following forms:
-
-   .. code-block:: javascript
-
-      db.collection.find( { $query: { }, $maxTimeMS: 100 } )
-      db.collection.find( { } )._addSpecial("$maxTimeMS", 100)
-
-   Interrupted operations return an error message similar to the
-   following:
-
-   .. code-block:: javascript
-
-      error: { "$err" : "operation exceeded time limit", "code" : 50 }

--- a/source/reference/operator/meta/min.txt
+++ b/source/reference/operator/meta/min.txt
@@ -9,105 +9,16 @@ Definition
 
 .. operator:: $min
 
+   .. deprecated:: 3.2
+
+      The :operator:`$min` operator is deprecated.
+      Use :method:`cursor.min()` instead. 
+   
+
    Specify a :operator:`$min` value to specify the *inclusive* lower
    bound for a specific index in order to constrain the results of
    :method:`~db.collection.find()`. The :operator:`$min` specifies the
    lower bound for *all* keys of a specific index *in order*.
 
    The :program:`mongo` shell provides the :method:`~cursor.min()`
-   wrapper method:
-
-   .. code-block:: javascript
-
-      db.collection.find( { <query> } ).min( { field1: <min value>, ... fieldN: <min valueN>} )
-
-   You can also specify the option with either of the two forms:
-
-   .. code-block:: javascript
-
-      db.collection.find( { <query> } )._addSpecial( "$min", { field1: <min value1>, ... fieldN: <min valueN> } )
-      db.collection.find( { $query: { <query> }, $min: { field1: <min value1>, ... fieldN: <min valueN> } } )
-
-Behavior
---------
-
-Interaction with Index Selection
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Because :method:`~cursor.min()` requires an index on a field, and
-forces the query to use this index, you may prefer the
-:query:`$gte` operator for the query if possible. Consider the
-following example:
-
-.. code-block:: javascript
-
-   db.collection.find( { _id: 7 } ).min( { age: 25 } )
-
-The query will use the index on the ``age`` field, even if the
-index on ``_id`` may be better.
-
-Index Bounds
-~~~~~~~~~~~~
-
-If you use :operator:`$max` with :operator:`$min` to specify a range,
-the index bounds specified in :operator:`$min` and :operator:`$max`
-must both refer to the keys of the same index.
-
-``$min`` without ``$max``
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. include:: /includes/fact-query-min-max.rst
-
-Examples
---------
-
-The following examples use the :program:`mongo` shell wrappers.
-
-Specify Inclusive Lower Bound
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Consider the following operations on a collection named
-``collection`` that has an index ``{ age: 1 }``:
-
-.. code-block:: javascript
-
-   db.collection.find().min( { age: 20 } )
-
-This operation limits the query to those documents where the
-field ``age`` is at least ``20`` and forces a query plan which scans the
-``{ age: 1 }`` index from 20 to :bsontype:`MaxKey <data_maxkey>`.
-
-Index Selection
-~~~~~~~~~~~~~~~
-
-You can explicitly specify the corresponding index with
-:method:`~cursor.hint()`. Otherwise, MongoDB selects the index using
-the fields in the :operator:`$max` and :operator:`$min` bounds; however, if
-multiple indexes exist on same fields with different sort orders, the selection
-of the index may be ambiguous.
-
-Consider a collection named ``collection`` that has the following
-two indexes:
-
-.. code-block:: javascript
-
-   { age: 1, type: -1 }
-   { age: 1, type: 1 }
-
-Without explicitly using :method:`~cursor.hint()`, it is unclear
-which index the following operation will select:
-
-.. code-block:: javascript
-
-   db.collection.find().min( { age: 20, type: 'C' } )
-
-Use with ``$max``
-~~~~~~~~~~~~~~~~~
-
-You can use :operator:`$min` in conjunction with :operator:`$max` to
-limit results to a specific range for the *same* index, as in the
-following example:
-
-.. code-block:: javascript
-
-   db.collection.find().min( { age: 20 } ).max( { age: 25 } )
+   wrapper method.

--- a/source/reference/operator/meta/orderby.txt
+++ b/source/reference/operator/meta/orderby.txt
@@ -4,41 +4,12 @@ $orderby
 
 .. default-domain:: mongodb
 
-.. query:: $orderby
+.. operator:: $orderby
+
+   .. deprecated:: 3.2
+
+      The :operator:`$orderby` operator is deprecated.
+      Use :method:`cursor.sort()` instead.
 
    The :operator:`$orderby` operator sorts the results of a query in
    ascending or descending order.
-
-   The :program:`mongo` shell provides the :method:`cursor.sort()`
-   method:
-
-   .. code-block:: javascript
-
-      db.collection.find().sort( { age: -1 } )
-
-   You can also specify the option in either of the following forms:
-
-   .. code-block:: javascript
-
-      db.collection.find()._addSpecial( "$orderby", { age : -1 } )
-      db.collection.find( { $query: {}, $orderby: { age : -1 } } )
-
-   These examples return all documents in the collection named
-   ``collection`` sorted by the ``age`` field in descending order.
-   Specify a value to :operator:`$orderby` of negative one (e.g.
-   ``-1``, as above) to sort in descending order or a positive value
-   (e.g. ``1``) to sort in ascending order.
-
-Behavior
---------
-
-The sort function requires that the entire sort be able to complete
-within 32 megabytes. When the sort option consumes more than 32
-megabytes, MongoDB will return an error.
-
-To avoid this error, create an index to support the sort operation or
-use :operator:`$orderby` in conjunction with :operator:`$maxScan`
-and/or :method:`cursor.limit()`. The :method:`cursor.limit()` increases
-the speed and reduces the amount of memory required to return this
-query by way of an optimized algorithm. The specified limit must result
-in a number of documents that fall within the 32 megabyte limit.

--- a/source/reference/operator/meta/query.txt
+++ b/source/reference/operator/meta/query.txt
@@ -9,55 +9,11 @@ Definition
 
 .. operator:: $query
 
+   .. deprecated:: 3.2
+
+      The :operator:`$query` operator is deprecated. Use the 
+      :doc:`cursor methods</reference/method/js-cursor>` to apply options to a 
+      cursor.
+   
    The :operator:`$query` operator forces MongoDB to interpret an expression
    as a query.
-
-   The following :program:`mongo` operations are equivalent, and
-   return only those documents in the collection named ``collection`` where the
-   ``age`` field equals ``25``.
-
-   .. code-block:: javascript
-
-      db.collection.find( { $query: { age : 25 } } )
-      db.collection.find( { age : 25 } )
-
-   :operator:`$query` is necessary to work with documents that contain a field
-   name ``query`` whose value is an embedded document, such as the following document:
-
-   .. code-block:: javascript
-
-      { _id: 1, age: 25, query: { a: 1 } }
-
-   The following find operation that does not use the :operator:`$query`
-   operator will return no results:
-
-   .. code-block:: javascript
-
-      db.documents.find( { query: { a: 1 } } )
-
-   To obtain the document, you will need to use the following query:
-
-   .. code-block:: javascript
-
-      db.documents.find( { "$query": { query: { a: 1 } } } )
-
-   .. seealso:: For more information about queries in MongoDB see
-      :doc:`/core/read-operations`,
-      :method:`db.collection.find()`, and `Getting Started with MongoDB
-      <http://docs.mongodb.org/getting-started/shell>`_.
-
-   .. note::
-
-      Do not mix query forms. If you use the :operator:`$query`
-      format, do not append :ref:`cursor methods
-      <js-query-cursor-methods>` to the
-      :method:`~db.collection.find()`. To modify the query use the
-      :doc:`meta-query operators </reference/operator/query-modifier>`,
-      such as :operator:`$explain`.
-
-      Therefore, the following two operations are equivalent:
-
-      .. code-block:: javascript
-
-         db.collection.find( { $query: { age : 25 }, $explain: true } )
-         db.collection.find( { age : 25 } ).explain()

--- a/source/reference/operator/meta/returnKey.txt
+++ b/source/reference/operator/meta/returnKey.txt
@@ -6,6 +6,11 @@ $returnKey
 
 .. operator:: $returnKey
 
+   .. deprecated:: 3.2
+
+      The :operator:`$returnKey` operator is deprecated. 
+      Use :method:`cursor.returnKey()` instead.
+
    Only return the index field or fields for the results of the query. If
    :operator:`$returnKey` is set to ``true`` and the query does not use
    an index to perform the read operation, the returned documents will

--- a/source/reference/operator/meta/snapshot.txt
+++ b/source/reference/operator/meta/snapshot.txt
@@ -6,6 +6,11 @@ $snapshot
 
 .. operator:: $snapshot
 
+   .. deprecated:: 3.2
+
+      The :operator:`$snapshot` operator is deprecated. 
+      Use :method:`cursor.snapshot()` instead.
+
    The :operator:`$snapshot` operator prevents the cursor from
    returning a document more than once because an intervening write
    operation results in a move of the document.
@@ -14,31 +19,4 @@ $snapshot
    lifetime of the cursor may or may not be returned.
 
    The :program:`mongo` shell provides the :method:`cursor.snapshot()`
-   method:
-
-   .. code-block:: javascript
-
-      db.collection.find().snapshot()
-
-   You can also specify the option in either of the following forms:
-
-   .. code-block:: javascript
-
-      db.collection.find()._addSpecial( "$snapshot", true )
-      db.collection.find( { $query: {}, $snapshot: true } )
-
-   The :operator:`$snapshot` operator traverses the index on the
-   ``_id`` field [#snapshot-alternative]_.
-
-   .. warning::
-
-      - You cannot use :operator:`$snapshot` with :term:`sharded
-        collections <sharding>`.
-
-      - Do **not** use :operator:`$snapshot` with :operator:`$hint` or
-        :operator:`$orderby` (or the corresponding
-        :method:`cursor.hint()` and :method:`cursor.sort()` methods.)
-
-   .. [#snapshot-alternative] You can achieve the
-      :operator:`$snapshot` isolation behavior using any *unique*
-      index on invariable fields.
+   method.

--- a/source/reference/operator/query-modifier.txt
+++ b/source/reference/operator/query-modifier.txt
@@ -7,19 +7,8 @@ Query Modifiers
 Introduction
 ------------
 
-In addition to the :doc:`MongoDB Query Operators
-</reference/operator>`, there are a number of "meta" operators that
-let you modify the output or behavior of a query. On the server,
-MongoDB treats the query and the options as a single object. The
-:program:`mongo` shell and driver interfaces may provide :ref:`cursor methods
-<js-query-cursor-methods>` that wrap these options. When possible, use these
-methods; otherwise, you can add these options using either of the
-following syntax:
-
-.. code-block:: javascript
-
-   db.collection.find( { <query> } )._addSpecial( <option> )
-   db.collection.find( { $query: { <query> }, <option> } )
+MongoDB provides :doc:`cursor methods </reference/method/js-cursor>` for 
+setting options on a query.
 
 Operators
 ---------
@@ -27,13 +16,7 @@ Operators
 Modifiers
 ~~~~~~~~~
 
-Many of these operators have corresponding :ref:`methods in the shell
-<js-query-cursor-methods>`. These methods provide a straightforward and
-user-friendly interface and are the preferred way to add these options.
-
-.. include:: /includes/toc/table-operator-meta.rst
-
-.. include:: /includes/toc/operator-meta.rst
+See :doc:`/reference/method/js-cursor` for query modifiers.
 
 Sort Order
 ~~~~~~~~~~


### PR DESCRIPTION
Round 2: CR changes

Round 1:

* Added 'deprecated' warnings to $<options>
* Removed cursor.addOption(), added deprecation warning