### PR TITLE
Fix index intersection example

### DIFF
--- a/source/core/index-intersection.txt
+++ b/source/core/index-intersection.txt
@@ -30,7 +30,7 @@ the following query:
 
 .. code-block:: javascript
 
-   db.orders.find( { item: "abc123", qty: { $gt: 15 } } )
+   db.orders.find( { item: "abc123", qty: 15 } )
 
 To determine if MongoDB used index intersection, run
 :method:`~cursor.explain()`; the results of :ref:`explain()


### PR DESCRIPTION
Looks like this query does not use an index intersection:

`db.orders.find( { item: "abc123", qty: { $gt: 15 } } )`

This one returns the described stage in the query plan output, showing the use of both indexes:

`db.orders.find( { item: "abc123", qty: 15 } )`

I think MongoDB does not consider an intersection when using a range in the query