### PR TITLE
Update unset.txt

### DIFF
--- a/source/reference/operator/update/unset.txt
+++ b/source/reference/operator/update/unset.txt
@@ -21,7 +21,9 @@ $unset
 
    The specified value in the :update:`$unset` expression (i.e. ``""``)
    does not impact the operation.
-
+   
+   Be sure to add {multi: true} if you want to remove this field from all of the documents in the collection; otherwise, it      will only remove it from the first document it finds that matches
+   
    .. include:: /includes/use-dot-notation.rst
 
 Behavior


### PR DESCRIPTION
There is nowhere specified that if multi is default set to false and will only affect 1 document. It's a bit confusing.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2743)

<!-- Reviewable:end -->
