### PR TITLE
DOCS-8080 Fixing typo in bookmarks example.

### DIFF
--- a/source/reference/operator/aggregation/project.txt
+++ b/source/reference/operator/aggregation/project.txt
@@ -187,7 +187,7 @@ Consider a ``bookmarks`` collection with the following documents:
 .. code-block:: javascript
 
    { _id: 1, user: "1234", stop: { title: "book1", author: "xyz", page: 32 } }
-   { _id: 2, user: "7890", stop: [ { title: "book2", author: "abc", page: 5 }, { title: "b", author: "ijk", page: 100 } ] }
+   { _id: 2, user: "7890", stop: [ { title: "book2", author: "abc", page: 5 }, { title: "book3", author: "ijk", page: 100 } ] }
 
 To include only the ``title`` field in the embedded document in the
 ``stop`` field, you can use  the :term:`dot notation`:


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2647)
<!-- Reviewable:end -->
