### PR TITLE
DOCS-8507: Internal authentication is no longer using MongoDB-CR

### DIFF
--- a/source/core/security-x.509.txt
+++ b/source/core/security-x.509.txt
@@ -68,9 +68,11 @@ For an example, see :doc:`/tutorial/configure-x509-client-authentication`
 Member x.509 Certificates
 --------------------------
 
+.. versionadded:: 3.0
+
 For internal authentication, members of sharded clusters and replica sets
-can use x.509 certificates instead of keyfiles, which use
-:doc:`/core/security-mongodb-cr` authentication mechanism.
+can use x.509 certificates instead of keyfiles, which use the
+:doc:`/core/security-scram-sha-1` authentication mechanism.
 
 Member Certificate Requirements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2701)
<!-- Reviewable:end -->
