### PR TITLE
DOCS-6971: findAndModify + write concern error

### DIFF
--- a/source/includes/fact-findAndModify-update-comparison.rst
+++ b/source/includes/fact-findAndModify-update-comparison.rst
@@ -24,11 +24,6 @@ When updating a document, |operation| and the
   only a single document but multiple documents matched, you will need to
   use additional logic to identify the updated document.
 
-- You cannot specify a :doc:`write concern </reference/write-concern>` to
-  |operation| to override the default write concern whereas, starting
-  in MongoDB 2.6, you can specify a write concern to the
-  :method:`~db.collection.update()` method.
-
 When modifying a *single* document, both |operation| and the
 :method:`~db.collection.update()` method *atomically* update the
 document. See :doc:`/core/write-operations-atomicity` for more


### PR DESCRIPTION
The comparison between `findAndModify` with the `update` command erroneously stated
that the former does not take a write concern. A write concern can be specified
starting in MongoDB 3.2.