### PR TITLE
DOCS-6106: document indexOptionDefaults

### DIFF
--- a/source/includes/apiargs-dbcommand-create-field.yaml
+++ b/source/includes/apiargs-dbcommand-create-field.yaml
@@ -110,4 +110,13 @@ arg_name: field
 interface: dbcommand
 operation: create
 position: 10
+---
+name: indexOptionDefaults
+source:
+   file: apiargs-method-db.createCollection-options-param.yaml
+   ref: indexOptionDefaults
+arg_name: field
+interface: dbcommand
+operation: create
+position: 11
 ...

--- a/source/includes/apiargs-method-db.createCollection-options-param.yaml
+++ b/source/includes/apiargs-method-db.createCollection-options-param.yaml
@@ -138,7 +138,7 @@ description: |
   validation rules or expressions. You can specify the expressions using
   the same operators as the :ref:`query operators <query-selectors>`
   with the exception of :query:`$geoNear`, :query:`$near`,
-  :query:`$nearSphere`, :query:`$text`, ahd :query:`$where`.
+  :query:`$nearSphere`, :query:`$text`, and :query:`$where`.
 
   .. note::
 
@@ -193,4 +193,30 @@ operation: db.createCollection
 optional: true
 position: 10
 type: string
+---
+name: indexOptionDefaults
+arg_name: field
+description: |
+  Allows users to specify a default configuration for indexes when
+  creating a collection.
+
+  The ``indexOptionDefaults`` option accepts a ``storageEngine``
+  document, which should take the following form:
+
+  .. code-block:: javascript
+
+     { <storage-engine-name>: <options> }
+
+  Storage engine configuration specified when creating indexes are
+  validated and logged to the :term:`oplog` during replication to
+  support replica sets with members that use different storage
+  engines.
+
+  .. versionadded:: 3.2
+
+interface: method
+operation: db.createCollection
+optional: true
+position: 11
+type: document
 ...

--- a/source/reference/command/create.txt
+++ b/source/reference/command/create.txt
@@ -26,7 +26,8 @@ Definition
         storageEngine: <document>,
         validator: <document>,
         validationLevel: <string>,
-        validationAction: <string>
+        validationAction: <string>,
+        indexOptionDefaults: <document>
       }
 
    :dbcommand:`create` has the following fields:

--- a/source/reference/method/db.createCollection.txt
+++ b/source/reference/method/db.createCollection.txt
@@ -32,7 +32,8 @@ Definition
                                     storageEngine: <document>,
                                     validator: <document>,
                                     validationLevel: <string>,
-                                    validationAction: <string> } )
+                                    validationAction: <string>,
+                                    indexOptionDefaults: <document> } )
 
    The :method:`db.createCollection()` method has the following parameters:
 


### PR DESCRIPTION
This adds documentation for the `indexOptionDefaults` option for the `create`
command and its shell helper, `db.createCommand()`.