### PR TITLE
DOCS-5204: clarify GridFS behavior for small files

### DIFF
--- a/source/core/gridfs.txt
+++ b/source/core/gridfs.txt
@@ -11,14 +11,21 @@ that exceed the :term:`BSON`\-document :ref:`size limit
 <limit-bson-document-size>` of 16 MB.
 
 Instead of storing a file in a single document, GridFS divides a file
-into parts, or chunks, [#chunk-disambiguation]_ and stores each of
-those chunks as a separate document. By default GridFS limits chunk
-size to 255 KB. GridFS uses two collections to store files. One
-collection stores the file chunks, and the other stores file metadata.
+into parts, or chunks [#chunk-disambiguation]_, and stores each chunk as
+a separate document. By default, GridFS uses a chunk size of 255 KB;
+that is, GridFS divides a file into chunks of 255 KB with the exception
+of the last chunk. The last chunk is only as large as necessary.
+Similarly, files that are no larger than the chunk size only have a
+final chunk, using only as much space as needed plus some additional
+metadata.
+
+GridFS uses two collections to store files. One collection stores the
+file chunks, and the other stores file metadata. For more information,
+refer to :ref:`gridfs-collections`.
 
 When you query a GridFS store for a file, the driver or client will
 reassemble the chunks as needed. You can perform range queries on
-files stored through GridFS.  You also can access information from
+files stored through GridFS. You also can access information from
 arbitrary sections of files, which allows you to "skip" into the
 middle of a video or audio file.
 
@@ -47,6 +54,8 @@ To store and retrieve files using :term:`GridFS`, use either of the following:
 
 - The :program:`mongofiles` command-line tool in the :program:`mongo`
   shell. See the :program:`mongofiles` reference for complete documentation.
+
+.. _gridfs-collections:
 
 GridFS Collections
 ------------------


### PR DESCRIPTION
Clarifies the behavior of GridFS when storing files that are smaller than the
default chunk size.