### PR TITLE
DOCS-7410: Document mongodump behaviour when connecting to a replica set

### DIFF
--- a/source/reference/program/mongodump.txt
+++ b/source/reference/program/mongodump.txt
@@ -61,11 +61,51 @@ Version Compatibility
 Read Preference
 ~~~~~~~~~~~~~~~
 
+Replica Sets
+````````````
+
+.. versionchanged:: 3.2.0
+
+   The choice of target or targets for the :option:`--host`
+   parameter affects the read preference of :program:`mongodump`
+   when connecting to a replica set.
+
+   - If the string passed to ``--host`` is prefixed by the replica set name,
+     :program:`mongodump` reads from the :readmode:`primary` replica set 
+     member by default. For example:
+
+     .. code-block:: javascript
+
+       --host "replSet/rep1.example.net:27017,rep2.example.net:27017,rep3.example.net:27017"
+
+   - If the string passed to ``--host`` contains a list of
+     :program:`mongod` instances, but does not include the replica set
+     name as a prefix to the host string, :program:`mongodump`
+     reads from the :readmode:`nearest` node by default. For example:
+
+     .. code-block:: javascript
+
+       --host "rep1.example.net:27017,rep2.example.net:27017,rep3.example.net:27017"
+
+Sharded Clusters
+````````````````
+
 .. versionchanged:: 3.0.5
 
    For a sharded cluster where the shards are replica sets,
-   :program:`mongodump`, when run against the :program:`mongos`
-   instance, no longer prefers reads from secondary members.
+   :program:`mongodump` no longer prefers reads from secondary
+   members when run against the :program:`mongos` instance.
+
+For sharded clusters, specify the hostname of a :program:`mongos`
+for the ``--host`` option.
+:program:`mongodump` reads from the :readmode:`primary` replica set
+member on each shard replica set in the cluster.
+
+Unsharded collections in a sharded cluster are stored on a
+:ref:`primary shard <primary-shard>`.
+:program:`mongodump` reads from the primary replica set member on
+the primary shard for any unsharded collections. Note: each
+database has its own primary shard.
 
 Overwrite Files
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
DOCS-7410: latest round of edits

DOCS-7410: fixed wording

DOCS-7410: clarifying the nuances of mongodump and sharded clusters

DOCS-7410: improved links to referenced terms

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2702)
<!-- Reviewable:end -->
