### PR TITLE
DOCS-7945: Fix the wrong index in the example

### DIFF
--- a/source/core/query-optimization.txt
+++ b/source/core/query-optimization.txt
@@ -159,9 +159,9 @@ An index **cannot** cover a query if:
 
   .. code-block:: none
 
-     { "user.login": 1 }
+     { "user": 1 }
 
-  The ``{ "user.login": 1 }`` index does **not** cover the
+  The ``{ "user": 1 }`` index does **not** cover the
   following query:
 
   .. code-block:: none


### PR DESCRIPTION
Based on the context, I think the first 2 `{ "user.login": 1 }` should be `{ "user": 1}`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2648)
<!-- Reviewable:end -->
