### PR TITLE
DOCS-7771: remove obsolete mongodump warning

### DIFF
--- a/source/tutorial/backup-small-sharded-cluster-with-mongodump.txt
+++ b/source/tutorial/backup-small-sharded-cluster-with-mongodump.txt
@@ -24,9 +24,6 @@ See :doc:`/core/backups` and
 information on backups in MongoDB and backups of sharded clusters in
 particular.
 
-.. important:: By default :program:`mongodump` issue its queries to
-   the non-primary nodes.
-
 Considerations
 --------------
 


### PR DESCRIPTION
   /tutorial/backup-small-sharded-cluster-with-mongodump
   contains obsolete warning on mongodump behavior.