### PR TITLE
DOCS-7216, 7271 - Fix images for write operations

### DIFF
--- a/source/images/crud-annotated-mongodb-updateMany.svg
+++ b/source/images/crud-annotated-mongodb-updateMany.svg
@@ -13,7 +13,7 @@
         <tspan x="-126.5" y="5" font-family="Inconsolata" font-size="24" fill="#3299CC">{ age: { $lt: 18 } }, </tspan>
       </text>
       <text transform="matrix(1, 0, 0, 1, 215, 80)">
-        <tspan x="-180" y="5" font-family="Inconsolata" font-size="24" fill="#3299CC">{ $set: { status: "Reject" } } </tspan>
+        <tspan x="-180" y="5" font-family="Inconsolata" font-size="24" fill="#3299CC">{ $set: { status: "reject" } } </tspan>
       </text>
       <text transform="matrix(1, 0, 0, 1, 20, 110)">
         <tspan x="-15" y="5" font-family="Inconsolata" font-size="24" fill="#004069">)</tspan>

--- a/source/images/crud-annotated-sql-replaceOne.svg
+++ b/source/images/crud-annotated-sql-replaceOne.svg
@@ -13,7 +13,7 @@
         <tspan x="-18.5" y="7.5" font-family="Inconsolata" font-size="24" fill="#004571">SET</tspan>
       </text>
       <text transform="matrix(1, 0, 0, 1, 201.5, 47.5)">
-        <tspan x="-114.5" y="7.5" font-family="Inconsolata" font-size="24" fill="#3299CC">name = 'ann' </tspan>
+        <tspan x="-114.5" y="7.5" font-family="Inconsolata" font-size="24" fill="#3299CC">name = 'amy' </tspan>
       </text>
       <text transform="matrix(1, 0, 0, 1, 35.5, 137.5)">
         <tspan x="-30.5" y="7.5" font-family="Inconsolata" font-size="24" fill="#004069">WHERE</tspan>
@@ -22,7 +22,7 @@
         <tspan x="-103.167" y="7.5" font-family="Inconsolata" font-size="24" fill="#3299CC">name = 'sue'</tspan>
       </text>
       <text transform="matrix(1, 0, 0, 1, 201.5, 77.5)" id="age_=_'26'">
-        <tspan x="-114.5" y="7.5" font-family="Inconsolata" font-size="24" fill="#3299CC">age = '26'</tspan>
+        <tspan x="-114.5" y="7.5" font-family="Inconsolata" font-size="24" fill="#3299CC">age = '25'</tspan>
       </text>
       <text transform="matrix(1, 0, 0, 1, 201.5, 107.167)" id="status_=_'enrolled'">
         <tspan x="-114.5" y="7.5" font-family="Inconsolata" font-size="24" fill="#3299CC">status = 'enrolled'</tspan>

--- a/source/images/crud-annotated-sql-updateMany.svg
+++ b/source/images/crud-annotated-sql-updateMany.svg
@@ -13,7 +13,7 @@
         <tspan x="-18.5" y="7.5" font-family="Inconsolata" font-size="24" fill="#004571">SET</tspan>
       </text>
       <text transform="matrix(1, 0, 0, 1, 200.5, 47.5)">
-        <tspan x="-114.5" y="7.5" font-family="Inconsolata" font-size="24" fill="#3299CC">status = 'Enrolled' </tspan>
+        <tspan x="-114.5" y="7.5" font-family="Inconsolata" font-size="24" fill="#3299CC">status = 'reject' </tspan>
       </text>
       <text transform="matrix(1, 0, 0, 1, 35.5, 77.5)">
         <tspan x="-30.5" y="7.5" font-family="Inconsolata" font-size="24" fill="#004069">WHERE</tspan>

--- a/source/images/crud-annotated-sql-updateOne.svg
+++ b/source/images/crud-annotated-sql-updateOne.svg
@@ -13,7 +13,7 @@
         <tspan x="-18.5" y="7.5" font-family="Inconsolata" font-size="24" fill="#004571">SET</tspan>
       </text>
       <text transform="matrix(1, 0, 0, 1, 200.5, 47.5)">
-        <tspan x="-114.5" y="7.5" font-family="Inconsolata" font-size="24" fill="#3299CC">status = 'Enrolled' </tspan>
+        <tspan x="-114.5" y="7.5" font-family="Inconsolata" font-size="24" fill="#3299CC">status = 'reject' </tspan>
       </text>
       <text transform="matrix(1, 0, 0, 1, 35.5, 77.5)">
         <tspan x="-30.5" y="7.5" font-family="Inconsolata" font-size="24" fill="#004069">WHERE</tspan>


### PR DESCRIPTION
* write-operations-introduction had incorrect text. Changed
'enrolled' to 'reject' for updateOne/updateMany and fixed case to be consistent with examples