### PR TITLE
DOCS-6982: clarify result of upsert

### DIFF
--- a/source/includes/steps-getting-started-update-upsert.yaml
+++ b/source/includes/steps-getting-started-update-upsert.yaml
@@ -93,16 +93,35 @@ action:
            "nModified" : 0,
            "_id" : ObjectId("53dbd7c8babeaec6342ed6c8")
        })
-post: |
-  The :data:`~WriteResult.nMatched` field shows that the operation
-  matched ``0`` documents.
+  - pre: |
+      The :data:`~WriteResult.nMatched` field shows that the operation
+      matched ``0`` documents.
 
-  The :data:`~WriteResult.nUpserted` of ``1`` shows that the update
-  added a document.
+      The :data:`~WriteResult.nUpserted` of ``1`` shows that the update
+      added a document.
 
-  The :data:`~WriteResult.nModified` of ``0`` specifies that no
-  existing documents were updated.
+      The :data:`~WriteResult.nModified` of ``0`` specifies that no
+      existing documents were updated.
 
-  The ``_id`` field shows the generated ``_id`` field for the added
-  document.
+      The information above indicates that the operation has created one
+      new document. The ``_id`` field shows the generated ``_id`` field
+      for the added document; you can perform a query to confirm the
+      result:
+    language: javascript
+    code: |
+      db.inventory.findOne( { _id: ObjectId("53dbd7c8babeaec6342ed6c8") } )
+  - pre: |
+      The result matches the document specified in the
+      :method:`~db.collection.update()`:
+    language: javascript
+    code: |
+      {
+          "_id" : ObjectId("56a12ec8242ae5d73c07b15e"),
+          "item" : "TBD2",
+          "details" : {
+              "model" : "14Q3",
+              "manufacturer" : "IJK Co."
+          },
+          "category" : "houseware"
+      }
 ...


### PR DESCRIPTION
Explicitly say that an upsert will create a new document if it doesn't already
exist.