### PR TITLE
Reorder rs node removal instructions

### DIFF
--- a/source/tutorial/remove-replica-set-member.txt
+++ b/source/tutorial/remove-replica-set-member.txt
@@ -16,28 +16,24 @@ following procedures.
 Remove a Member Using ``rs.remove()``
 -------------------------------------
 
-1. Shut down the :program:`mongod` instance for the member you wish to
-   remove. To shut down the instance, connect using the
-   :program:`mongo` shell and the :method:`db.shutdownServer()`
-   method.
 
-#. Connect to the replica set's current :term:`primary`. To determine
+1. Connect to the replica set's current :term:`primary`. To determine
    the current primary, use :method:`db.isMaster()` while connected to
    any member of the replica set.
 
 #. Use :method:`rs.remove()` in either of the following forms to
-   remove the member:
+   remove a member:
 
    .. code-block:: javascript
 
       rs.remove("mongod3.example.net:27017")
       rs.remove("mongod3.example.net")
 
-   MongoDB disconnects the shell briefly as the replica set elects a
-   new primary. The shell then automatically reconnects. The
-   shell displays a ``DBClientCursor::init call() failed`` error even
-   though the command succeeds.
-
+#. Shut down the :program:`mongod` instance for the member you 
+   removed. To shut down the instance, connect using the
+   :program:`mongo` shell and the :method:`db.shutdownServer()`
+   method.
+   
 .. _remove-member-using-reconfig:
 
 Remove a Member Using ``rs.reconfig()``
@@ -47,12 +43,7 @@ To remove a member you can manually edit the :doc:`replica set
 configuration document </reference/replica-configuration>`, as described
 here.
 
-1. Shut down the :program:`mongod` instance for the member you wish to
-   remove. To shut down the instance, connect using the
-   :program:`mongo` shell and the :method:`db.shutdownServer()`
-   method.
-
-#. Connect to the replica set's current :term:`primary`. To determine
+1. Connect to the replica set's current :term:`primary`. To determine
    the current primary, use :method:`db.isMaster()` while connected to
    any member of the replica set.
 
@@ -110,7 +101,7 @@ here.
 
       rs.reconfig(cfg)
 
-   As a result of :method:`rs.reconfig()` the shell will disconnect
+   As a result of :method:`rs.reconfig()` the shell may disconnect
    while the replica set renegotiates which member is primary. The
    shell displays a ``DBClientCursor::init call() failed`` error even
    though the command succeeds, and will automatically reconnected.
@@ -135,3 +126,8 @@ here.
               }
           ]
       }
+
+#. Shut down the :program:`mongod` instance for the member you 
+   removed. To shut down the instance, connect using the
+   :program:`mongo` shell and the :method:`db.shutdownServer()`
+   method.


### PR DESCRIPTION
To avoid losing quorum, one should always run reconfigure prior to shutting down nodes marked for removal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2731)
<!-- Reviewable:end -->
