### PR TITLE
Remove a link to the nonexistant geoNear query expression.

### DIFF
--- a/source/core/document-validation.txt
+++ b/source/core/document-validation.txt
@@ -17,8 +17,8 @@ insertions. Validation rules are specified on a per-collection basis
 using the ``validator`` option, which takes a document that specifies
 the validation rules or expressions. Specify the expressions
 using any :ref:`query operators <query-selectors>`,
-with the exception of :query:`$geoNear`, :query:`$near`,
-:query:`$nearSphere`, :query:`$text`, and :query:`$where`.
+with the exception of :query:`$near`, :query:`$nearSphere`, :query:`$text`,
+and :query:`$where`.
 
 Add document validation to an existing collection using the
 :dbcommand:`collMod` command with the ``validator`` option. You can also


### PR DESCRIPTION
Document validation only accepts query expressions, and the only prohibited
geospatial query expressions are near and nearSphere.