### PR TITLE
DOCS-6847: mongodump must connect to a running mongod in 3.0

### DIFF
--- a/source/core/backups.txt
+++ b/source/core/backups.txt
@@ -79,7 +79,7 @@ files. These tools are simple and efficient for backing up small
 MongoDB deployments, but are not ideal for capturing backups of larger
 systems.
 
-:program:`mongodump` and :program:`mongorestore` can operate against a
+:program:`mongodump` and :program:`mongorestore` operate against a
 running :program:`mongod` process, and can manipulate the underlying
 data files directly. By default, :program:`mongodump` does not
 capture the contents of the :doc:`local database </reference/local-database>`.
@@ -94,13 +94,8 @@ than system memory, the queries will push the working set out of
 memory.
 
 To mitigate the impact of :program:`mongodump` on the performance of
-the replica set, use :program:`mongodump` to capture backups from a
-:doc:`secondary </core/replica-set-secondary>` member of a replica set.
-Alternatively, you can shut down a secondary and use
-:program:`mongodump` with the data files directly. If you shut down a
-secondary to capture data with :program:`mongodump` ensure that the
-operation can complete before its oplog becomes too stale to continue
-replicating.
+a replica set, use :program:`mongodump` to capture backups from a
+:doc:`secondary </core/replica-set-secondary>` member of the replica set.
 
 For replica sets, :program:`mongodump` also supports a point in time
 feature with the :option:`--oplog <mongodump --oplog>`


### PR DESCRIPTION
This is to go into 3.0 -- the updates for 3.2 are in my backup reorg code review ticket currently.