### PR TITLE
DOCS-8478: Size and Count accuracy in WT after unexpected shutdown

### DIFF
--- a/source/includes/fact-unexpected-shutdown-accuracy.rst
+++ b/source/includes/fact-unexpected-shutdown-accuracy.rst
@@ -6,8 +6,10 @@ The amount of drift depends on the number of insert, update, or delete
 operations performed between the last :ref:`checkpoint
 <storage-wiredtiger-checkpoints>` and the unclean shutdown. Checkpoints
 usually occur every 60 seconds. However, :program:`mongod` instances running
-with non-default :option:`syncDelay` settings may have more or less frequent
+with non-default :option:`--syncdelay` settings may have more or less frequent
 checkpoints.
 
 Run :dbcommand:`validate` on each collection on the :program:`mongod` to
-to restore the correct statistics after an unclean shutdown.
+to restore the correct statistics after an unclean shutdown. If multiple
+:program:`mongod` instances experienced an unclean shutdown, perform the
+validation procedure on each :program:`mongod`. 

--- a/source/reference/command/count.txt
+++ b/source/reference/command/count.txt
@@ -44,12 +44,17 @@ Behavior
 
 .. include:: /includes/extracts/fact-count-on-sharded-clusters-cmd-count.rst
 
-For MongoDB instances using the :doc:`WiredTiger </core/wiredtiger>`
-storage engine, after an unclean shutdown, statistics on size and count
-may off by up to 1000 documents as reported by :dbcommand:`collStats`,
-:dbcommand:`dbStats`, :dbcommand:`count`. To restore the correct
-statistics for the collection, run :dbcommand:`validate` on the
-collection.
+Accuracy after Unexpected Shutdown
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. |cmd| replace:: :dbcommand:`count`
+.. |opt| replace:: count
+
+.. include:: /includes/fact-unexpected-shutdown-accuracy.rst
+
+.. note:: 
+   This loss of accuracy only applies to :dbcommand:`count`
+   operations that do *not* include a query document.
 
 Examples
 --------

--- a/source/reference/command/dbStats.txt
+++ b/source/reference/command/dbStats.txt
@@ -45,12 +45,13 @@ The time required to run the command depends on the total size of the
 database. Because the command must touch all data files, the command
 may take several seconds to run.
 
-For MongoDB instances using the :doc:`WiredTiger </core/wiredtiger>`
-storage engine, after an unclean shutdown, statistics on size and count
-may off by up to 1000 documents as reported by :dbcommand:`collStats`,
-:dbcommand:`dbStats`, :dbcommand:`count`. To restore the correct
-statistics for the collection, run :dbcommand:`validate` on the
-collection.
+Accuracy after Unexpected Shutdown
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. |cmd| replace:: :dbcommand:`dbStats`
+.. |opt| replace:: count and size
+
+.. include:: /includes/fact-unexpected-shutdown-accuracy.rst
 
 .. _dbstats-output:
 

--- a/source/reference/method/db.collection.stats.txt
+++ b/source/reference/method/db.collection.stats.txt
@@ -49,9 +49,17 @@ by ``scale``.
 .. note::
 
    The scale factor rounds values to whole numbers.
-   
+
 Depending on the storage engine, the data returned may differ. For details on 
 the fields, see :ref:`output details <collStats-output>`.
+
+Accuracy after Unexpected Shutdown
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. |cmd| replace:: :method:`db.collection.stats()`
+.. |opt| replace:: count and size
+
+.. include:: /includes/fact-unexpected-shutdown-accuracy.rst
 
 Index Filter Behavior
 ~~~~~~~~~~~~~~~~~~~~~

--- a/source/reference/method/db.stats.txt
+++ b/source/reference/method/db.stats.txt
@@ -31,12 +31,13 @@ Description
 Behavior
 --------
 
-For MongoDB instances using the :doc:`WiredTiger </core/wiredtiger>`
-storage engine, after an unclean shutdown, statistics on size and count
-may off by up to 1000 documents as reported by :dbcommand:`collStats`,
-:dbcommand:`dbStats`, :dbcommand:`count`. To restore the correct
-statistics for the collection, run :dbcommand:`validate` on the
-collection.
+Accuracy after Unexpected Shutdown
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. |cmd| replace:: :method:`db.stats`
+.. |opt| replace:: count and size
+
+.. include:: /includes/fact-unexpected-shutdown-accuracy.rst
 
 Example
 -------


### PR DESCRIPTION
Extension of DOCS-7979, applied to count dbcommand, dbstats and helper methods

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2712)
<!-- Reviewable:end -->
