### PR TITLE
Update index-ttl.txt

### DIFF
--- a/source/core/index-ttl.txt
+++ b/source/core/index-ttl.txt
@@ -16,7 +16,7 @@ TTL Indexes
 
 TTL indexes are special single-field indexes that MongoDB can use to
 automatically remove documents from a collection after a certain amount
-of time. Data expiration is useful for certain types of information
+of time or at a specific clock time. Data expiration is useful for certain types of information
 like machine generated event data, logs, and session information that
 only need to persist in a database for a finite amount of time.
 


### PR DESCRIPTION
Add phrase to indicate that TTL indexes can also delete data based on a specific wall clock time. The page https://docs.mongodb.com/v3.2/tutorial/expire-data/ indicates this point, but this page does not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2761)
<!-- Reviewable:end -->
