### PR TITLE
Updated link of snappy to the new project page

### DIFF
--- a/source/reference/glossary.txt
+++ b/source/reference/glossary.txt
@@ -877,7 +877,7 @@ Glossary
       Snappy is the default compression
       library for MongoDB's use of :ref:`WiredTiger
       <storage-wiredtiger>`. See `Snappy
-      <https://code.google.com/p/snappy/>`_ and the `WiredTiger compression
+      <https://google.github.io/snappy/>`_ and the `WiredTiger compression
       documentation <http://source.wiredtiger.com/2.4.1/compression.html>`_
       for more information.
 


### PR DESCRIPTION
On the old link there is a notice that the project has moved:
https://code.google.com/hosting/moved?project=snappy