### PR TITLE
add arch tag to avoid apt update error/warning

### DIFF
--- a/source/includes/steps-install-mongodb-on-ubuntu.yaml
+++ b/source/includes/steps-install-mongodb-on-ubuntu.yaml
@@ -22,17 +22,17 @@ action:
     Ubuntu 12.04
       .. code-block:: sh
 
-         echo "deb http://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list
+         echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list
 
     Ubuntu 14.04
       .. code-block:: sh
 
-         echo "deb http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list
+         echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list
 
     Ubuntu 16.04
       .. code-block:: sh
 
-         echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list
+         echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list
 ---
 title: Reload local package database.
 stepnum: 3


### PR DESCRIPTION
The warning is:

N: Skipping acquire of configured file 'multiverse/binary-i386/Packages' as repository 'http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 InRelease' doesn't support architecture 'i386'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2803)
<!-- Reviewable:end -->
