### PR TITLE
DOCS-7935 Added upsert caveat that if querying on a specific value fo…

### DIFF
--- a/source/includes/apiargs-method-db.collection.findAndModify-param.yaml
+++ b/source/includes/apiargs-method-db.collection.findAndModify-param.yaml
@@ -77,10 +77,14 @@ arg_name: param
 description: |
   Used in conjunction with the ``update`` field.
 
-  When ``true``, |operation| creates a new
-  document if no document matches the ``query``, or if documents match
-  the ``query``, |operation| performs an
-  update. To avoid multiple upserts, ensure that the ``query`` fields
+  When ``true``, |operation| either:
+
+  - Creates a new document if no documents match the ``query``. For more
+    details see :ref:`upsert behavior <upsert-behavior>`.
+
+  - Updates a single document that matches the ``query``.
+
+  To avoid multiple upserts, ensure that the ``query`` fields
   are :ref:`uniquely indexed <index-type-unique>`.
 
   The default is ``false``.

--- a/source/includes/apiargs-method-db.collection.findOneAndReplace-param.yaml
+++ b/source/includes/apiargs-method-db.collection.findOneAndReplace-param.yaml
@@ -71,19 +71,19 @@ type: number
 ---
 arg_name: param
 description: |
-   When ``true``, :method:`~db.collection.findOneAndReplace()` creates a new 
-   document if no document matches the ``filter``. If a document matches the 
-   filter, the method performs a replacement.
+  When ``true``, :method:`~db.collection.findOneAndReplace()` either:
+
+  - Inserts the document from the ``replacement`` parameter if no document matches the
+    ``filter``. Returns ``null`` after inserting the new document, unless
+    ``returnNewDocument`` is ``true``.
+
+  - Replaces the document that matches the ``filter`` with the ``replacement`` document.
    
-   The new document is created using the equality conditions from the 
-   ``filter`` with the ``replacement`` document.
+  MongoDB will add the ``_id`` field to the replacement document if it is not specified
+  in either the ``filter`` or ``replacement`` documents. If ``_id`` is present in both,
+  the values must be equal.
    
-   Comparison conditions like :query:`$gt` or :query:`$lt` are ignored.
-   
-   Returns ``null`` after inserting the new document, unless 
-   ``returnNewDocument`` is ``true``.
-   
-   Defaults to ``false``.
+  Defaults to ``false``.
    
 interface: method
 name: upsert

--- a/source/includes/apiargs-method-db.collection.replaceOne-param.yaml
+++ b/source/includes/apiargs-method-db.collection.replaceOne-param.yaml
@@ -30,8 +30,16 @@ type: document
 ---
 arg_name: param
 description: |
-  When ``true``, if no documents match the ``filter``, a new document is 
-  inserted based on the ``replacement`` document.
+  When ``true``, :method:`~db.collection.replaceOne()` either:
+
+  - Inserts the document from the ``replacement`` parameter if no document matches the
+    ``filter``. 
+
+  - Replaces the document that matches the ``filter`` with the ``replacement`` document.
+
+  MongoDB will add the ``_id`` field to the replacement document if it is not specified
+  in either the ``filter`` or ``replacement`` documents. If ``_id`` is present in both,
+  the values must be equal.
   
 interface: method
 name: upsert

--- a/source/reference/method/Bulk.find.upsert.txt
+++ b/source/reference/method/Bulk.find.upsert.txt
@@ -66,8 +66,8 @@ a replacement document that only contains field and value pairs:
 
 If the replacement operation with the :method:`Bulk.find.upsert()`
 option performs an insert, the inserted document is the replacement
-document. If the replacement document does not specify an ``_id``
-field, MongoDB adds the ``_id`` field:
+document. If neither the replacement document nor the query document
+specifies an ``_id`` field, MongoDB adds the ``_id`` field:
 
 .. code-block:: javascript
 
