### PR TITLE
DOCS-7697: Deprecate 'fastmodinsert' metric for MongoDB 3.4

### DIFF
--- a/source/reference/database-profiler.txt
+++ b/source/reference/database-profiler.txt
@@ -286,6 +286,16 @@ operation.
    A boolean that indicates the update operation's ``upsert`` option
    value. Only appears if ``upsert`` is true.
 
+.. data:: system.profile.fastmodinsert
+
+   .. deprecated:: 3.4
+
+   Records the number of update operations that match all of the
+   following criteria:
+
+   - Are upserts (that result in an insert)
+   - Do not use a modifier operation such as :update:`$set`
+
 .. data:: system.profile.keyUpdates
 
    The number of :doc:`index </indexes>` keys the update changed in


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2748)
<!-- Reviewable:end -->
