### PR TITLE
Index intersection and sort

### DIFF
--- a/source/core/index-intersection.txt
+++ b/source/core/index-intersection.txt
@@ -144,7 +144,7 @@ MongoDB cannot use index intersection for the following query with sort:
 
    db.orders.find( { qty: { $gt: 10 } } ).sort( { status: 1 } )
 
-That is, MongoDB does not use the ``{ qty: 1 }`` index for the query,
+Instead, MongoDB uses the ``{ qty: 1 }`` index for the query,
 and the separate ``{ status: 1 }`` or the ``{ status: 1, ord_date: -1
 }`` index for the sort.
 


### PR DESCRIPTION
I cannot follow the document as it is, so I wonder whether there was a mistake in it. You say that query intersection cannot be used for the query, and that individual indexes will also not be used. In other words, can the query not be optimised at all? That sounds unlikely. Did you mean what I am suggesting here?