### PR TITLE
DOCS-9078: Native LDAP AccessDirectory tutorial

### DIFF
--- a/source/core/security-ldap.txt
+++ b/source/core/security-ldap.txt
@@ -348,3 +348,4 @@ users using LDAP, see:
 
       /tutorial/configure-ldap-sasl-activedirectory
       /tutorial/configure-ldap-sasl-openldap
+      /tutorial/authenticate-nativeldap-activedirectory

--- a/source/includes/steps-configure-ldap-sasl-activedirectory-authentication.yaml
+++ b/source/includes/steps-configure-ldap-sasl-activedirectory-authentication.yaml
@@ -1,0 +1,402 @@
+title: Configure TLS/SSL for the server running MongoDB
+stepnum: 1
+ref: security-nativeldap-activedirectory-authauthz-configTLS
+level: 4
+inherit:
+  file: steps-kerberos-auth-activedirectory-authz.yaml
+  ref: security-kerberos-activedirectory-authauthz-configTLS
+---
+title: Connect to the MongoDB server.
+ref: security-nativeldap-activedirectory-authauthz-preconnect
+stepnum: 2
+inherit:
+  file: steps-kerberos-auth-activedirectory-authz.yaml
+  ref: security-nativeldap-activedirectory-preconnect
+level: 4  
+---
+title: Create user administrative role.
+ref: security-nativeldap-activedirectory-authauthz-userAdmin
+inherit:
+  file: steps-kerberos-auth-activedirectory-authz.yaml
+  ref: security-nativeldap-activedirectory-authz-userAdmin
+stepnum: 3
+level: 4
+---
+title: Create a MongoDB configuration file.
+ref: security-nativeldap-activedirectory-authauthz-configfile
+stepnum: 4
+inherit:
+  file: steps-kerberos-auth-activedirectory-authz.yaml
+  ref: security-kerberos-activedirectory-authauthz-configfile
+level: 4
+---
+title: Configure MongoDB to connect to Active Directory.
+ref: security-nativeldap-activedirectory-authauthz-configuremongodb
+stepnum: 5
+level: 4
+pre: |
+
+  In the MongoDB configuration file, set :setting:`security.ldap.servers` to
+  the host and port of the :abbr:`AD (Active Directory)` server. If your
+  :abbr:`AD (Active Directory)` infrastructure includes multiple :abbr:`AD
+  (Active Directory)` servers for the purpose of replication, specify the host
+  and port of the servers as a comma-delimited list to
+  :setting:`security.ldap.servers`.
+  
+  You must also enable LDAP authentication by setting
+  :setting:`security.authentication` to `enabled` and :setting:`setParameter`
+  :parameter:`authenticationMechanisms` to ``PLAIN``
+  
+  .. example::
+  
+     To connect to an :abbr:`AD (Active Directory)` server located at
+     ``activedirectory.example.net``, include the following in the
+     configuration file:
+     
+     .. code-block:: yaml
+     
+        security:
+          authentication: "enabled"
+          ldap:
+            servers: "activedirectory.example.net"
+        setParameter:
+          authenticationMechanisms: "PLAIN"
+
+  MongoDB must bind to the :abbr:`AD (Active Directory)` server to perform
+  queries. By default, MongoDB uses the simple authentication mechanism to
+  bind itself to the :abbr:`AD (Active Directory)` server.
+  
+  Alternatively, you can configure the following settings in the configuration
+  file to bind to the :abbr:`AD (Active Directory)` server using ``SASL``:
+    
+  - Set :setting:`security.ldap.bind.method` to ``sasl``
+  
+  - :setting:`security.ldap.bind.saslMechanisms`, specifying a string of
+    comma-separated SASL mechanisms the :abbr:`AD (Active Directory)` server
+    supports.
+    
+  This tutorial uses the default ``simple`` LDAP authentication mechanism.
+---
+title: Configure LDAP Query Template for authorization.
+ref: security-nativeldap-activedirectory-authauthz-querytemplate
+level: 4
+stepnum: 6
+pre: |
+
+  In the MongoDB configuration file, set
+  :setting:`security.ldap.authz.queryTemplate` to an `RFC4516
+  <https://tools.ietf.org/html/rfc4516>`_ formatted LDAP query URL template.
+  In the template, use the ``{USER}`` placeholder to substitute the
+  authenticated username into the LDAP query URL. Design the query template to
+  retrieve the authenticated user's groups.
+  
+  .. note::
+  
+     A full description of `RFC4515 <https://tools.ietf.org/html/rfc4515>`_,
+     RFC4516, or :abbr:`AD (Active Directory)` queries is out of scope for
+     this tutorial. The :setting:`~security.ldap.authz.queryTemplate` provided
+     in this tutorial is an example only, and may not be applicable for your
+     specific :abbr:`AD (Active Directory)` deployment.
+  
+  .. example::
+  
+     The following query template returns any groups that list ``{USER}`` as a
+     member, following recursive group memberships. This LDAP query assumes
+     that group objects track user membership by storing full user
+     Distinguished Name (DN) using the ``member`` attribute. The query
+     includes the :abbr:`AD (Active Directory)` specific matching rule OID
+     ``1.2.840.113556.1.4.1941`` for `LDAP_MATCHING_RULE_IN_CHAIN
+     <https://msdn.microsoft.com/en-us/library/aa746475(v=vs.85).aspx>`_. This
+     matching rule is an :abbr:`AD (Active Directory)` specific extension to
+     LDAP search filters.
+       
+     .. code-block:: yaml
+     
+        security:
+          ldap:
+            authz:
+              queryTemplate: 
+                "DC=example,DC=com??sub?(&(objectClass=group)(member:1.2.840.113556.1.4.1941:={USER}))"
+     
+     Using the query template, MongoDB substitutes ``{USER}`` with the
+     authenticated username to query the LDAP server.
+  
+     For example, a user authenticates as
+     ``CN=sam,CN=Users,DC=dba,DC=example,DC=com``. MongoDB creates an LDAP
+     query based on the :setting:`~security.ldap.authz.queryTemplate`,
+     substituting the ``{USER}`` token with the provided username. The Active
+     Directory server performs a recursive group lookup for any group that
+     either directly or transitively lists the user as a member. Based on the
+     :ref:`Active Directory groups <activedirectory-authauthz-groupObj>`, the
+     :abbr:`AD (Active Directory)` server returns
+     ``CN=dba,CN=Users,DC=example,DC=com`` and
+     ``CN=engineering,CN=Users,DC=example,DC=com``.
+  
+  MongoDB maps each returned group :abbr:`DN (Distinguished Name)` to a role
+  on the ``admin`` database. For each mapped group :abbr:`DN (Distinguished
+  Name)`, if there is an existing role on the ``admin`` database whose name
+  exactly matches the :abbr:`DN (Distinguished Name)`, MongoDB grants the user
+  the roles and privileges assigned to that role.
+  
+  The matching rule ``LDAP_MATCHING_RULE_IN_CHAIN`` requires providing the
+  full :abbr:`DN (Distinguished Name)` of the authenticating user. If users
+  authenticate using a different username format, such as their ``user
+  principal name``, you must transform the incoming usernames into :abbr:`DNs
+  (Distinguished Name)` using :setting:`security.ldap.userToDNMapping`.
+  
+---
+title: Transform incoming usernames for authentication via Active Directory,
+stepnum: 7
+ref: security-nativeldap-activedirectory-authauthz-transform
+optional: true
+level: 4
+pre: |
+
+  If your users authenticate with a username that is not a full LDAP DN,
+  you may need to transform the username to support LDAP authentication
+  or authorization. MongoDB uses the transformed username for both
+  authentication and authorization.
+
+  In the MongoDB configuration file, set
+  :setting:`~security.ldap.userToDNMapping` to transform the authenticating
+  user's provided username into an :abbr:`AD (Active Directory)` DN to support
+  the :setting:`~security.ldap.authz.queryTemplate`.
+  
+  .. example::
+  
+     Given the configured :setting:`~security.ldap.authz.queryTemplate`,
+     users must authenticate with their full LDAP DN. If users instead
+     authenticate using their ``userPrincipalName``, then a transformation
+     must be applied to conver the provided username to a full LDAP DN.
+     
+     The following :setting:`~security.ldap.userToDNMapping` configuration
+     uses the ``match`` regular expression filter to capture the provided 
+     username. MongoDB inserts the captured username into the ``ldapQuery``
+     query template before executing the query.
+     
+     .. code-block:: yaml
+     
+        security:
+          ldap:
+            userToDNMapping:
+              '[
+                 {
+                    match : "(.+)",
+                    ldapQuery: "DC=example,DC=com??sub?(userPrincipalName={0})"
+                 }
+            ]'
+
+     The Active Directory server returns the full LDAP DN associated to the
+     user object with a matching ``userPrincipalName``. MongoDB can then use
+     this transformed username for authentication *and* authorization.
+
+  You must modify the given sample configuration to match your deployment. For
+  example, the ``ldapQuery`` base :abbr:`DN (Distinguished Name)` must match
+  the base :abbr:`DN (Distinguished Name)` which contains your user entities.
+  Other modifications may be necessary to support your :abbr:`AD (Active
+  Directory)` deployment.
+   
+  .. example:: 
+    
+     A user authenticates as ``alice@ENGINEERING.EXAMPLE.COM``. MongoDB first
+     applies any transformations specified in
+     :setting:`~security.ldap.userToDNMapping`. Based on the provided
+     configuration, MongoDB captures the username in the ``match`` stage and
+     executes an LDAP query:
+
+     .. code-block:: yaml
+        
+        DC=example,DC=com??sub?(userPrincipalName=alice@ENGINEERING.EXAMPLE.COM)
+      
+     Based on the configured :ref:`Active Directory
+     users<activedirectory-authauthz-userObj>`, the :abbr:`AD (Active
+     Directory)` server should return
+     ``CN=alice,CN=Users,DC=engineering,DC=example,DC=com``.
+
+     MongoDB then executes the LDAP query configured in
+     :setting:`~security.ldap.authz.queryTemplate`, replacing the ``{USER}``
+     token with the *transformed* username
+     ``CN=alice,CN=Users,DC=engineering,DC=example,DC=com``.
+---
+title: Configure query credentials.
+stepnum: 8
+ref: security-nativeldap-activedirectory-authauthz-credentials
+inherit:
+  file: steps-kerberos-auth-activedirectory-authz.yaml
+  ref: security-kerberos-activedirectory-authauthz-credentials 
+level: 4
+replacement:
+  AUTH: "Active Directory"
+---
+title: Add additional configuration settings.
+stepnum: 9
+optional: true
+ref: security-nativeldap-activedirectory-configfile
+inherit:
+  file: steps-kerberos-auth-activedirectory-authz.yaml
+  ref: security-kerberos-activedirectory-authauthz-configFile
+level: 4
+pre: |
+
+  Add any additional configuration options required for your deployment. 
+  For example, you can specify your desired :setting:`storage.dbPath` or
+  change the default :setting:`net.port` number. 
+---
+title: Start the MongoDB server with Active Directory authentication and authorization.
+ref: security-nativeldap-activedirectory-startserver
+level: 4
+stepnum: 10
+pre: |
+
+  Start the MongoDB server with the :option:`--config` option, specifying the
+  path to the configuration file created during this procedure. If the
+  MongoDB server is currently running, make the appropriate preparations to
+  stop the server.
+  
+  .. code-block:: shell
+  
+     mongod --config <path-to-config-file>
+  
+
+  :abbr:`Windows (Microsoft Windows)` MongoDB deployments must use
+  :program:`mongod.exe` instead of :program:`mongod`.
+---
+title: Connect to the MongoDB server.
+ref: security-nativeldap-activedirectory-localhost
+level: 4
+stepnum: 11
+pre: |
+  
+  Connect to the MongoDB server, authenticating as a user whose direct or
+  transitive group membership corresponds to a MongoDB role on the ``admin``
+  database with :authrole:`userAdmin`, :authrole:`userAdminAnyDatabase`,
+  or a custom role with equivalent privileges.
+  
+  Use the :program:`mongo` shell to authenticate to the MongoDB
+  server, set the following options:
+  
+  - :option:`--host` with the hostname of the MongoDB server
+  - :option:`--port` with the port of the MongoDB server
+  - :option:`--username` to the user's username
+  - :option:`--password` to the user's password
+  - :option:`--authenticationMechanism` to ``"PLAIN"``
+  - :option:`--authenticationDatabase` to ``"$external"``
+  
+  .. example::
+  
+     Previously in this procedure, you configured the
+     ``dn:CN=dba,CN=Users,DC=example,DC=com`` role on the ``admin`` database
+     with the required permissions. This role corresponds to an :abbr:`AD
+     (Active Directory)` group. Based on the configured :ref:`AD users
+     <activedirectory-authauthz-userObj>`, you can authenticate as the user
+     ``sam@dba.example.com`` and receive the required permissions.
+     
+     .. code-block:: shell
+     
+        mongo --username sam@DBA.EXAMPLE.COM --password secret123 --authenticationMechanisms="PLAIN" --authenticationDatabase "$external" --host <hostname> --port <port>
+  
+  :abbr:`Windows (Microsoft Windows)` MongoDB deployments must use
+  :program:`mongo.exe` instead of :program:`mongo`.
+  
+  Given the configured :ref:`Active Directory users
+  <activedirectory-authauthz-userObj>`, the user authenticates successfully and
+  receives the appropriate permissions.
+  
+  .. note::
+    
+     If you want to authenticate as an existing non-``$external`` user, set
+     :option:`--authenticationMechanism` to ``SCRAM-SHA-1``. This requires
+     that the MongoDB server's :setting:`setParameter`
+     :parameter:`authenticationMechanisms` includes ``SCRAM-SHA-1``.
+---
+title: Create roles for mapping returned :abbr:`AD (Active Directory)` groups.
+ref: security-nativeldap-activedirectory-rolecreation
+level: 4
+stepnum: 11
+inherit:
+  file: steps-kerberos-auth-activedirectory-authz.yaml
+  ref: security-kerberos-activedirectory-authauthz-rolecreation
+replacement:
+  GROUP: :ref:`Active Directory groups <activedirectory-authauthz-groupObj>`
+---
+title: Transition existing users from ``$external`` to the ActiveDirectory server
+ref: security-nativeldap-activedirectory-authz-transitionusers
+stepnum: 12
+level: 4
+pre: |
+  
+  If upgrading an existing installation with :ref:`users <users>` configured
+  on the ``$external`` database, you must meet the following requirements for
+  each user to ensure access after configuring MongoDB for :abbr:`AD (Active
+  Directory)` authentication and authorization:
+  
+  - User has a corresponding user object on the :abbr:`AD (Active Directory)`
+    server.
+    
+  - User has membership in the appropriate groups on the :abbr:`AD (Active
+    Directory)` server.
+  
+  - MongoDB contains the roles on the ``admin`` database named for the user's
+    :abbr:`AD (Active Directory)` groups, such that the authorized user
+    retains its privileges.
+  
+  .. example::
+  
+     The following user exists on the ``$external`` database:
+       
+     .. code-block:: javascript
+     
+        {
+          user : "joe@ANALYTICS.EXAMPLE.COM",
+          roles: [ 
+            { role : "read", db : "web_analytics" },
+            { role : "read", db : "PrimaryApplication" }
+          ]
+        }
+     
+     Assuming the user belongs to the :abbr:`AD (Active Directory)` group
+     ``CN=marketing,CN=Users,DC=example,DC=com``, the following operation
+     creates a matching role with the appropriate privileges:
+     
+     .. code-block:: javascript
+     
+       db.getSiblingDB("admin").createRole(
+          {
+            role: "CN=marketing,CN=Users,DC=example,DC=com",
+            privileges: [],
+            roles: [
+              { role: "read", db: "web_analytics" }
+              { role: "read", db: "PrimaryApplication" }
+            ]
+          }
+       )
+     
+     Based on the configured :setting:`~security.ldap.authz.queryTemplate`,
+     MongoDB authorizes any user who has direct or transitive membership in the
+     ``CN=marketing,CN=Users,DC=example,DC=com`` group to perform
+     :authrole:`read` operations on the ``web_analytics`` and
+     ``PrimaryApplication`` databases.
+  
+  .. important::
+     
+     When configuring a role for a corresponding :abbr:`AD (Active Directory)`
+     group, remember that *all* users with membership in that group can
+     receive the assigned roles and privileges. Consider applying the
+     `principle of least privilege
+     <https://www.us-cert.gov/bsi/articles/knowledge/principles/least-privilege>`_
+     when configuring MongoDB roles, :abbr:`AD (Active Directory)` groups,
+     or group membership.
+     
+  If you want to continue allowing users on non-``$external`` databases to
+  access MongoDB, you must include ``SCRAM-SHA-1`` in the
+  :setting:`setParameter` :parameter:`authenticationMechanisms` configuration
+  option.
+  
+  .. code-block:: yaml
+    
+     setParameter:
+       authenticationMechanisms: "PLAIN,SCRAM-SHA-1"
+       
+  Alternatively, transition non-``$external`` users to :abbr:`AD (Active
+  Directory)` by following the above procedure.
+...

