### PR TITLE
regex in $nin operator

### DIFF
--- a/source/reference/operator/query/nin.txt
+++ b/source/reference/operator/query/nin.txt
@@ -50,6 +50,27 @@ $nin
    document does not contain the ``tags`` field.
 
    .. include:: /includes/extracts/nin_operators_selectivity.rst
+   
+   Use the ``$nin`` Operator with a Regular Expression
+--------------------------------------------------
+
+The :query:`$nin` operator can specify matching values using regular
+expressions of the form ``/pattern/``. You *cannot* use :query:`$regex`
+operator expressions inside an :query:`$nin`.
+
+Consider the following example:
+
+.. code-block:: javascript
+
+   db.inventory.find( { tags: { $nin: [ /^be/, /^st/ ] } } )
+
+This query selects all documents in the ``inventory`` collection where
+the ``tags`` field holds an array that contains at least one element
+that not starts with either ``be`` or ``st``.
+
+.. note:: The regular expression of the form ``/pattern/`` is distinct
+   from a string value which is enclosed in quotes.
+
       
    .. seealso::
 


### PR DESCRIPTION
We can use regex in $nin operator. You have documented in $in operator but not in $nin operator. 