### PR TITLE
DOCS-6486: readConcern shell helper for find/count

### DIFF
--- a/source/includes/apiargs-method-cursor.readConcern-param.yaml
+++ b/source/includes/apiargs-method-cursor.readConcern-param.yaml
@@ -1,0 +1,11 @@
+name: level
+arg_name: param
+description: |
+  One of the following :term:`read concern` modes: :readconcern:`"local"` or
+  :readconcern:`"majority"`
+interface: method
+operation: cursor.readConcern
+optional: true
+position: 1
+type: string
+...

--- a/source/includes/ref-toc-method-cursor.yaml
+++ b/source/includes/ref-toc-method-cursor.yaml
@@ -66,6 +66,10 @@ name: ":method:`cursor.pretty()`"
 file: /reference/method/cursor.pretty
 description: "Configures the cursor to display results in an easy-to-read format."
 ---
+name: ":method:`cursor.readConcern()`"
+file: /reference/method/cursor.readConcern
+description: "Specifies a :term:`read concern` for a :method:`find() <db.collection.find()>` or :method:`count() <db.collection.count()>` operation."
+---
 name: ":method:`cursor.readPref()`"
 file: /reference/method/cursor.readPref
 description: "Specifies a :term:`read preference` to a cursor to control how the client directs queries to a :term:`replica set`."

--- a/source/reference/command/find.txt
+++ b/source/reference/command/find.txt
@@ -101,9 +101,12 @@ confirmed as having been written to a majority of the nodes.
       }
    )
 
-The :program:`mongo` shell method :method:`db.collection.find()` does not
-support ``readConcern``; however, drivers updated for 3.2 may provide
-support for ``readConcern`` in their respective ``find`` method. Refer to
-your specific driver for details.
-       
+A ``readConcern`` can be specified for the :program:`mongo` shell method
+:method:`db.collection.find()` using the :method:`cursor.readConcern`
+method:
+
+.. code-block:: javascript
+
+   db.restaurants.find( { rating: { $lt: 5 } } ).readConcern("majority")
+
 .. seealso:: :ref:`3.2-driver-compatibility`

--- a/source/reference/glossary.txt
+++ b/source/reference/glossary.txt
@@ -737,6 +737,12 @@ Glossary
       type: 'food' }`` is equivalent to the query predicate ``{ type:
       'utensil' }`` for a query shape.
 
+   read concern
+      Specifies a level of isolation for read operations. For example,
+      you can use read concern to only read data that has propagated to
+      a majority of nodes in a :term:`replica set`. See
+      :doc:`Read Concern </reference/readConcern>`.
+
    read preference
       A setting that determines how clients direct read operations.
       Read preference affects all replica sets, including shard replica

--- a/source/reference/method/cursor.readConcern.txt
+++ b/source/reference/method/cursor.readConcern.txt
@@ -1,0 +1,32 @@
+====================
+cursor.readConcern()
+====================
+
+.. default-domain:: mongodb
+
+
+Definition
+----------
+
+.. method:: cursor.readConcern(level)
+
+   .. versionadded:: 3.2
+
+   Specify a :term:`read concern` for the :method:`db.collection.find()`
+   or :method:`db.collection.count()` methods.
+
+   The :method:`~cursor.readConcern()` method has the following form:
+
+   .. code-block:: javascript
+
+      db.collection.find().readConcern(<level>)
+      db.collection.count().readConcern(<level>)
+
+   The :method:`~cursor.readConcern()` method has the following
+   parameter:
+
+   .. include:: /includes/apiargs/method-cursor.readConcern-param.rst
+
+   .. include:: /includes/fact-enable-majority-readConcern.rst
+
+.. seealso:: :doc:`/reference/readConcern`


### PR DESCRIPTION
Adds documentation for the `.readConcern()` helper for the `db.collection.find()`
and `db.collection.count()` methods.

An entry for "read concern" has also been added to the glossary.