### PR TITLE
DOCS-8197, DOCS-9382, DOCS-8462: connection string updates

### DIFF
--- a/source/reference/connection-string.txt
+++ b/source/reference/connection-string.txt
@@ -190,8 +190,8 @@ Connection Options
 Connection Pool Options
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Most drivers implement some kind of connection pooling handle this for
-you behind the scenes. Some drivers do not support connection
+Most drivers implement some kind of connection pool handling. 
+Some drivers do not support connection
 pools. See your :doc:`driver </applications/drivers>` documentation
 for more information on the connection pooling implementation. These
 options allow applications to configure the connection pool when
@@ -348,7 +348,9 @@ on a per-connection basis in the connection string:
    * - .. urioption:: readPreference
 
      - Specifies the :term:`replica set` read preference for this
-       connection. The read preference values are the following:
+       connection. 
+       
+       The read preference values are the following:
 
        - :readmode:`primary`
        - :readmode:`primaryPreferred`
@@ -395,8 +397,7 @@ Authentication Options
    * - .. urioption:: authSource
 
      - Specify the database name associated with the user's
-       credentials, if the ``users`` collection does not exist in the
-       database to which the client is connecting. :urioption:`authSource`
+       credentials. :urioption:`authSource`
        defaults to the database specified in the connection string.
 
        For authentication mechanisms that delegate credential storage
@@ -446,6 +447,63 @@ Authentication Options
        :parameter:`saslServiceName` setting on a MongoDB instance, you
        will need to set :urioption:`gssapiServiceName` to the same
        value.
+
+Server Selection and Discovery Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+MongoDB provides the following options to configure how MongoDB drivers
+and :program:`mongos` instances select a server to which to direct read
+or write operations.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+   
+   * - Connection Option
+     - Description
+   
+   * - .. urioption:: localThresholdMS
+
+     - The size (in milliseconds) of the latency window for selecting
+       among multiple suitable MongoDB instances. *Default*: 15
+       milliseconds.
+       
+       All drivers use :urioption:`localThresholdMS`. Use the
+       ``localThreshold`` alias when specifying the latency window size
+       to :program:`mongos`.
+
+   * - .. urioption:: serverSelectionTimeoutMS
+
+     - Specifies how long (in milliseconds) to block for server
+       selection before throwing an exception. *Default*: 30,000
+       milliseconds.
+
+ * - .. urioption:: serverSelectionTryOnce
+
+     - **Single-threaded drivers only**. When ``true``, instructs the
+       driver to scan the MongoDB deployment exactly once after server
+       selection fails and then either select a server or raise an
+       error. When ``false``, the driver blocks and searches for a
+       server up to the :urioption:`serverSelectionTimeoutMS` value.
+       *Default*: ``true``.
+       
+       Multi-threaded drivers and :program:`mongos` do not support
+       :urioption:`serverSelectionTryOnce`.
+
+   * - .. urioption:: heartbeatFrequencyMS
+
+     - :urioption:`heartbeatFrequencyMS` controls when the driver
+       checks the state of the MongoDB deployment. Specify the interval
+       (in milliseconds) between checks, counted from the end of the
+       previous check until the beginning of the next one.
+       
+       *Default*:
+       
+       - Single-threaded drivers: 60 seconds.
+       - Multi-threaded drivers: 10 seconds.
+       
+       :program:`mongos` does not support changing the frequency of 
+       the heartbeat checks.
 
 Miscellaneous Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -521,11 +579,15 @@ The following connects and logs in to the ``records`` database as user
 UNIX Domain Socket
 ~~~~~~~~~~~~~~~~~~
 
-The following connects to a UNIX domain socket:
+Use a URL encoded connection string when connecting to a UNIX domain
+socket. 
+
+The following connects to a UNIX domain socket with file path
+``/tmp/mongodb-27017.sock``:
 
 .. code-block:: none
 
-   mongodb:///tmp/mongodb-27017.sock
+   mongodb://%2Ftmp%2Fmongodb-27017.sock
 
 .. note:: Not all drivers support UNIX domain sockets. For information
    on your driver, see the :doc:`drivers </applications/drivers>`


### PR DESCRIPTION
- adds server selection options
- copy edits
- escapes connection string in unix socket section

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2792)
<!-- Reviewable:end -->
