### PR TITLE
Fix a typo in the journalLatencyTest command name

### DIFF
--- a/source/includes/ref-toc-command-testing.yaml
+++ b/source/includes/ref-toc-command-testing.yaml
@@ -22,7 +22,7 @@ name: ":dbcommand:`_hashBSONElement`"
 file: /reference/command/hashBSONElement
 description: "Internal command. Computes the MD5 hash of a BSON element."
 ---
-name: ":dbcommand:`_journalLatencyTest`"
+name: ":dbcommand:`journalLatencyTest`"
 file: /reference/command/journalLatencyTest
 description: "Tests the time required to write and perform a file system sync for a file in the journal directory."
 ---


### PR DESCRIPTION
The command name does not have a leading underscore:

src/mongo/db/storage/mmap_v1/journal_latency_test_cmd.cpp:    JournalLatencyTestCmd() : Command("journalLatencyTest") {}
