### PR TITLE
DOCS-9124 - Added a note in the BSON types table that decimal was added in version 3.4.

### DIFF
--- a/source/includes/fact-bson-types.rst
+++ b/source/includes/fact-bson-types.rst
@@ -99,7 +99,7 @@
    * - Decimal128
      - 19
      - "decimal"
-     -
+     - New in version 3.4.
    
    * - Min key
      - -1


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2740)
<!-- Reviewable:end -->
