### PR TITLE
Update steps-3.2-upgrade-replica-set.yaml

### DIFF
--- a/source/includes/steps-3.2-upgrade-replica-set.yaml
+++ b/source/includes/steps-3.2-upgrade-replica-set.yaml
@@ -34,20 +34,6 @@ content: |
      :program:`mongod` binary with the 3.2 binary.
 
    - Restart.
----
-title: Upgrade the replication protocol.
-level: 5
-ref: upgrade-replication-protocol
-pre: |
-
-   Connect a :program:`mongo` shell to the current primary and upgrade
-   the replication protocol
-action:
-   language: javascript
-   code: |
-     cfg = rs.conf();
-     cfg.protocolVersion=1;
-     rs.reconfig(cfg);
 post: |
   Replica set failover is not instant and will render the set
   unavailable to accept writes until the failover process


### PR DESCRIPTION
Remove the requirement to upgrade the election protocol version to PV1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2742)
<!-- Reviewable:end -->
