### PR TITLE
minor: moveChunk parameter name is "_secondaryThrottle"

### DIFF
--- a/source/includes/apiargs-command-moveChunk-field.yaml
+++ b/source/includes/apiargs-command-moveChunk-field.yaml
@@ -54,7 +54,7 @@ description: |
   and deletes data during chunk migrations. For details, see
   :ref:`sharded-cluster-config-secondary-throttle`.
 interface: command
-name: secondaryThrottle
+name: _secondaryThrottle
 operation: moveChunk
 optional: true
 position: 5


### PR DESCRIPTION
The argument table is missing an underscore in the name for `_secondaryThrottle`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2652)
<!-- Reviewable:end -->
