### PR TITLE
DOCS-5076: must "use database" before dataSize cmd

### DIFF
--- a/source/tutorial/merge-chunks-in-sharded-cluster.txt
+++ b/source/tutorial/merge-chunks-in-sharded-cluster.txt
@@ -106,11 +106,18 @@ Verify a Chunk is Empty
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 The :dbcommand:`mergeChunks` command requires at least one empty input
-chunk. In the :program:`mongo` shell, check the amount of data in a
-chunk using an operation that resembles:
+chunk. To check the size of a chunk, use the :dbcommand:`dataSize`
+command in the sharded collection's database. For example, the following
+checks the amount of data in the chunk for the ``users`` collection in
+the ``test`` database:
+
+.. important:: You must use the ``use <db>`` helper to switch to the
+   database containing the sharded collection before running the
+   :dbcommand:`dataSize` command.
 
 .. code-block:: javascript
 
+   use test
    db.runCommand({
       "dataSize": "test.users",
       "keyPattern": { username: 1 },


### PR DESCRIPTION
When connected to a mongos, the `dataSize` command must be run in the context of
the database containing the collection to measure.

See [SERVER-21976](https://jira.mongodb.org/browse/SERVER-21976).