### PR TITLE
Remove 's' regex flag from extended JSON

### DIFF
--- a/source/reference/mongodb-extended-json.txt
+++ b/source/reference/mongodb-extended-json.txt
@@ -206,10 +206,9 @@ Regular Expression
   by the letters of the alphabet.
 
 - ``<jOptions>`` is a string that may contain only the characters 'g',
-  'i', 'm' and 's' (added in v1.9). Because the ``JavaScript`` and
-  ``mongo Shell`` representations support a limited range of options,
-  any nonconforming options will be dropped when converting to this
-  representation.
+  'i' and 'm'. Because the ``JavaScript`` and ``mongo Shell``
+  representations support a limited range of options, any nonconforming
+  options will be dropped when converting to this representation.
 
 OID
 ~~~


### PR DESCRIPTION
I tested the mongo shell of every stable version between 1.6.0 and 3.2.0, and none support 's' as a valid flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2492)
<!-- Reviewable:end -->
