### PR TITLE
Added note about settings.heartbeatTimeoutSecs

### DIFF
--- a/source/reference/replica-configuration.txt
+++ b/source/reference/replica-configuration.txt
@@ -386,6 +386,10 @@ Replica Set Configuration Fields
       respond in time, other members mark the delinquent member as
       inaccessible.
 
+      The setting only applies when using :rsconf:`protocolVersion: 0`. 
+      When using :rsconf:`protocolVersion: 1` the relevant setting is 
+      :rsconf:`settings.electionTimeoutMillis`.
+
    .. rsconf::  settings.electionTimeoutMillis
 
       .. versionadded:: 3.2


### PR DESCRIPTION
heartbeatTimeoutSecs is only applicable for replication protocol v0.

This edit was going to be much smaller, then I decided to write more, and as a result I'm not sure if I got the formatting right. Please fix if needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2659)
<!-- Reviewable:end -->
