### PR TITLE
DOCS-7112: added note about index building with movePrimary

### DIFF
--- a/source/reference/command/movePrimary.txt
+++ b/source/reference/command/movePrimary.txt
@@ -20,11 +20,26 @@ movePrimary
 
    .. code-block:: javascript
 
-      { movePrimary : "test", to : "shard0001" }
+      db.runCommand( { movePrimary: <currentPrimaryShard>, to: <newPrimaryShard> } )
 
-   When the command returns, the database's primary location will
-   shift to the designated shard. To fully decommission a
+   For example, the following command moves the primary shard from ``test`` to
+   ``shard0001``:
+
+   .. code-block:: javascript
+
+      db.runCommand( { movePrimary : "test", to : "shard0001" } )
+
+   When the command returns, the database's primary shard location
+   has switched to the specified shard. To fully decommission a
    shard, use the :dbcommand:`removeShard` command.
+
+   .. note::
+
+      The destination shard must rebuild its indexes
+      in the foreground when it becomes the primary shard.
+      The collection locks while the indexes are building,
+      preventing reads and writes until the indexes are finished.
+      See :doc:`/core/index-creation` for details.
 
    :dbcommand:`movePrimary` is an administrative command that is only available
    for :program:`mongos` instances.


### PR DESCRIPTION
DOCS-7112: changed wording on movePrimary entry
Removed conditional 'if' around paragraph on index building
Fixed 2 quibbles

DOCS-7112: added prototype to example

DOCS-7112: more specificity when referring to primary shards

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2703)
<!-- Reviewable:end -->
