### PR TITLE
DOCS-6785: readConcern special cases

### DIFF
--- a/source/includes/apiargs-dbcommand-aggregate-field.yaml
+++ b/source/includes/apiargs-dbcommand-aggregate-field.yaml
@@ -78,8 +78,7 @@ description: |
 
    .. include:: /includes/fact-enable-majority-readConcern.rst
 
-   To use the ``readConcern`` level of :readconcern:`"majority"`, you
-   cannot include the :pipeline:`$out` stage.
+   .. include:: /includes/fact-aggregate-readConcern.rst
 
    .. versionadded:: 3.2
 

--- a/source/includes/apiargs-dbcommand-count-field.yaml
+++ b/source/includes/apiargs-dbcommand-count-field.yaml
@@ -61,8 +61,7 @@ description: |
 
    .. include:: /includes/fact-enable-majority-readConcern.rst
 
-   To use the ``readConcern`` level of ``"majority"``, you must specify a
-   nonempty ``query`` condition.
+   .. include:: /includes/fact-count-readConcern.rst
 
    .. versionadded:: 3.2
 optional: true

--- a/source/includes/fact-aggregate-readConcern.rst
+++ b/source/includes/fact-aggregate-readConcern.rst
@@ -1,0 +1,2 @@
+To use a :doc:`/reference/readConcern` level of :readconcern:`"majority"`, you
+cannot include the :pipeline:`$out` stage.

--- a/source/includes/fact-count-readConcern.rst
+++ b/source/includes/fact-count-readConcern.rst
@@ -1,0 +1,2 @@
+To use a :doc:`/reference/readConcern` level of :readconcern:`"majority"`, you
+must specify a nonempty ``query`` condition.

--- a/source/includes/fact-enable-majority-readConcern.rst
+++ b/source/includes/fact-enable-majority-readConcern.rst
@@ -1,5 +1,5 @@
-To use :doc:`/reference/readConcern` level of :readconcern:`"majority"`,
-you must start the :program:`mongod` instances with
-:option:`--enableMajorityReadConcern` command line option or, if using a
-configuration file, the :setting:`replication.enableMajorityReadConcern`
-setting.
+To use a :doc:`/reference/readConcern` level of
+:readconcern:`"majority"`, you must start the :program:`mongod`
+instances with the :option:`--enableMajorityReadConcern` command line option
+or, if using a configuration file, the
+:setting:`replication.enableMajorityReadConcern` setting.

--- a/source/reference/command/aggregate.txt
+++ b/source/reference/command/aggregate.txt
@@ -209,9 +209,7 @@ majority of the nodes.
 
    - .. include:: /includes/fact-enable-majority-readConcern.rst
 
-   - To use the ``readConcern`` level of :readconcern:`"majority"` with
-     :dbcommand:`aggregate`, you cannot include the :pipeline:`$out`
-     stage.
+   - .. include:: /includes/fact-aggregate-readConcern.rst
 
    - .. include:: /includes/fact-readConcern-most-recent-data-in-node.rst
 

--- a/source/reference/method/db.collection.aggregate.txt
+++ b/source/reference/method/db.collection.aggregate.txt
@@ -214,9 +214,7 @@ majority of the nodes.
 
    - .. include:: /includes/fact-enable-majority-readConcern.rst
 
-   - To use the ``readConcern`` level of :readconcern:`"majority"` with
-     :method:`db.collection.aggregate()`, you cannot include the
-     :pipeline:`$out` stage.
+   - .. include:: /includes/fact-aggregate-readConcern.rst
 
    - .. include:: /includes/fact-readConcern-most-recent-data-in-node.rst
 

--- a/source/reference/method/db.collection.count.txt
+++ b/source/reference/method/db.collection.count.txt
@@ -47,6 +47,13 @@ may off by up to 1000 documents as reported by :dbcommand:`collStats`,
 statistics for the collection, run :dbcommand:`validate` on the
 collection.
 
+Count with Read Concern
+~~~~~~~~~~~~~~~~~~~~~~~
+A :doc:`/reference/readConcern` can be specified with the
+:method:`cursor.readConcern()` method.
+
+.. include:: /includes/fact-count-readConcern.rst
+
 Examples
 --------
 


### PR DESCRIPTION
Documents the special cases when using a read concern with a count or
aggregation command.