### PR TITLE
Update glossary.txt

### DIFF
--- a/source/reference/glossary.txt
+++ b/source/reference/glossary.txt
@@ -378,8 +378,8 @@ Glossary
 
    initial sync
       The :term:`replica set` operation that replicates data from an
-      existing replica set member to a new or restored replica set
-      member. See :ref:`replica-set-initial-sync`.
+      existing replica set member to a new replica set member. See
+      :ref:`replica-set-initial-sync`.
 
    intent lock
       A :term:`lock` on a resource that indicates that the holder


### PR DESCRIPTION
Initial sync is the process of copying all data to a new member. The "or restored" part is confusing - a member that has had data restored should not need to go through the initial sync process (unless the restore was not valid)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2783)
<!-- Reviewable:end -->
