### PR TITLE
Update glossary.txt

### DIFF
--- a/source/reference/glossary.txt
+++ b/source/reference/glossary.txt
@@ -1038,8 +1038,8 @@ Glossary
       A situation in which two concurrent operations, at least
       one of which is a write, attempt to use a resource in a way
       that would violate constraints imposed by a storage engine
-      using optimistic :term:`concurrency control`. MongoDB will abort
-      and transparently retry one of the conflicting operations.
+      using optimistic :term:`concurrency control`. MongoDB will 
+      transparently abort and retry one of the conflicting operations.
 
    write lock
       An exclusive :term:`lock` on a resource such as a collection


### PR DESCRIPTION
Swapped words for the "write conflict" definition as it could originally be read as "MongoDB [server] will abort". Now it should be clear that only one of the conflicting operations will be aborted and retried.