### PR TITLE
Fix missing images in metadata.yaml

### DIFF
--- a/source/images/metadata.yaml
+++ b/source/images/metadata.yaml
@@ -955,6 +955,17 @@ output:
     dpi: 72
     width: 700
 ---
+name: sharding-segmenting-shards-overview
+alt: "Diagram of Data Segmentation tags using Tag Aware Sharding"
+output:
+  - type: print
+    tag: 'print'
+    dpi: 300
+    width: 900
+  - type: web
+    dpi: 72
+    width: 700
+---
 name: sharding-segmenting-shards-architecture
 alt: "Diagram of Data Segmentation Architecture using Tag Aware Sharding"
 output:
@@ -967,6 +978,28 @@ output:
     width: 700
 ---
 name: sharding-tiered-slas-overview
+alt: "Diagram of sharded cluster architecture for tiered SLA"
+output:
+  - type: print
+    tag: 'print'
+    dpi: 300
+    width: 900
+  - type: web
+    dpi: 72
+    width: 700
+---
+name: sharding-tiered-slas-architecture
+alt: "Diagram of sharded cluster architecture for tiered SLA"
+output:
+  - type: print
+    tag: 'print'
+    dpi: 300
+    width: 900
+  - type: web
+    dpi: 72
+    width: 700
+---
+name: sharding-tiered-slas-tags
 alt: "Diagram of sharded cluster architecture for tiered SLA"
 output:
   - type: print


### PR DESCRIPTION
DOCS-8105 stomped a few images related to the tag sharding tutorials.

This should fix the missing files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2725)
<!-- Reviewable:end -->
