### PR TITLE
minor: grammar fixes in fsync

### DIFF
--- a/source/reference/command/fsync.txt
+++ b/source/reference/command/fsync.txt
@@ -48,7 +48,7 @@ Impact on Larger Deployments
 
 An :dbcommand:`fsync` lock is only possible on *individual*
 :program:`mongod` instances of a
-sharded cluster, not on the entire cluster. To backup an entire sharded
+sharded cluster, not on the entire cluster. To back up an entire sharded
 cluster, please see :doc:`/administration/backup-sharded-clusters` for
 more information.
 
@@ -57,16 +57,16 @@ Alternatives with Journaling
 
 If your :program:`mongod` has :term:`journaling <journal>` enabled,
 consider using :ref:`another method <backup-with-journaling>` to create a
-back up of the data set.
+backup of the data set.
 
 Impact on Read Operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-After :dbcommand:`fsync`, with lock, runs on a :program:`mongod`,
-all write operations will block until a subsequent unlock. Read operations *may* also
-block. As a result, :dbcommand:`fsync`,
-with lock, is not a reliable mechanism for making
-a :program:`mongod` instance operate in a read-only mode.
+After :dbcommand:`fsync` with the ``lock`` option runs on a
+:program:`mongod`, all write operations will block until a subsequent
+unlock. Read operations *may* also block. As a result, :dbcommand:`fsync`
+with lock is not a reliable mechanism for making a :program:`mongod`
+instance operate in a read-only mode.
 
 .. important::
 
@@ -76,8 +76,9 @@ a :program:`mongod` instance operate in a read-only mode.
 
 .. warning::
 
-   When calling :dbcommand:`fsync` with lock, ensure that the connection remains
-   open to allow a subsequent call to :method:`db.fsyncUnlock()`.
+   When calling :dbcommand:`fsync` with the ``lock`` option, ensure that
+   the connection remains open to allow a subsequent call to
+   :method:`db.fsyncUnlock()`.
 
    Closing the connection may make it difficult to release the lock.
 
@@ -87,7 +88,7 @@ Examples
 Run Asynchronously
 ~~~~~~~~~~~~~~~~~~
 
-The :dbcommand:`fsync` operation is synchronous by default To run
+The :dbcommand:`fsync` operation is synchronous by default. To run
 :dbcommand:`fsync` asynchronously, use the ``async`` field set to
 ``true``:
 


### PR DESCRIPTION
Fixed "backup" and "back up", as well as a missing period.

I also changed

    :dbcommand:`fsync` with lock

to

    :dbcommand:`fsync` with the ``lock`` option

because I thought it sounded clearer; it also matches the wording elsewhere in the page. Feel free to dismiss.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2646)
<!-- Reviewable:end -->
