### PR TITLE
Fix typographical error in `--sslAllowInvalidHostnames`.

### DIFF
--- a/source/includes/options-shared.yaml
+++ b/source/includes/options-shared.yaml
@@ -240,7 +240,7 @@ description: |
   .. versionadded:: 3.0
 
   Disables the validation of the hostnames in TLS/SSL certificates. Allows
-  {{program}} to connect to MongoDB instances if the hostname their
+  {{program}} to connect to MongoDB instances even if the hostname in their
   certificates do not match the specified hostname.
 
   .. include:: /includes/fact-ssl-supported.rst


### PR DESCRIPTION
I copied/pasted this into my own documentation for another tool, and this was caught in review.

https://jira.mongodb.org/browse/DOCS-9623

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2800)
<!-- Reviewable:end -->