--- a/source/includes/steps-kerberos-auth-activedirectory-authz.yaml
+++ b/source/includes/steps-kerberos-auth-activedirectory-authz.yaml
@@ -87,7 +87,7 @@ content: |
   
 ---
 title: Connect to the MongoDB server.
-stepnum: 4
+stepnum: 3
 ref: security-nativeldap-activedirectory-preconnect
 level: 4
 pre: |
@@ -119,7 +119,7 @@ pre: |
 title: Create user administrative role.
 ref: security-nativeldap-activedirectory-authz-userAdmin
 level: 4
-stepnum: 5
+stepnum: 4
 pre: |
 
   To manage MongoDB users using :abbr:`AD (Active Directory)`, you need to
@@ -159,12 +159,12 @@ pre: |
      
      Consider applying the `principle of least privilege
      <https://www.us-cert.gov/bsi/articles/knowledge/principles/least-privilege>`_
-     when configuring MongoDB roles, :abbr:`AD (Active Directory)` groups, or group
-     membership.
+     when configuring MongoDB roles, :abbr:`AD (Active Directory)` groups, or 
+     group membership.
   
 ---
 title: Create a MongoDB configuration file.
-stepnum: 6
+stepnum: 5
 ref: security-kerberos-activedirectory-authauthz-configfile
 level: 4
 pre: |
