### PR TITLE
Fixed mongod systemd service path on Ubuntu 16.04

### DIFF
--- a/source/includes/steps-install-mongodb-on-ubuntu.yaml
+++ b/source/includes/steps-install-mongodb-on-ubuntu.yaml
@@ -94,7 +94,7 @@ action:
 
        Follow this step ONLY if you are running Ubuntu 16.04.
 
-    Create a new file at /lib/systemd/system/mongod.service with the
+    Create a new file at /etc/systemd/system/mongod.service with the
     following contents:
   language: ini
   code: |


### PR DESCRIPTION
Fixed mongod systemd service path on Ubuntu 16.04.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2691)
<!-- Reviewable:end -->
