### PR TITLE
Fixed creating neighborhoods  index

### DIFF
--- a/source/tutorial/geospatial-tutorial.txt
+++ b/source/tutorial/geospatial-tutorial.txt
@@ -166,7 +166,7 @@ collection using the :program:`mongo` shell:
 .. code-block:: javascript
 
    db.restaurants.createIndex({ location: "2dsphere" })
-   db.neighborhoods.createIndex({ coordinates: "2dsphere" })
+   db.neighborhoods.createIndex({ geometry: "2dsphere" })
 
 Exploring the Data
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The neighborhoods document structure looks like {"_id": ..., "geometry" : { "coordinates": [ ...],"type" : "Polygon"},"name":"..."}}

It makes more sense to create index like db.neighborhoods.createIndex({ geometry: "2dsphere" }) than db.neighborhoods.createIndex({ coordinates: "2dsphere" })