### PR TITLE
add missing word and colon

### DIFF
--- a/source/crud.txt
+++ b/source/crud.txt
@@ -44,7 +44,7 @@ For examples, see :doc:`/tutorial/insert-documents`.
 Read Operations
 ---------------
 
-Read operations :ref:`documents <bson-document-format>` from a
+Read operations read :ref:`documents <bson-document-format>` from a
 :ref:`collection <collections>`; i.e. queries a collection for
 documents. MongoDB provides the following methods to read documents from
 a collection:
@@ -89,7 +89,7 @@ Delete Operations
 -----------------
 
 Delete operations remove documents from a collection. MongoDB provides
-the following methods to delete documents of a collection
+the following methods to delete documents of a collection:
 
 - :method:`db.collection.remove()`
 


### PR DESCRIPTION
> Read operations documents from a collection; i.e. queries a collection for documents

I think you miss "read" after "operations"
> MongoDB provides the following methods to delete documents of a collection

I think you miss ":"  after "collection".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2672)
<!-- Reviewable:end -->
