### PR TITLE
Adding "or"

### DIFF
--- a/source/core/security-internal-authentication.txt
+++ b/source/core/security-internal-authentication.txt
@@ -9,7 +9,7 @@ Internal Authentication
 
 You can authenticate members of :term:`replica sets <replica set>` and
 :term:`sharded clusters <sharded cluster>`. For the internal authentication of
-the members, MongoDB can use either keyfiles :ref:`x.509 <security-auth-x509>`
+the members, MongoDB can use either keyfiles or :ref:`x.509 <security-auth-x509>`
 certificates.
 
 .. note::


### PR DESCRIPTION
Should add an "or" between "keyfiles x509 certificates" because they are two separate items.