### PR TITLE
Use full fingerprint in docs

### DIFF
--- a/source/includes/steps-install-mongodb-on-ubuntu.yaml
+++ b/source/includes/steps-install-mongodb-on-ubuntu.yaml
@@ -9,7 +9,7 @@ action:
     `MongoDB public GPG Key <https://www.mongodb.org/static/pgp/server-3.2.asc>`_:
   language: sh
   code: |
-    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
+    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 42F3E95A2C4F08279C4960ADD68FA50FEA312927
 ---
 title: Create a list file for MongoDB.
 stepnum: 2


### PR DESCRIPTION
It is easy to create and upload a key with a 32bit key id collision to `keyserver.ubuntu.com`. Full details of the vulnerability can be found at https://evil32.com/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2558)
<!-- Reviewable:end -->