@@ -82,13 +82,13 @@ Insert for ``Bulk.find.updateOne()``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The :method:`Bulk.find.updateOne()` method accepts, as its parameter,
-an ``<update>`` document that contains only field and value pairs or
+an update document that contains only field and value pairs or
 only :ref:`update operator <update-operators>` expressions.
 
 Field and Value Pairs
 `````````````````````
 
-If the ``<update>`` document contains only field and value pairs:
+If the update document contains only field and value pairs:
 
 .. code-block:: javascript
 
@@ -104,9 +104,9 @@ If the ``<update>`` document contains only field and value pairs:
    bulk.execute();
 
 Then, if the update operation with the :method:`Bulk.find.upsert()`
-option performs an insert, the inserted document is the ``<update>``
-document. If the update document does not specify an ``_id`` field,
-MongoDB adds the ``_id`` field:
+option performs an insert, the inserted document is the update
+document. If neither the update document nor the query document
+specifies an ``_id`` field, MongoDB adds the ``_id`` field:
 
 .. code-block:: javascript
 
@@ -121,7 +121,7 @@ MongoDB adds the ``_id`` field:
 Update Operator Expressions
 ```````````````````````````
 
-If the ``<update>`` document contains contains only :ref:`update
+If the update document contains contains only :ref:`update
 operator <update-operators>` expressions:
 
 .. code-block:: javascript
@@ -138,9 +138,10 @@ operator <update-operators>` expressions:
 
 Then, if the update operation with the :method:`Bulk.find.upsert()`
 option performs an insert, the update operation inserts a document with
-field and values from the ``<query>`` document of the
+field and values from the query document of the
 :method:`Bulk.find()` method and then applies the specified update from
-the ``<update>`` document:
+the update document. If neither the update document nor the query document
+specifies an ``_id`` field, MongoDB adds the ``_id`` field:
 
 .. code-block:: javascript
 
@@ -154,9 +155,6 @@ the ``<update>`` document:
       "points" : "0"
    }
 
-If neither the ``<query>`` document nor the ``<update>`` document
-specifies an ``_id`` field, MongoDB adds the ``_id`` field.
-
 Insert for ``Bulk.find.update()``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -165,7 +163,7 @@ update method :method:`Bulk.find.update()`, if no documents match the
 query condition, the update operation inserts a *single* document.
 
 The :method:`Bulk.find.update()` method accepts, as its parameter, an
-``<update>`` document that contains *only* :ref:`update operator
+update document that contains *only* :ref:`update operator
 <update-operators>` expressions:
 
 .. code-block:: javascript
@@ -182,9 +180,11 @@ The :method:`Bulk.find.update()` method accepts, as its parameter, an
 
 Then, if the update operation with the :method:`Bulk.find.upsert()`
 option performs an insert, the update operation inserts a single
-document with the fields and values from the ``<query>`` document of
+document with the fields and values from the query document of
 the :method:`Bulk.find()` method and then applies the specified update
-from the ``<update>`` document:
+from the update document. If neither the update document
+nor the query document specifies an ``_id`` field, MongoDB adds
+the ``_id`` field:
 
 .. code-block:: javascript
 
@@ -196,9 +196,6 @@ from the ``<update>`` document:
       "lastModified": ISODate("2014-01-21T20:27:06.691Z"),
       "points": "0"
    }
-
-If neither the ``<query>`` document nor the ``<update>`` document
-specifies an ``_id`` field, MongoDB adds the ``_id`` field.
 
 .. seealso::
 

--- a/source/reference/method/db.collection.update.txt
+++ b/source/reference/method/db.collection.update.txt
@@ -114,6 +114,8 @@ expressions, then:
 Upsert Option
 ~~~~~~~~~~~~~
 
+.. _upsert-behavior:
+
 Upsert Behavior
 ```````````````
 
@@ -122,7 +124,10 @@ criteria, :method:`~db.collection.update()` inserts a *single* document.
 The update creates the new document with either:
 
 - The fields and values of the ``<update>`` parameter if the
-  ``<update>`` parameter contains only field and value pairs, or
+  ``<update>`` parameter is a replacement document (i.e., contains
+  only field and value pairs). If neither the ``<query>`` nor the
+  ``<update>`` document specifies an ``_id`` field, MongoDB adds
+  the ``_id`` field with an :ref:`objectid` value.
 
 - The fields and values of both the ``<query>`` and ``<update>``
   parameters if the ``<update>`` parameter contains :ref:`update


### PR DESCRIPTION
…r _id without update operators and the upsert occurs, the _id will be added as part of the new document. -JD

DOCS-7935 Changed language for db.collection.update.  Added that update() and findAndModify() handle upserts similarly.  Updated parameter files to reflect upsert findings.  Removed incorrect statements for findOneAndReplace(). - JD

DOCS-7935 Fixed incorrectly named parameter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2662)
<!-- Reviewable:end -->
