### PR TITLE
DOCS-6872: reorganize storage and storage engines

### DIFF
--- a/config/sphinx_local.yaml
+++ b/config/sphinx_local.yaml
@@ -36,6 +36,7 @@ theme:
     - /release-notes/2.8
     - /release-notes/3.0
     - /release-notes/3.2
+    - /storage
     - /administration/production-checklist
     - /contributors/getting-started
 sidebars:

--- a/source/core/inmemory.txt
+++ b/source/core/inmemory.txt
@@ -6,14 +6,13 @@ In-Memory Storage Engine
 
 .. default-domain:: mongodb
 
-.. warning:: The in-memory storage engine is currently in **beta**. Do not use
-   in production.
+.. include:: /includes/fact-inmemory-beta.rst
 
-Starting in MongoDB Enterprise 3.2, an in-memory storage engine is available in
-the 64-bit builds for beta-testing purposes. Other than some metadata, the
-in-memory storage engine does not maintain any on-disk data, By avoiding disk
-I/O, the in-memory storge engine allows for more predictable latency of
-database operations.
+Starting in MongoDB Enterprise 3.2, an in-memory storage engine is
+available in the 64-bit builds for beta-testing purposes. Other than
+some metadata, the in-memory storage engine does not maintain any
+on-disk data. By avoiding disk I/O, the in-memory storage engine allows
+for more predictable latency of database operations.
 
 Specify In-Memory Storage Engine
 --------------------------------

--- a/source/core/storage-engines.txt
+++ b/source/core/storage-engines.txt
@@ -1,0 +1,31 @@
+===============
+Storage Engines
+===============
+
+.. default-domain:: mongodb
+
+The :term:`storage engine` is the component of the database that is
+responsible for managing how data is stored, both in memory and on disk.
+MongoDB supports multiple storage engines, as different engines perform
+better for specific workloads. Choosing the appropriate storage engine
+for your use case can significantly impact the performance of your
+applications.
+
+:doc:`WiredTiger </core/wiredtiger>` is the default storage engine
+starting in MongoDB 3.2. It is well-suited for most workloads and is
+recommended for new deployments. WiredTiger provides a document-level
+concurrency model, checkpointing, and compression, among other features.
+In MongoDB Enterprise, WiredTiger also supports
+:doc:`/core/security-encryption-at-rest`.
+
+:doc:`MMAPv1 </core/mmapv1>` is the original MongoDB storage engine and
+is the default storage engine for MongoDB versions before 3.2. It
+performs well on workloads with high volumes of reads and writes, as
+well as in-place updates.
+
+The :doc:`In-Memory Storage Engine </core/inmemory>` is available in
+MongoDB Enterprise. Rather than storing documents on-disk, it retains
+them in-memory for more predictable data latencies. This storage engine
+is in **beta** -- do **not** use in production.
+
+.. include:: /includes/toc/storage-engines.rst

--- a/source/faq/storage.txt
+++ b/source/faq/storage.txt
@@ -18,18 +18,13 @@ What is a storage engine?
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A storage engine is the part of a database that is responsible for
-managing how data is stored on disk. Many databases support multiple
-storage engines, where different engines perform better for specific
-workloads. For example, one storage engine might offer better
-performance for read-heavy workloads, and another might support
-a higher-throughput for write operations.
+managing how data is stored, both in memory and on disk. Many databases
+support multiple storage engines, where different engines perform better
+for specific workloads. For example, one storage engine might offer
+better performance for read-heavy workloads, and another might support a
+higher-throughput for write operations.
 
-What will be the default storage engine going forward?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-MMAPv1 is the default storage engine in 3.0. With multiple storage
-engines, you can decide which storage engine is
-best for your application.
+.. seealso:: :doc:`/core/storage-engines`
 
 Can you mix storage engines in a replica set?
 ---------------------------------------------

--- a/source/includes/fact-inmemory-beta.rst
+++ b/source/includes/fact-inmemory-beta.rst
@@ -1,0 +1,2 @@
+.. warning:: The in-memory storage engine is currently in **beta**. Do
+   not use in production.

--- a/source/includes/toc-storage-engines.yaml
+++ b/source/includes/toc-storage-engines.yaml
@@ -1,0 +1,12 @@
+file: /core/wiredtiger
+description: |
+   An overview of the WiredTiger storage engine.
+---
+file: /core/mmapv1
+description: |
+   An overview of the MMAPv1 storage engine.
+---
+file: /core/inmemory
+description: |
+   An overview of the in-memory storage engine.
+...

--- a/source/includes/toc-storage.yaml
+++ b/source/includes/toc-storage.yaml
@@ -1,12 +1,16 @@
-file: /core/mmapv1
+file: /core/storage-engines
 description: |
-   An introduction to the MMAPv1 storage engine.
+   An introduction to MongoDB storage engines.
 ---
-file: /core/wiredtiger
-description:
-   An introduction to the WiredTiger storage engine.
+file: /core/journaling
+description: |
+   A guide on using and configuring the :term:`journal`.
 ---
-file: /core/inmemory
-description:
-   An introduction to the in-memory storage engine.
+file: /core/gridfs
+description: |
+   A versatile storage system suited to handling large files.
+---
+file: /faq/storage
+description: |
+   Frequently asked questions about storage.
 ...

--- a/source/reference/glossary.txt
+++ b/source/reference/glossary.txt
@@ -913,6 +913,13 @@ Glossary
       standalone into a replica set, see
       :doc:`/tutorial/convert-standalone-to-replica-set`.
 
+   storage engine
+      The part of a database that is responsible for managing how data
+      is stored and accessed, both in memory and on disk. Different
+      storage engines perform better for specific workloads. See
+      :doc:`/core/storage-engines` for specific details on the built-in
+      storage engines in MongoDB.
+
    strict consistency
       A property of a distributed system requiring that all members
       always reflect the latest changes to the system. In a database

--- a/source/storage.txt
+++ b/source/storage.txt
@@ -4,8 +4,18 @@ Storage
 
 .. default-domain:: mongodb
 
-This section introduces the storage engines available in MongoDB.
+The :doc:`storage engine </core/storage-engines>` is the primary
+component of MongoDB responsible for managing data. MongoDB provides a
+variety of storage engines, allowing you to choose one most suited to
+your application.
 
-.. include:: /includes/toc/dfn-list-storage.rst
+The :term:`journal` is a log that helps the database recover in the
+event of a hard shutdown. There are several configurable options that
+allows the journal to strike a balance between performance and
+reliability that works for your particular use case.
+
+:doc:`/core/gridfs` is a versatile storage system that is suited to
+handling large files, such as those exceeding the 16 MB document size
+limit.
 
 .. include:: /includes/toc/storage.rst


### PR DESCRIPTION
Reworded the storage section to give a more general overview of the different
storage sections in the Manual.

Moved the storage engines to their own sub-section underneath storage, complete
with short descriptions of each.