### PR TITLE
DOCS-6898: findAndModify takes a write concern

### DIFF
--- a/source/includes/apiargs-dbcommand-findAndModify-field.yaml
+++ b/source/includes/apiargs-dbcommand-findAndModify-field.yaml
@@ -5,7 +5,7 @@ interface: command
 name: findAndModify
 operation: findAndModify
 optional: false
-position: 1
+position: 0
 type: string
 ---
 arg_name: field
@@ -63,4 +63,11 @@ operation: findAndModify
 source:
   file: apiargs-method-db.collection.findAndModify-param.yaml
   ref: bypassDocumentValidation
+---
+arg_name: field
+interface: dbcommand
+operation: findAndModify
+source:
+  file: apiargs-method-db.collection.findAndModify-param.yaml
+  ref: writeConcern
 ...

--- a/source/includes/apiargs-method-db.collection.findAndModify-param.yaml
+++ b/source/includes/apiargs-method-db.collection.findAndModify-param.yaml
@@ -101,4 +101,17 @@ replacement:
 position: 8
 operation: db.collection.findAndModify
 interface: method
+---
+arg_name: param
+description: |
+  A document expressing the :doc:`write concern </reference/write-concern>`.
+  Omit to use the default write concern.
+
+  .. versionadded:: 3.2
+interface: method
+name: writeConcern
+operation: db.collection.findAndModify
+optional: true
+position: 9
+type: document
 ...

--- a/source/reference/command/findAndModify.txt
+++ b/source/reference/command/findAndModify.txt
@@ -31,7 +31,8 @@ Definition
         new: <boolean>,
         fields: <document>,
         upsert: <boolean>,
-        bypassDocumentValidation: <boolean>
+        bypassDocumentValidation: <boolean>,
+        writeConcern: <document>
       }
 
    The :dbcommand:`findAndModify` command takes the following

--- a/source/reference/method/db.collection.findAndModify.txt
+++ b/source/reference/method/db.collection.findAndModify.txt
@@ -33,7 +33,8 @@ Definition
           new: <boolean>,
           fields: <document>,
           upsert: <boolean>,
-          bypassDocumentValidation: <boolean>
+          bypassDocumentValidation: <boolean>,
+          writeConcern: <document>
       });
 
    The :method:`db.collection.findAndModify()` method takes a document


### PR DESCRIPTION
Documents the optional `writeConcern` parameter for `findAndModify` and its
corresponding shell helper.

This change is new in MongoDB version 3.2.