### PR TITLE
Corrected case issue

### DIFF
--- a/source/core/gridfs.txt
+++ b/source/core/gridfs.txt
@@ -320,7 +320,7 @@ You cannot use :doc:`/core/hashed-sharding` when sharding the ``chunks``
 collection.
 
 The ``files`` collection is small and only contains metadata. None of the
-required keys for GridfS lend themselves to an even distribution in a 
+required keys for GridFS lend themselves to an even distribution in a 
 sharded environment. If you *must* shard the ``files`` collection, use the 
 ``_id`` field, possibly in combination with an application field.
 


### PR DESCRIPTION
GridFS was written incorrectly in the documentation (Grid**f**S).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2690)
<!-- Reviewable:end -->
