### PR TITLE
DOCS-6910: fixes grammar on agg pipeline intro paragraph

### DIFF
--- a/source/core/aggregation-pipeline.txt
+++ b/source/core/aggregation-pipeline.txt
@@ -6,7 +6,7 @@ Aggregation Pipeline
 
 The aggregation pipeline is a framework for data aggregation modeled
 on the concept of data processing pipelines. Documents enter a
-multi-stage pipeline that transforms the documents into an aggregated
+multi-stage pipeline that transforms the documents into aggregated
 results.
 
 .. include:: /images/aggregation-pipeline.rst


### PR DESCRIPTION
The tiniest pull request ever -- we refer to 'aggregated results' elsewhere in the manual, but I wasn't sure if 'an aggregated result set' would be preferable.