@@ -185,7 +185,7 @@ pre: |
 
 ---
 title: Configure MongoDB to connect to Active Directory`.
-stepnum: 7
+stepnum: 6
 ref: security-kerberos-activedirectory-authauthz-configuremongodb
 level: 4
 pre: |
@@ -209,9 +209,9 @@ pre: |
           ldap:
             servers: "activedirectory.example.net"
 
-  MongoDB must bind to the :abbr:`AD (Active Directory)` server to perform queries. By
-  default, MongoDB uses the simple authentication mechanism to bind itself to
-  the :abbr:`AD (Active Directory)` server.
+  MongoDB must bind to the :abbr:`AD (Active Directory)` server to perform
+  queries. By default, MongoDB uses the simple authentication mechanism to
+  bind itself to the :abbr:`AD (Active Directory)` server.
   
   Alternatively, you can configure the following settings in the configuration
   file to bind to the :abbr:`AD (Active Directory)` server using ``SASL``:
@@ -226,7 +226,7 @@ pre: |
 
 ---
 title: Configure MongoDB for Kerberos authentication.
-stepnum: 8
+stepnum: 7
 ref: security-kerberos-activedirectory-authauthz-configurebinding
 level: 4
 pre: |
@@ -250,7 +250,7 @@ pre: |
 title: Configure LDAP Query Template for authorization.
 ref: security-kerberos-activedirectory-authauthz-querytemplate
 level: 4
-stepnum: 9
+stepnum: 8
 pre: |
 
   In the MongoDB configuration file, set
@@ -318,7 +318,7 @@ pre: |
   
 ---
 title: Transform incoming usernames for authentication via Active Directory.
-stepnum: 10
+stepnum: 9
 ref: security-kerberos-activedirectory-authauthz-transform
 level: 4
 pre: |
@@ -377,7 +377,7 @@ pre: |
   
 --- 
 title: Configure query credentials.
-stepnum: 11
+stepnum: 10
 ref: security-kerberos-activedirectory-authauthz-credentials 
 level: 4 
 pre: |
@@ -387,7 +387,7 @@ pre: |
     
   Configure the following settings in the configuration file:
   
-  - :setting:`security.ldap.bind.queryUser`, specifying the Kerberos user the
+  - :setting:`security.ldap.bind.queryUser`, specifying the {{AUTH}} user the
     :program:`mongod` or :program:`mongos` binds as for performing queries on
     the :abbr:`AD (Active Directory)` server. 
     
@@ -408,11 +408,13 @@ pre: |
   
   The :setting:`~security.ldap.bind.queryUser` must
   have permission to perform all LDAP queries on behalf of MongoDB.
+replacement:
+  AUTH: "Kerberos"
 ---
 title: Add additional configuration settings.
-stepnum: 12
+stepnum: 11
 optional: true
-ref: security-nativeldap-activedirectory-configfile
+ref: security-kerberos-activedirectory-authauthz-configFile
 level: 4
 pre: |
 
@@ -421,10 +423,10 @@ pre: |
   the available options.
   
 ---
-title: Start the MongoDB server with Kerberos authentication and :abbr:`AD (Active Directory)` authorization.
-ref: security-nativeldap=activedirectory-authz-startserver
+title: Start the MongoDB server with Kerberos authentication and Active Directory authorization.
+ref: security-kerberos-activedirectory-authauthz-startserver
 level: 4
-stepnum: 13
+stepnum: 12
 pre: |
 
   Start the MongoDB server with the :option:`--config` option, specifying the
@@ -453,22 +455,15 @@ pre: |
   
 ---
 title: Connect to the MongoDB server.
-ref: security-nativeldap-activedirectory-authz-localhost
+ref: security-kerberos-activedirectory-authauthz-localhost
 level: 4
-stepnum: 14
+stepnum: 13
 pre: |
   
   Connect to the MongoDB server, authenticating as a user whose direct or
   transitive group membership corresponds to a MongoDB role on the ``admin``
   database with :authrole:`userAdmin`, :authrole:`userAdminAnyDatabase`,
   or a custom role with equivalent privileges.
-  
-  Previously in this procedure, you configured the
-  ``dn:CN=dba,CN=Users,DC=example,DC=com`` role on the ``admin`` database with
-  the required permissions. This role corresponds to an :abbr:`AD (Active
-  Directory)` group. Based on the configured :ref:`AD users
-  <kerb-auth-ldap-authz-userObj>`, you can authenticate as the user
-  ``sam/dba@example.com`` and receive the required permissions.
   
   Use the :program:`mongo` shell to authenticate to the MongoDB
   server, set the following options:
@@ -480,9 +475,18 @@ pre: |
   - :option:`--authenticationMechanism` to ``"GSSAPI"``
   - :option:`--authenticationDatabase` to ``"$external"``
     
-  .. code-block:: shell
+  .. example::
   
-     mongo --username sam@DBA.EXAMPLE.COM --password secret123 --authenticationMechanisms="GSSAPI" --authenticationDatabase "$external" --host <hostname> --port <port>
+     Previously in this procedure, you configured the
+     ``dn:CN=dba,CN=Users,DC=example,DC=com`` role on the ``admin`` database with
+     the required permissions. This role corresponds to an :abbr:`AD (Active
+     Directory)` group. Based on the configured :ref:`AD users
+     <kerb-auth-ldap-authz-userObj>`, you can authenticate as the user
+     ``sam@dba.example.com`` and receive the required permissions.  
+     
+     .. code-block:: shell
+     
+        mongo --username sam@DBA.EXAMPLE.COM --password secret123 --authenticationMechanisms="GSSAPI" --authenticationDatabase "$external" --host <hostname> --port <port>
   
   :abbr:`Windows (Microsoft Windows)` MongoDB deployments must use
   :program:`mongo.exe` instead of :program:`mongo`.
@@ -497,12 +501,11 @@ pre: |
      :option:`--authenticationMechanism` to ``SCRAM-SHA-1``. This requires
      that the MongoDB server's :setting:`setParameter`
      :parameter:`authenticationMechanisms` includes ``SCRAM-SHA-1``.
-  
 ---
 title: Create roles for mapping returned :abbr:`AD (Active Directory)` groups.
-ref: security-nativeldap-activedirectory-authz-rolecreation
+ref: security-kerberos-activedirectory-authauthz-rolecreation
 level: 4
-stepnum: 15
+stepnum: 14
 pre: |
 
   For each group on the :abbr:`AD (Active Directory)` server you wish to use
@@ -527,8 +530,7 @@ pre: |
            }
         )
      
-     Given the configured :ref:`Active Directory groups
-     <kerb-auth-ldap-authz-groupObj>`, MongoDB grants a user authenticating
+     Given the configured {{GROUP}}, MongoDB grants a user authenticating
      as either ``sam@DBA.EXAMPLE.COM`` or ``alice@ENGINEERING.EXAMPLE.COM`` the
      :authrole:`readWrite` role on the ``PrimaryApplication`` database.
      
@@ -538,12 +540,13 @@ pre: |
      user with :authrole:`userAdmin` on ``admin``,
      :authrole:`userAdminAnyDatabase`, or a custom role on with equivalent
      privileges. 
-  
+replacement:
+  GROUP: ":ref:`Active Directory groups <kerb-auth-ldap-authz-groupObj>`"
 ---
 title: Transition existing users from ``$external`` to the Active Directory server.
-ref: security-nativeldap-activedirectory-authz-transitionusers
+ref: security-kerberos-activedirectory-authauthz-transitionusers
 level: 4
-stepnum: 16
+stepnum: 15
 optional: true
 pre: |
   

--- a/source/reference/configuration-options.txt
+++ b/source/reference/configuration-options.txt
@@ -1,3 +1,5 @@
+.. _configuration-options:
+
 ==========================
 Configuration File Options
 ==========================

--- a/source/tutorial/authenticate-nativeldap-activedirectory.txt
+++ b/source/tutorial/authenticate-nativeldap-activedirectory.txt
@@ -1,6 +1,6 @@
-=================================================================================
-Configure MongoDB with Kerberos Authentication and Active Directory Authorization
-=================================================================================
+=======================================================================
+Authenticate and Authorize Users Using Active Directory via Native LDAP
+=======================================================================
 
 .. default-domain:: mongodb
 
@@ -10,33 +10,25 @@ Configure MongoDB with Kerberos Authentication and Active Directory Authorizatio
    :depth: 1
    :class: singlecol
 
-.. versionadded:: 3.4
+.. versionadded:: 3.4 MongoDB Enterprise
 
-   `MongoDB Enterprise
-   <http://www.mongodb.com/products/mongodb-enterprise?jmp=docs>`_ supports
-   querying an LDAP server for the LDAP groups to which an authenticated user
-   belongs. MongoDB maps the LDAP distinguished names (DN) of each returned
-   group to :ref:`roles <roles>` on the ``admin`` database. MongoDB authorizes
-   the user based on the mapped roles and their associated privileges. See
-   :ref:`LDAP Authorization <security-ldap-external>` for more information.
-
-MongoDB Enterprise supports authentication using a :doc:`Kerberos service
-</core/kerberos>`. Kerberos is an industry standard authentication protocol
-for large client/server systems.
+   MongoDB Enterprise provides support via platform LDAP
+   libraries for proxying authentication and authorization requests to a
+   specified Lightweight Directory Access Protocol (LDAP) service such as
+   Active Directory (AD).
 
 This tutorial describes how to configuring MongoDB to perform authentication
