### PR TITLE
Add comment about where to connect

### DIFF
--- a/source/tutorial/adjust-replica-set-member-priority.txt
+++ b/source/tutorial/adjust-replica-set-member-priority.txt
@@ -20,7 +20,10 @@ priority.
 Considerations
 --------------
 
-To modify priorities, you update the :rsconf:`members`
+To modify priorities, you can connect to any replicaset member (not a mongos).
+Changes you make there will be picked up by other replica set members.
+
+After connecting, you update the :rsconf:`members`
 array in the replica configuration object. The array index begins with
 ``0``. Do **not** confuse this index value with the value of the replica
 set member's :rsconf:`members[n]._id` field in the


### PR DESCRIPTION
All these tutorials should be self-contained and presume no info in previous tutorials.
This means that everywhere we say, "you must update this...", you need to add a 
previous statement for, 'connect to this component'.

Many of customers have sharded replicasets.  Saying 'first connect, then...' is too vague.
Don't presume the user knows which to connect to - primary, replica, arbiter, all 3, config
server, or mongos.  Especially n00bs, don't know which thing to connect to.