### PR TITLE
Small correction about findOne uses.

### DIFF
--- a/source/tutorial/query-documents.txt
+++ b/source/tutorial/query-documents.txt
@@ -717,7 +717,7 @@ The query returns the following documents:
 Additional Methods
 ------------------
 
-The following methods can also delete documents from a collection:
+The following methods can also read documents from a collection:
 
 - :method:`db.collection.findOne` [#findOne]_
 


### PR DESCRIPTION
The text was saying findOne is used to remove documents instead of reading them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2638)
<!-- Reviewable:end -->