-through a Kerberos server and authorization through an Active Directory (AD)
-server via the platform libraries.
+and authorization through an Active Directory (AD) server via the platform
+libraries.
 
 Prerequisites
 -------------
 
 .. important::
 
-   Thoroughly familiarize yourself with the following subjects before
-   proceeding:
+   Thoroughly familiarize yourself with the following subjects before proceeding:
 
-   - :ref:`Kerberos Authentication <security-kerberos>`
+   - :ref:`LDAP Authentication <security-ldap>`
    - :ref:`LDAP Authorization <security-ldap-external>`
    - `Active Directory <https://msdn.microsoft.com/en-us/library/bb742424.aspx>`_
 
@@ -51,27 +43,16 @@ mechanisms, or the specific :abbr:`AD (Active Directory)` configuration
 requirements for a given SASL mechanism are beyond the scope of this tutorial.
 This tutorial assumes prior knowledge of SASL and its related subject matter.
 
-Setting up and configuring a Kerberos deployment is beyond the scope of
-this document. This tutorial assumes you have configured a
-:ref:`Kerberos service principal <kerberos-service-principal>` for each
-:program:`mongod` and :program:`mongos` instance in your MongoDB
-deployment, and you have a valid :ref:`keytab file <keytab-files>` for
-for each :program:`mongod` and :program:`mongos` instance.
-
-.. include:: /includes/fact-kerberos-FQDN-repica-sets.rst
-
-.. include:: /includes/fact-confirm-enterprise-binaries.rst
-
 Considerations
 --------------
 
