### PR TITLE
DOCS-6922  improve enable-authentication.txt

### DIFF
--- a/source/tutorial/enable-authentication.txt
+++ b/source/tutorial/enable-authentication.txt
@@ -38,6 +38,11 @@ Considerations
 With access control enabled, ensure you have a user with :authrole:`userAdmin`
 or :authrole:`userAdminAnyDatabase` role in the ``admin`` database.
 
+This tutorial assumes a :term:`standalone` environment.
+
+The :doc:`/tutorial/enable-internal-authentication` tutorial has steps
+specific to enabling access control on replica sets and sharded clusters.
+
 You can create users before enabling access control or you can create
 users after enabling access control. If you enable access control before
 creating any user, MongoDB provides a :ref:`localhost exception


### PR DESCRIPTION
User noted lack of direction in applying tutorial to a replica set or
sharded cluster. Added clarification that tutorial assumes a
standalone environment and linked to the replica set / sharded cluster
authentication tutorial.