### PR TITLE
Mention that removeShard draining uses the balancer

### DIFF
--- a/source/reference/command/removeShard.txt
+++ b/source/reference/command/removeShard.txt
@@ -13,9 +13,9 @@ removeShard
 .. dbcommand:: removeShard
 
    Removes a shard from a :term:`sharded cluster`. When you run
-   :dbcommand:`removeShard`, MongoDB drains the shard by moving the shard's
-   chunks to other shards in the cluster. Once the shard is drained, MongoDB
-   removes the shard from the cluster.
+   :dbcommand:`removeShard`, MongoDB drains the shard by using the balancer to
+   move the shard's chunks to other shards in the cluster. Once the shard is
+   drained, MongoDB removes the shard from the cluster.
    
    .. |command| replace:: ``removeShard``
 


### PR DESCRIPTION
Follow-up from DOCS-7777.  That the balancer is the mechanism by which shards are drained is mentioned briefly in the Example.  This change makes the balancer's involvement much more explicit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2658)
<!-- Reviewable:end -->
