### PR TITLE
DOCS-7773: mongoexport defaults to primary readPreference

### DIFF
--- a/source/reference/program/mongoexport.txt
+++ b/source/reference/program/mongoexport.txt
@@ -33,11 +33,33 @@ Considerations
 Required Access
 ---------------
 
-In order to connect to a :program:`mongod` that enforces authorization
-with the :option:`--auth <mongod --auth>` option, you must use the
-:option:`--username <mongoexport --username>` and :option:`--password
-<mongoexport --password>` options. The connecting user must possess at a
-minimum, the :authrole:`read` role on the database that they are exporting.
+:program:`mongoexport` requires read access on the target database.
+
+Ensure that the connecting user posseses, at a minimum, the :authrole:`read`
+role on the target database.
+
+When connecting to a :program:`mongod` or :program:`mongos` that enforces
+:doc:`/core/authentication`, ensure you use the required security
+parameters based on the configured
+:ref:`authentication mechanism <available-authentication-mechanisms>`.
+
+.. _mongoexport-read-preference:
+
+Read Preference
+---------------
+
+:program:`mongoexport` defaults to :readmode:`primary` :ref:`read
+preference <replica-set-read-preference>` when connected to a :program:`mongos`
+or a :term:`replica set`.
+
+You can override the default read preference using the
+:option:`--readPreference <mongoexport --readPreference>` option.
+
+.. important::
+
+   Using a non-primary read preference on a :program:`mongos` may
+   produce inconsistencies in data, including duplicates or missing
+   documents.
 
 Options
 -------


### PR DESCRIPTION
Recommend holding until DOCS-7774 is ready for pull, otherwise one of the links will not work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2632)
<!-- Reviewable:end -->
