### PR TITLE
minor: fix typos in fsyncLock/fsyncUnlock

### DIFF
--- a/source/includes/extracts-wired-tiger-base.yaml
+++ b/source/includes/extracts-wired-tiger-base.yaml
@@ -2,12 +2,12 @@ ref: _wt-fsync-lock-compatibility
 content: |
   .. versionchanged:: 3.2
  
-     Starting in MongoDB 3.2, {{operation}} can ensure that the data
-     files do not change for MongoDB instances using either the MMAPv1
-     or the WiredTiger storage engine, thus providing consistency for
-     the purposes of creating backups.
+     {{operation}} can ensure that the data files do not change for
+     MongoDB instances using either the MMAPv1 or the WiredTiger storage
+     engines, thus providing consistency for the purposes of creating
+     backups.
 
-     In previous MongoDB version, {{operation}} *cannot* guarantee a
+     In previous MongoDB versions, {{operation}} *cannot* guarantee a
      consistent set of files for low-level backups (e.g. via file copy
      ``cp``, ``scp``, ``tar``) for WiredTiger.
 

--- a/source/reference/method/db.fsyncLock.txt
+++ b/source/reference/method/db.fsyncLock.txt
@@ -15,9 +15,9 @@ Definition
 
 .. method:: db.fsyncLock()
 
-   Forces the :program:`mongod` to flush all pending write operations
-   to the disk and locks the *entire* :program:`mongod` instance to
-   prevent additional writes until the user releases the lock with the
+   Forces the :program:`mongod` to flush all pending write operations to
+   disk and locks the *entire* :program:`mongod` instance to prevent
+   additional writes until the user releases the lock with the
    :method:`db.fsyncUnlock()` command. :method:`db.fsyncLock()` is an
    administrative command.
 
@@ -29,7 +29,7 @@ Definition
 
         { fsync: 1, lock: true }
 
-   This function locks the database and create a window for
+   This function locks the database and creates a window for
    :doc:`backup operations </core/backups>`.
 
 

--- a/source/reference/method/db.fsyncUnlock.txt
+++ b/source/reference/method/db.fsyncUnlock.txt
@@ -22,7 +22,7 @@ Definition
 
    :method:`db.fsyncUnlock()` is an administrative operation.
 
-Wired Tiger Compatibility
--------------------------
+Compatibility with WiredTiger
+-----------------------------
 
 .. include:: /includes/extracts/wt-fsync-lock-compatibility.rst


### PR DESCRIPTION
I had a few nits with the spelling/grammar while reading the `fsyncLock()` and `fsyncUnlock()` pages. Please feel free to accept only some or none of these changes! :)