### PR TITLE
DOCS-7997: kerberos conf file is krb5.conf not kerb5.conf

### DIFF
--- a/source/core/kerberos.txt
+++ b/source/core/kerberos.txt
@@ -100,7 +100,7 @@ Service principal names must be reachable over the network using the
 fully qualified domain name (FQDN) part of its service principal name.
 
 By default, Kerberos attempts to identify hosts using the
-``/etc/kerb5.conf`` file before using DNS to resolve hosts.
+``/etc/krb5.conf`` file before using DNS to resolve hosts.
 
 On Windows, if running MongoDB as a service, see
 :ref:`assign-service-principal-name`.

--- a/source/tutorial/troubleshoot-kerberos.txt
+++ b/source/tutorial/troubleshoot-kerberos.txt
@@ -51,7 +51,7 @@ with :doc:`Kerberos </core/kerberos>`, ensure that:
 - Both the Kerberos Key Distribution Center (KDC) and the system
   running :program:`mongod` instance or :program:`mongos` must be able
   to resolve each other using DNS. By default, Kerberos attempts to
-  resolve hosts using the content of the ``/etc/kerb5.conf`` before
+  resolve hosts using the content of the ``/etc/krb5.conf`` before
   using DNS to resolve hosts.
 
 - The time synchronization of the systems running :program:`mongod` or


### PR DESCRIPTION
If we could cherry-pick this into v3.0 and v2.6, that'd be super. (I'm also happy to push it there myself.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2635)
<!-- Reviewable:end -->
