### PR TITLE
DOCS-7979: Unclean shutdown may cause 60 seconds of drift in collStat…

### DIFF
--- a/source/includes/fact-unexpected-shutdown-accuracy.rst
+++ b/source/includes/fact-unexpected-shutdown-accuracy.rst
@@ -1,0 +1,13 @@
+After an unclean shutdown of a :program:`mongod` using the :doc:`Wired Tiger
+</core/wiredtiger>` storage engine, |opt| statistics reported by
+|cmd| may be inaccurate.
+
+The amount of drift depends on the number of insert, update, or delete
+operations performed between the last :ref:`checkpoint
+<storage-wiredtiger-checkpoints>` and the unclean shutdown. Checkpoints
+usually occur every 60 seconds. However, :program:`mongod` instances running
+with non-default :option:`syncDelay` settings may have more or less frequent
+checkpoints.
+
+Run :dbcommand:`validate` on each collection on the :program:`mongod` to
+to restore the correct statistics after an unclean shutdown.

--- a/source/reference/command/collStats.txt
+++ b/source/reference/command/collStats.txt
@@ -17,11 +17,11 @@ Definition
 
    The :dbcommand:`collStats` command returns a variety of storage statistics
    for a given collection.
-   
+
    .. |command| replace:: ``collStats``
 
    .. include:: /includes/fact-dbcommand.rst
-   
+
    The :dbcommand:`collStats` command has the following syntax:
 
    .. code-block:: javascript
@@ -39,19 +39,18 @@ Definition
 Behavior
 --------
 
-Unexpected Shutdown and Count
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Accuracy after Unexpected Shutdown
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For MongoDB instances using the :doc:`WiredTiger </core/wiredtiger>`
-storage engine, after an unclean shutdown, statistics on size and count
-may off by up to 1000 documents as reported by :dbcommand:`collStats`,
-:dbcommand:`dbStats`, :dbcommand:`count`. Run :dbcommand:`validate` on
-the collection to restore the correct statistics for the collection.
+.. |cmd| replace:: :dbcommand:`collStats`
+.. |opt| replace:: size
+
+.. include:: /includes/fact-unexpected-shutdown-accuracy.rst
 
 Example
 -------
 
-The following operation runs the :dbcommand:`collStats` command on the 
+The following operation runs the :dbcommand:`collStats` command on the
 ``restaurant`` collection, specifying a scale of ``1024`` bytes:
 
 .. code-block:: javascript
@@ -236,8 +235,8 @@ Output
 
    The total amount of storage allocated to this collection for
    :term:`document` storage. The ``scale`` argument affects this
-   value. 
-   
+   value.
+
    :data:`~collStats.storageSize` does not include index size. See
    :data:`~collStats.totalIndexSize` for index sizing.
 

--- a/source/reference/method/db.collection.count.txt
+++ b/source/reference/method/db.collection.count.txt
@@ -45,15 +45,17 @@ Index Use
 
 .. include:: /includes/fact-count-index-use.rst
 
-Unexpected Shutdown and Count
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Accuracy after Unexpected Shutdown
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For MongoDB instances using the :doc:`WiredTiger </core/wiredtiger>`
-storage engine, after an unclean shutdown, statistics on size and count
-may off by up to 1000 documents as reported by :dbcommand:`collStats`,
-:dbcommand:`dbStats`, :dbcommand:`count`. To restore the correct
-statistics for the collection, run :dbcommand:`validate` on the
-collection.
+.. |cmd| replace:: :method:`~db.collection.count()`
+.. |opt| replace:: count
+
+.. include:: /includes/fact-unexpected-shutdown-accuracy.rst
+
+.. note:: 
+   This loss of accuracy only applies to :method:`~db.collection.count()`
+   operations that do *not* include a query predicate.
 
 Examples
 --------


### PR DESCRIPTION
…s or count

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2644)
<!-- Reviewable:end -->
