### PR TITLE
Fix update query example in doc

### DIFF
--- a/source/reference/method/Bulk.find.updateOne.txt
+++ b/source/reference/method/Bulk.find.updateOne.txt
@@ -41,7 +41,7 @@ If the ``<update>`` document contains only :ref:`update operator
 
    {
      $set: { status: "D" },
-     points: { $inc: 2 }
+     $inc: { points: 2 }
    }
 
 Then, :method:`Bulk.find.updateOne()` updates only the corresponding


### PR DESCRIPTION
This fix in the bulk.find.updateOne() doc.
The correct syntax for $inc operator is:
{ $inc: { field1: amount1 } }