### PR TITLE
Fix document validation example

### DIFF
--- a/source/core/document-validation.txt
+++ b/source/core/document-validation.txt
@@ -136,9 +136,9 @@ but allows the insertion or update to proceed.
                   { phone: { $type: "string" } },
                   { email: { $regex: /@mongodb\.com$/ } },
                   { status: { $in: [ "Unknown", "Incomplete" ] } }
-               ],
-             validationAction: "warn"
-            }
+               ]
+            },
+            validationAction: "warn"
          }
       )
    


### PR DESCRIPTION
Fix a typo in the document validation example, using validationAction equals to "warn"