### PR TITLE
DOCS-8141 connectionStatus lacks a usage box

### DIFF
--- a/source/reference/command/connectionStatus.txt
+++ b/source/reference/command/connectionStatus.txt
@@ -20,6 +20,10 @@ Definition
    Returns information about the current connection, specifically the
    state of authenticated users and their available permissions.
 
+   .. code-block:: javascript
+
+      db.runCommand( { connectionStatus: 1 } )
+
 Output
 ------
 


### PR DESCRIPTION
Adds a code block box with the run command syntax.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2653)
<!-- Reviewable:end -->
