### PR TITLE
Username/password containing @ and : must be URL encoded

### DIFF
--- a/source/reference/connection-string.txt
+++ b/source/reference/connection-string.txt
@@ -51,6 +51,8 @@ The components of this string are:
        specific database using these credentials after connecting to
        the :program:`mongod` instance.
 
+       If username or password contains an at-sign ("@") or colon (":") then the username and/or password must be URL encoded. At-sign ("@") is replaced with "%40" (3 characters), while colon (":") is replaced with "%3A" (3 characters).
+
    * - ``host1``
 
      - Required. It identifies a server


### PR DESCRIPTION
Reference: https://github.com/mongodb/specifications/blob/master/source/connection-string/connection-string-spec.rst#userinfo-optional

Usernames and passwords that contain @ or : require these symbols to be URL encoded.

https://jira.mongodb.org/browse/DOCS-8333

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2665)

<!-- Reviewable:end -->
