### PR TITLE
DOCS-6736: reword atomicity and unique indexes

### DIFF
--- a/source/core/write-operations-atomicity.txt
+++ b/source/core/write-operations-atomicity.txt
@@ -49,12 +49,13 @@ Concurrency Control
 Concurrency control allows multiple applications to run concurrently
 without causing data inconsistency or conflicts.
 
-An approach may be to create a :ref:`unique index <index-type-unique>`
-on a field (or fields) that should have only unique values (or unique
-combination of values) prevents duplicate insertions or updates that
-result in duplicate values. For examples of use cases, see
-:ref:`update() and Unique Index <update-with-unique-indexes>` and
-:ref:`findAndModify() and Unique Index <upsert-and-unique-index>`.
+One approach is to create a :ref:`unique index <index-type-unique>` on a
+field that can only have unique values. This prevents insertions or
+updates from creating duplicate data. Create a unique index on multiple
+fields to force uniqueness on that combination of field values. For
+examples of use cases, see :ref:`update() and Unique Index
+<update-with-unique-indexes>` and :ref:`findAndModify() and Unique Index
+<upsert-and-unique-index>`.
 
 Another approach is to specify the expected current value of a field in
 the query predicate for the write operations. For an example, see


### PR DESCRIPTION
This reworks the advice on utilizing unique indexes to achieve atomicity for certain operations.