### PR TITLE
Fix the returnOriginal param in the findOneAndUpdate

### DIFF
--- a/source/reference/method/db.collection.findOneAndUpdate.txt
+++ b/source/reference/method/db.collection.findOneAndUpdate.txt
@@ -16,11 +16,11 @@ Definition
 .. method:: db.collection.findOneAndUpdate( filter, update, options )
 
    .. versionadded:: 3.2
-   
-   Updates a single document based on the ``filter`` and 
+
+   Updates a single document based on the ``filter`` and
    ``sort`` criteria.
-   
-   The :method:`~db.collection.findOneAndUpdate()` method has the following 
+
+   The :method:`~db.collection.findOneAndUpdate()` method has the following
    form:
 
    .. code-block:: javascript
@@ -33,7 +33,7 @@ Definition
            sort: <document>,
            maxTimeMS: <number>,
            upsert: <boolean>,
-           returnNewDocument: <boolean>,
+           returnOriginal: <boolean>,
            collation: <document>
          }
       )
@@ -45,14 +45,14 @@ Definition
 
    :returns:
 
-      Returns either the original document or, if ``returnNewDocument: true``, 
+      Returns either the original document or, if ``returnOriginal: true``,
       the updated document.
-      
+
 Behavior
 --------
 
-:method:`~db.collection.findOneAndUpdate()` updates the first matching 
-document in the collection that matches the ``filter``. 
+:method:`~db.collection.findOneAndUpdate()` updates the first matching
+document in the collection that matches the ``filter``.
 The ``sort`` parameter can be used to influence which document is updated.
 
 The ``projection`` parameter takes a document in the following form:
@@ -60,7 +60,7 @@ The ``projection`` parameter takes a document in the following form:
 .. code-block:: javascript
 
    { field1 : < boolean >, field2 : < boolean> ... }
-   
+
 The ``<boolean>`` value can be any of the following:
 
 - ``1`` or ``true`` to include the field. The method returns the
@@ -91,13 +91,13 @@ The ``grades`` collection contains documents similar to the following:
    { _id: 6322, name : "A. MacDyver", "assignment" : 2, "points" : 14 },
    { _id: 6234, name : "R. Stiles", "assignment" : 1, "points" : 10 }
 
-The following operation finds the first document where ``name : R. Stiles`` 
+The following operation finds the first document where ``name : R. Stiles``
 and increments the score by ``5``:
 
 .. code-block:: javascript
 
-   db.scores.findOneAndUpdate( 
-      { "name" : "R. Stiles" }, 
+   db.scores.findOneAndUpdate(
+      { "name" : "R. Stiles" },
       { $inc: { "points" : 5 } }
    )
 
@@ -106,8 +106,8 @@ The operation returns the *original* document before the update:
 .. code-block:: javascript
 
    { _id: 6319, name: "R. Stiles", "assignment" : 2, "points" : 12 }
-   
-If ``returnNewDocument`` was true, the operation would return the 
+
+If ``returnOriginal`` was true, the operation would return the
 updated document instead.
 
 .. _findOneAndUpdate-example-sort-and-replace-document:
@@ -128,7 +128,7 @@ The ``grades`` collection contains documents similar to the following:
 
 The following operation updates a document where ``name : "A. MacGyver"``.  The
 operation sorts the matching documents by ``points`` ascending to update the
-matching document with the least points. 
+matching document with the least points.
 
 .. code-block:: javascript
 
@@ -149,8 +149,8 @@ The operation returns the *original* document before the update:
 Project the Returned Document
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following operation uses projection to only display the ``_id``, 
-``points``, and ``assignment`` fields in the returned document: 
+The following operation uses projection to only display the ``_id``,
+``points``, and ``assignment`` fields in the returned document:
 
 .. code-block:: javascript
 
@@ -159,8 +159,8 @@ The following operation uses projection to only display the ``_id``,
       { $inc : { "points" : 5 } },
       { sort : { "points" : 1 }, projection: { "assignment" : 1, "points" : 1 } }
    )
-   
-The operation returns the *original* document with only the 
+
+The operation returns the *original* document with only the
 fields specified in the ``projection`` document and the ``_id`` field as it was not
 explicitly suppressed (``_id: 0``) in the :ref:`projection document <projections>`.
 
@@ -200,7 +200,7 @@ If the operation exceeds the time limit, it returns:
 Update Document with Upsert
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following operation uses the ``upsert`` field to insert the update 
+The following operation uses the ``upsert`` field to insert the update
 document if nothing matches the ``filter``:
 
 .. code-block:: javascript
@@ -209,7 +209,7 @@ document if nothing matches the ``filter``:
    db.scores.findOneAndUpdate(
       { "name" : "A.B. Abracus" },
       { $set: { "name" : "A.B. Abracus", "assignment" : 5}, $inc : { "points" : 5 } },
-      { sort: { "points" : 1 }, upsert:true, returnNewDocument : true }
+      { sort: { "points" : 1 }, upsert:true, returnOriginal : true }
    );
    }
    catch (e){
@@ -226,8 +226,8 @@ The operation returns the following:
       "assignment" : 5,
       "points" : 5
    }
-   
-If ``returnNewDocument`` was false, the operation would return ``null`` as 
+
+If ``returnOriginal`` was false, the operation would return ``null`` as
 there is no original document to return.
 
 Specify Collation


### PR DESCRIPTION
The correct parameter to return the new update document when using `findOneAndUpdate` is `returnOriginal` instead of `returnNewDocument`

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2749)

<!-- Reviewable:end -->
