### PR TITLE
Do not recommend logical config server DNS names for CSRS

### DIFF
--- a/source/tutorial/deploy-shard-cluster.txt
+++ b/source/tutorial/deploy-shard-cluster.txt
@@ -50,8 +50,6 @@ Deploy the Config Server Replica Set
 The config servers store the sharded cluster's metadata. The following
 steps deploy a three member replica set for the config servers.
 
-.. include:: /includes/tip-hostnames.rst
-
 #. Start all the config servers with both the :option:`--configsvr` and
    :option:`--replSet \<name\> <--replSet>` options:
 


### PR DESCRIPTION
The idea of having logical DNS names for the config servers only applies the old-style triplet of config servers.  The rationale for it is being able to redirect the logical DNS name mapping to another host, in order to "swap out" one of the 3 config servers.  However, in the context of config servers *as replsets*, this is bad advice - any situation where you would "swap out" an old-style config server, with CSRS you should instead just use normal replica set management operations to handle (eg. add a new member, remove another member, etc).