### PR TITLE
Remove most of our intersphinx files

### DIFF
--- a/config/intersphinx.yaml
+++ b/config/intersphinx.yaml
@@ -2,35 +2,7 @@ name: pymongo
 url: http://api.mongodb.org/python/current/
 path: pymongo.inv
 ---
-name: python
-url: https://docs.python.org/2/
-path: python2.inv
----
 name: python2
 url: https://docs.python.org/2/
 path: python2.inv
----
-name: python3
-url: https://docs.python.org/3/
-path: python3.inv
----
-name: sphinx
-url: http://www.sphinx-doc.org/
-path: objects.inv
-### I don't think we actually link to anything for sphinx so
-### this probably can go.  In either case, did update to the
-### new location, but probably can comment out in future so
-### we don't have to maintain things that we don't use.
----
-name: django
-url: https://django.readthedocs.org/en/latest/
-path: django.inv
----
-# name: djangomongodbengine
-# url: http://django-mongodb.org/
-# path: djangomongodb.inv
-# ---
-name: djangotoolbox
-url: http://djangotoolbox.readthedocs.org/en/latest/
-path: djangotoolbox.inv
 ...


### PR DESCRIPTION
Docs build is clean. I think we could also remove python2, but there's some brittleness in giza that requires us to have at least two entries here.