### PR TITLE
DOCS-7678 recommend kernel.pid_max of 64000

### DIFF
--- a/source/administration/production-checklist-operations.txt
+++ b/source/administration/production-checklist-operations.txt
@@ -192,7 +192,7 @@ Linux
    - Configure sufficient file handles (``fs.file-max``), kernel pid limit
      (``kernel.pid_max``), and maximum threads per process
      (``kernel.threads-max``) for your deployment. For large systems,
-     values of 98000, 32768, and 64000 are a good starting point.
+     values of 98000, 64000, and 64000 are a good starting point.
 
    - Ensure that your system has swap space configured. Refer to your
      operating system's documentation for details on appropriate sizing.


### PR DESCRIPTION
This is to match the ulimits nproc recommendation of 64000.