### PR TITLE
Removed repetition of Document Size in docs

### DIFF
--- a/source/includes/fact-update-field-order.rst
+++ b/source/includes/fact-update-field-order.rst
@@ -1,7 +1,3 @@
-When performing update operations that increase the document size
-beyond the allocated space for that document, the update operation
-relocates the document on disk.
-
 .. order-of-document-fields
 
 MongoDB preserves the order of the document fields following write


### PR DESCRIPTION
Hi there :tophat: ,

This PR is just removing some repetitions in mongoDB manual update docs [here](https://docs.mongodb.com/manual/tutorial/update-documents/#field-order).

- Before

 >**Document Size**
When performing update operations that increase the document size beyond the allocated space for that document, the update operation relocates the document on disk.
**Field Order**
When performing update operations that increase the document size beyond the allocated space for that document, the update operation relocates the document on disk.
MongoDB preserves the order of the document fields following write operations except for the following cases:
The _id field is always the first field in the document.
Updates that include renaming of field names may result in the reordering of fields in the document.
Changed in version 2.6: Starting in version 2.6, MongoDB actively attempts to preserve the field order in a document. Before version 2.6, MongoDB did not actively preserve the order of the fields in a document.

- After

 >**Document Size**
When performing update operations that increase the document size beyond the allocated space for that document, the update operation relocates the document on disk.
**Field Order**
~~When performing update operations that increase the document size beyond the allocated space for that document, the update operation relocates the document on disk.~~
MongoDB preserves the order of the document fields following write operations except for the following cases:
The _id field is always the first field in the document.
Updates that include renaming of field names may result in the reordering of fields in the document.
Changed in version 2.6: Starting in version 2.6, MongoDB actively attempts to preserve the field order in a document. Before version 2.6, MongoDB did not actively preserve the order of the fields in a document.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2655)
<!-- Reviewable:end -->