-This tutorial explains configuring MongoDB for Kerberos authentication and
-:abbr:`AD (Active Directory)` authorization.
+This tutorial explains configuring MongoDB for :abbr:`AD (Active Directory)`
+authentication and authorization.
 
 To perform this procedure on your own MongoDB server, you must modify the
 given procedures with respect to your own specific infrastructure, especially
-Kerberos configurations, constructing :abbr:`AD (Active Directory)` queries,
-or managing users.
+Active Directory configurations, constructing :abbr:`AD (Active Directory)`
+queries, or managing users.
 
 Transport Layer Security
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -86,7 +67,7 @@ This tutorial provides instructions for the required host configurations.
 This tutorial assumes you have access to the AD server's CA certificates and
 can create a copy of the certificates on the MongoDB server.
 
-.. _kerb-auth-ldap-authz-adschema:
+.. _activedirectory-authauthz-adschema:
 
 Example Active Directory Schema
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -95,7 +76,7 @@ This tutorial uses the following example :abbr:`AD (Active Directory)` objects
 as the basis for the provided queries, configurations, and output. Each object
 shows only a subset of the possible attributes.
 
-.. _kerb-auth-ldap-authz-userObj:
+.. _activedirectory-authauthz-userObj:
 
 User Objects
 ++++++++++++
