### PR TITLE
DOCS-7000: no _id index scan for cursor.snapshot()

### DIFF
--- a/source/faq/developers.txt
+++ b/source/faq/developers.txt
@@ -591,15 +591,13 @@ driver <>`.
 How do I isolate cursors from intervening write operations?
 -----------------------------------------------------------
 
-With the :doc:`MMAPv1 storage engine </core/mmapv1>`, MongoDB cursors
-can return the same document more than once in some situations.
-[#duplicate-document-in-result-set]_ You can use the
-:method:`~cursor.snapshot()` method on a cursor to isolate the
-operation for a very specific case.
+MongoDB cursors can return the same document more than once in some
+situations. [#duplicate-document-in-result-set]_ You can use the
+:method:`~cursor.snapshot()` method on a cursor to isolate the operation
+for a very specific case.
 
-:method:`~cursor.snapshot()` traverses the index on the ``_id`` field
-and guarantees that the query will return each document (with respect to
-the value of the ``_id`` field) no more than once. [#id-is-immutable]_
+:method:`~cursor.snapshot()` guarantees that the query will return each
+document no more than once.
 
 The :method:`~cursor.snapshot()` does not guarantee that the data
 returned by the query will reflect a single moment in time *nor* does it
@@ -610,7 +608,7 @@ provide isolation from insert or delete operations.
    - You **cannot** use :method:`~cursor.snapshot()` with
      :term:`sharded collections <sharding>`.
 
-   - You **cannot** use :method:`~cursor.snapshot()` with
+   - You **cannot** use :method:`~cursor.snapshot()` with the
      :method:`~cursor.sort()` or :method:`~cursor.hint()` cursor methods.
 
 As an alternative, if your collection has a field or fields that are
@@ -627,10 +625,6 @@ that index.
    document growth) or that change the indexed field on the index used
    by the query; then the cursor will return the same document more
    than once.
-
-.. [#id-is-immutable] MongoDB does not permit changes to the value of the
-   ``_id`` field; it is not possible for a cursor that transverses
-   this index to pass the same document more than once.
 
 .. _faq-developers-embed-documents:
 

--- a/source/includes/extracts-concurrency-consistency-recency.yaml
+++ b/source/includes/extracts-concurrency-consistency-recency.yaml
@@ -147,51 +147,6 @@ content: |
    :ref:`faq-developers-isolate-cursors`.
 
 ---
-ref: isolate-cursor-snapshot-faq
-content: |
-   MongoDB cursors can return the same document more than once in some
-   situations. [#duplicate-document-in-result-set]_ You can use the
-   :method:`~cursor.snapshot()` method on a cursor to isolate the
-   operation for a very specific case.
-
-   :method:`~cursor.snapshot()` traverses the index on the ``_id``
-   field and guarantees that the query will return each document (with
-   respect to the value of the ``_id`` field) no more than once.
-   [#id-is-immutable]_
-
-   The :method:`~cursor.snapshot()` does not guarantee that the data
-   returned by the query will reflect a single moment in time *nor*
-   does it provide isolation from insert or delete operations.
-
-   .. note::
-
-      - You **cannot** use :method:`~cursor.snapshot()` with
-        :term:`sharded collections <sharding>`.
-
-      - You **cannot** use :method:`~cursor.snapshot()` with
-        :method:`~cursor.sort()` or :method:`~cursor.hint()` cursor methods.
-
-      - Queries with results of less than 1 megabyte are effectively
-        snapshotted.
-
-   As an alternative, if your collection has a field or fields that are
-   never modified, you can use a *unique* index on this field or these
-   fields to achieve a similar result as the :method:`~cursor.snapshot()`.
-   Query with :method:`~cursor.hint()` to explicitly force the query to use
-   that index.
-
-   .. [#duplicate-document-in-result-set] As a cursor returns documents
-      other operations may interleave with the query: if some of these
-      operations are :doc:`updates </core/write-operations>` that cause
-      the document to move (in the case of a MMAPv1 collection scan,
-      caused by document growth) or that change the indexed field on
-      the index used by the query; then the cursor will return the same
-      document more than once.
-
-   .. [#id-is-immutable] MongoDB does not permit changes to the value
-      of the ``_id`` field; it is not possible for a cursor that
-      transverses this index to pass the same document more than once.
----
 ref: lock-general
 content: |
     MongoDB uses multi-granularity locking [#mgl-ref]_ that allows

--- a/source/includes/ref-toc-operator-meta.yaml
+++ b/source/includes/ref-toc-operator-meta.yaml
@@ -40,7 +40,7 @@ description: "Modifies the documents returned to include references to the on-di
 ---
 name: ":operator:`$snapshot`"
 file: /reference/operator/meta/snapshot
-description: "Forces the query to use the index on the ``_id`` field. See :method:`~cursor.snapshot()`."
+description: "Guarantees that a query returns each document no more than once. See :method:`~cursor.snapshot()`."
 ---
 name: ":operator:`$query`"
 file: /reference/operator/meta/query

--- a/source/reference/method/cursor.snapshot.txt
+++ b/source/reference/method/cursor.snapshot.txt
@@ -28,6 +28,5 @@ cursor.snapshot()
    The :method:`~cursor.snapshot()` does not guarantee
    isolation from insertion or deletions.
 
-   The :method:`~cursor.snapshot()` traverses the index on the ``_id``
-   field. As such, :method:`~cursor.snapshot()` **cannot**
-   be used with :method:`~cursor.sort()` or :method:`~cursor.hint()`.
+   The :method:`~cursor.snapshot()` **cannot** be used with
+   :method:`~cursor.sort()` or :method:`~cursor.hint()`.


### PR DESCRIPTION
Due to SERVER-19593, the `cursor.snapshot()` method no longer forces an `_id` index
scan and instead performs a collection scan.

This removes the description of the implementation of `cursor.snapshot()`. It also
removes the extract `isolate-cursor-snapshot-faq`.