### PR TITLE
fix field names with dot by replacing document

### DIFF
--- a/source/release-notes/2.6-compatibility.txt
+++ b/source/release-notes/2.6-compatibility.txt
@@ -531,9 +531,8 @@ Solution
      existing document.
 
    - For existing documents that have fields with names that contain a
-     dot (``.``), either replace the whole document or :update:`unset
-     <$unset>` the field. To find fields whose names contain a dot, run
-     :method:`db.upgradeCheckAllDBs()`.
+     dot (``.``), replace the whole document. To find fields whose
+     names contain a dot, run :method:`db.upgradeCheckAllDBs()`.
 
    - For existing documents that have fields with names that start with
      a dollar sign (``$``), :update:`unset <$unset>` or :update:`rename


### PR DESCRIPTION
$unset won't work on 2.6 onwards while replacing the the entire document works in all versions

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2675)

<!-- Reviewable:end -->