@@ -120,7 +101,7 @@ User Objects
    userPrincipalName: joe@analytics.example.com
    memberof: CN=marketing,CN=Users,DC=example,DC=com
 
-.. _kerb-auth-ldap-authz-groupObj:
+.. _activedirectory-authauthz-groupObj:
 
 Group Objects
 +++++++++++++
@@ -171,7 +152,7 @@ later.
 Procedure
 ---------
 
-.. include:: /includes/steps/kerberos-auth-activedirectory-authz.rst
+.. include:: /includes/steps/configure-ldap-sasl-ActiveDirectory-authentication.rst
 
 This procedure produces the following configuration file:
 
@@ -180,7 +161,7 @@ This procedure produces the following configuration file:
    security:
       authentication: "enabled"
       ldap:
-         servers: activedirectory.example.net"
+         servers: "activedirectory.example.net"
          bind:
             queryUser: "mongodbadmin@dba.example.com"
             queryPassword: "secret123"
@@ -194,14 +175,12 @@ This procedure produces the following configuration file:
          authz:
             queryTemplate: "DC=example,DC=com??sub?(&(objectClass=group)(member:1.2.840.113556.1.4.1941:={USER}))"
    setParameter:
-      authenticationMechanism: "GSSAPI"
+      authenticationMechanism: "PLAIN"
 
-.. important::
-
-   The given sample configuration requires modification to match your :abbr:`AD
-   (Active Directory)` schema, directory structure, and configuration. You may
-   also require additional :doc:`configuration file options
-   </reference/configuration-options>` for your deployment.
+The given sample configuration requires modification to match your Active
+Directory schema, directory structure, and configuration. You may also require
+additional :doc:`configuration file options
+</reference/configuration-options>` for your deployment.
 
 For more information on configuring roles and privileges, see:
 
@@ -209,4 +188,5 @@ For more information on configuring roles and privileges, see:
 
 - :ref:`privilege actions <security-user-actions>`
 
-- :doc:`collection level access control </core/collection-level-access-control>`
+- :doc:`collection level access control
+  </core/collection-level-access-control>`


### PR DESCRIPTION
Tutorial to support 3.4 LDAP Authentication and Authorization

There are some fixes missed as a part of DOCS-9079 in here as well

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2790)
<!-- Reviewable:end -->
