### PR TITLE
DOCS-8593: emphasizes SSL certs must be FIPS-compliant

### DIFF
--- a/source/tutorial/configure-fips.txt
+++ b/source/tutorial/configure-fips.txt
@@ -26,11 +26,12 @@ Prerequisites
 -------------
 
 .. important::
+
    .. include:: /includes/extracts/security-prereq-configure-fips.rst
 
-Only the `MongoDB Enterprise`_ version supports FIPS mode. See
+Only `MongoDB Enterprise`_ edition supports FIPS mode. See
 :doc:`/administration/install-enterprise` to download and install
-`MongoDB Enterprise`_ to use FIPS mode.
+`MongoDB Enterprise`_.
 
 Your system must have an OpenSSL library configured with the FIPS 140-2
 module. At the command line, type ``openssl version`` to confirm your
@@ -68,10 +69,10 @@ system. However, if your environment requires FIPS compliant encryption
 uses only FIPS-compliant encryption.
 
 MongoDB's FIPS support covers the way that MongoDB uses OpenSSL for
-network encryption and X509 authentication. If you use Kerberos or
-LDAP Proxy authentication, you must ensure that these external
-mechanisms are FIPS-compliant. ``MONGODB-CR`` authentication is *not*
-FIPS compliant.
+network encryption, ``SCRAM-SHA-1`` authentication, and x.509
+authentication. If you use Kerberos or LDAP authentication, you must
+ensure that these external mechanisms are FIPS-compliant.
+``MONGODB-CR`` authentication is **not** FIPS compliant.
 
 Procedure
 ---------
@@ -79,7 +80,9 @@ Procedure
 Configure MongoDB to use TLS/SSL
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-See :doc:`/tutorial/configure-ssl` for details about configuring OpenSSL.
+See :doc:`/tutorial/configure-ssl` for details about configuring
+OpenSSL. For FIPS mode, use FIPS-compliant algorithms and ensure that 
+the private key used to sign the certificate meets the PKCS#8 standard.
 
 Run ``mongod`` or ``mongos`` instance in FIPS mode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -88,10 +91,10 @@ Perform these steps after you :doc:`/tutorial/configure-ssl`.
 
 .. include:: /includes/steps/fips-config.rst
 
-Confirm FIPS mode is running
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Confirm that FIPS mode is running
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Check the server log file for a message FIPS is active:
+Check the server log file for a message that FIPS is active:
 
 .. code-block:: sh
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2711)
<!-- Reviewable:end -->
