### PR TITLE
DOCS-6931: use correct kilobyte unit symbol

### DIFF
--- a/source/administration/production-notes.txt
+++ b/source/administration/production-notes.txt
@@ -528,7 +528,7 @@ For the MMAPv1 storage engine:
 
 - Ensure that readahead settings for the block devices that store the
   database files are appropriate. For random access use patterns, set
-  low readahead values. A readahead of 32 (16 KB) often works well.
+  low readahead values. A readahead of 32 (16 kB) often works well.
 
   For a standard block device, you can run ``sudo blockdev --report``
   to get the readahead settings and ``sudo blockdev --setra <value>

--- a/source/core/data-model-operations.txt
+++ b/source/core/data-model-operations.txt
@@ -116,7 +116,7 @@ sorted results. MongoDB automatically creates a unique index on the
 
 As you create indexes, consider the following behaviors of indexes:
 
-- Each index requires at least 8 KB of data space.
+- Each index requires at least 8 kB of data space.
 
 - Adding an index has some negative performance impact for write
   operations. For collections with high write-to-read ratio, indexes
@@ -166,7 +166,7 @@ the following behaviors:
 
 - Each collection has a certain minimum overhead of a few kilobytes.
 
-- Each index, including the index on ``_id``, requires at least 8 KB of
+- Each index, including the index on ``_id``, requires at least 8 kB of
   data space.
 
 - For each :term:`database`, a single namespace file (i.e.

--- a/source/core/gridfs.txt
+++ b/source/core/gridfs.txt
@@ -18,8 +18,8 @@ that exceed the :term:`BSON`\-document :ref:`size limit
 
 Instead of storing a file in a single document, GridFS divides the file
 into parts, or chunks [#chunk-disambiguation]_, and stores each chunk as
-a separate document. By default, GridFS uses a chunk size of 255 KB;
-that is, GridFS divides a file into chunks of 255 KB with the exception
+a separate document. By default, GridFS uses a chunk size of 255 kB;
+that is, GridFS divides a file into chunks of 255 kB with the exception
 of the last chunk. The last chunk is only as large as necessary.
 Similarly, files that are no larger than the chunk size only have a
 final chunk, using only as much space as needed plus some additional
@@ -40,7 +40,7 @@ the entire file into memory. See also
 :ref:`faq-developers-when-to-use-gridfs`.
 
 .. versionchanged:: 2.4.10
-   The default chunk size changed from 256 KB to 255 KB.
+   The default chunk size changed from 256 kB to 255 kB.
 
 .. index:: GridFS; initialize
 .. _gridfs-use:
@@ -162,10 +162,10 @@ following fields. Applications may create additional arbitrary fields:
 
    The size of each chunk in **bytes**. GridFS divides the document into
    chunks of size ``chunkSize``, except for the last, which is only as
-   large as needed. The default size is 255 kilobytes (KB).
+   large as needed. The default size is 255 kilobytes (kB).
 
    .. versionchanged:: 2.4.10
-      The default chunk size changed from 256 KB to 255 KB.
+      The default chunk size changed from 256 kB to 255 kB.
 
 .. data:: files.uploadDate
 

--- a/source/core/journaling.txt
+++ b/source/core/journaling.txt
@@ -50,7 +50,7 @@ With journaling, WiredTiger creates a log record per transaction.
 
 MongoDB configures WiredTiger to use in-memory buffering for storing
 the write-ahead log records. Threads coordinate to allocate and copy
-into their portion of the buffer. All log records up to 128 KB are
+into their portion of the buffer. All log records up to 128 kB are
 buffered.
 
 WiredTiger syncs the buffered log records to disk according to the

--- a/source/reference/command/compact.txt
+++ b/source/reference/command/compact.txt
@@ -95,7 +95,7 @@ Specifying ``paddingBytes`` can be useful if your documents start small
 but then increase in size significantly.
 
 For example, if your documents
-are initially 40 bytes long and you grow them by 1 KB, using
+are initially 40 bytes long and you grow them by 1 kB, using
 ``paddingBytes: 1024`` might be reasonable since using ``paddingFactor:
 4.0`` would specify a record size of 160 bytes (``4.0`` times the
 initial document size), which would only provide a padding of 120 bytes

--- a/source/release-notes/2.4-changelog.txt
+++ b/source/release-notes/2.4-changelog.txt
@@ -76,7 +76,7 @@
 - Runtime: The SIGXCPU signal is now caught and mongod writes a log message and exits gracefully (:issue:`SERVER-12034`)
 - Runtime: Fixed issue where mongod fails to start on Linux when /sys/dev/block directory is not readable (:issue:`SERVER-9248`)
 - Windows: No longer zero-fill newly allocated files on systems other than Windows 7 or Windows Server 2008 R2 (:issue:`SERVER-8480`)
-- GridFS: Chunk size is decreased to 255 KB (from 256 KB) to avoid overhead with usePowerOf2Sizes option (:issue:`SERVER-13331`)
+- GridFS: Chunk size is decreased to 255 kB (from 256 kB) to avoid overhead with usePowerOf2Sizes option (:issue:`SERVER-13331`)
 - SNMP: Fixed MIB file validation under smilint (:issue:`SERVER-12487`)
 - Shell: Fixed issue in V8 memory allocation that could cause long-running shell commands to crash (:issue:`SERVER-11871`)
 - Shell: Fixed memory leak in the md5sumFile shell utility method (:issue:`SERVER-11560`)


### PR DESCRIPTION
In the SI system, the correct unit is "kB", not "KB".