### PR TITLE
Correct `updateMany` to `updateOne`

### DIFF
--- a/source/reference/method/db.collection.updateOne.txt
+++ b/source/reference/method/db.collection.updateOne.txt
@@ -17,7 +17,7 @@ Definition
 
    .. code-block:: javascript
 
-      db.collection.updateMany(
+      db.collection.updateOne(
          <filter>,
          <update>,
          {


### PR DESCRIPTION
Reference docs for `db.collection.updateOne` reference `updateMany` in the example. This corrects that.