### PR TITLE
DOCS-8583: revises and edits existing Kerberos troubleshooting guide

### DIFF
--- a/source/tutorial/troubleshoot-kerberos.txt
+++ b/source/tutorial/troubleshoot-kerberos.txt
@@ -14,69 +14,81 @@ Troubleshoot Kerberos Authentication
 
 .. _kerberos-troubleshooting-checklist:
 
-Kerberos Configuration Checklist
---------------------------------
+Kerberos Configuration Debugging Strategies
+-------------------------------------------
 
-If you have difficulty starting :program:`mongod` or :program:`mongos`
-with :doc:`Kerberos </core/kerberos>`, ensure that:
+If you have difficulty starting or authenticating against
+:program:`mongod` or :program:`mongos` with :doc:`Kerberos
+</core/kerberos>`:
 
-
-- The :program:`mongod` and the :program:`mongos` binaries are from
-  MongoDB Enterprise. 
+- Ensure that you are running MongoDB Enterprise, not MongoDB Community
+  Edition. Kerberos authentication is a MongoDB Enterprise feature
+  and will not work with MongoDB Community Edition binaries.
 
   .. include:: /includes/fact-confirm-enterprise-binaries.rst
 
-- You are not using the :ecosystem:`HTTP Console
-  </tools/http-interface/#http-console>`. MongoDB Enterprise
-  does not support Kerberos authentication over the HTTP Console
-  interface.
-
-- On Linux, either the service principal name (SPN) in the :ref:`keytab file
-  <keytab-files>` matches the SPN for the :program:`mongod` or :program:`mongos`
-  instance, or the :program:`mongod` or the :program:`mongos` instance use the
-  :parameter:`--setParameter saslHostName=\<host name\> <saslHostName>` to match the name
-  in the keytab file.
-
-- The canonical system hostname of the system that runs the
+- Ensure that the canonical system hostname of the
   :program:`mongod` or :program:`mongos` instance is a resolvable,
-  fully qualified domain for this host. You can test the system
-  hostname resolution with the ``hostname -f`` command at the system
-  prompt.
+  fully qualified domain name. 
+  
+  On Linux, you can verify the system hostname resolution with the ``hostname
+  -f`` command at the system prompt.
 
-- Each host that runs a :program:`mongod` or :program:`mongos` instance
-  has both the ``A`` and ``PTR`` DNS records to provide forward and
-  reverse lookup. The records allow the host to resolve the components
-  of the Kerberos infrastructure.
+- On Linux, ensure that the `primary component of the service principal name (SPN)
+  <http://web.mit.edu/KERBEROS/krb5-1.5/krb5-1.5.4/doc/krb5-user/What-is-a-Kerberos-Principal_003f.html>`_ 
+  of the SPN is ``mongodb``. If the primary component of the SPN
+  **is not** ``mongodb``,
+  you must specify the primary component using
+  :parameter:`--setParameter saslServiceName <saslServiceName>`. 
 
-- Both the Kerberos Key Distribution Center (KDC) and the system
-  running :program:`mongod` instance or :program:`mongos` must be able
-  to resolve each other using DNS. By default, Kerberos attempts to
-  resolve hosts using the content of the ``/etc/krb5.conf`` before
-  using DNS to resolve hosts.
+.. _kerberos-spn-matches-fqdn:
 
-- The time synchronization of the systems running :program:`mongod` or
-  the :program:`mongos` instances and the Kerberos infrastructure are
-  within the maximum time skew (default is 5 minutes) of each other.
-  Time differences greater than the maximum time skew will prevent
-  successful authentication.
+- On Linux, ensure that the `instance component of the service principal 
+  name (SPN) <http://web.mit.edu/KERBEROS/krb5-1.5/krb5-1.5.4/doc/krb5-user/What-is-a-Kerberos-Principal_003f.html>`_ 
+  in the
+  :ref:`keytab file <keytab-files>` matches the canonical system hostname
+  of the :program:`mongod` or :program:`mongos`
+  instance. If the :program:`mongod` or :program:`mongos`
+  instance's system hostname is not in the keytab file,
+  authentication will fail with a ``GSSAPI error acquiring 
+  credentials.`` error message.
 
-Debug with More Verbose Logs on Linux
--------------------------------------
+  If the hostname of your :program:`mongod` or :program:`mongos` instance
+  as returned by ``hostname -f``
+  is not fully qualified,
+  use :parameter:`--setParameter saslHostName
+  <saslHostName>` to set the instance's fully qualified domain name when
+  starting your :program:`mongod` or :program:`mongos`.
+  
+- Ensure that each host that runs a :program:`mongod` or
+  :program:`mongos` instance has ``A`` and ``PTR`` DNS records to
+  provide both forward and reverse DNS lookup. The ``A`` record should
+  map to the :program:`mongod` or :program:`mongos`'s FQDN.
 
-If you still encounter problems with Kerberos on Linux, you can start
-both :program:`mongod` and :program:`mongo` (or another client) with
-the environment variable ``KRB5_TRACE`` set to different files to
-produce more verbose logging of the Kerberos process to help further
-troubleshooting. For example, the following starts a standalone
-:program:`mongod` with ``KRB5_TRACE`` set:
+- Ensure that clocks on the servers hosting your MongoDB instances and
+  Kerberos infrastructure are within the maximum time skew: 5 minutes
+  by default. Time differences greater than the maximum time skew
+  prevent successful authentication.
+
+Kerberos Trace Logging on Linux
+-------------------------------
+
+MIT Kerberos provides the ``KRB5_TRACE`` environment variable for
+trace logging output. If you are having persistent problems with
+MIT Kerberos on Linux, you can set ``KRB5_TRACE`` when starting your
+:program:`mongod`, :program:`mongos`, or :program:`mongo` instances to
+produce verbose logging.
+
+For example, the following command starts a standalone :program:`mongod`
+whose keytab file is at the default ``/etc/krb5.keytab`` path
+and sets ``KRB5_TRACE`` to write to ``/logs/mongodb-kerberos.log``:
 
 .. code-block:: sh
 
-   env KRB5_KTNAME=/opt/mongodb/mongod.keytab \
-       KRB5_TRACE=/opt/mongodb/log/mongodb-kerberos.log \
-       /opt/mongodb/bin/mongod --dbpath /opt/mongodb/data \
-       --fork --logpath /opt/mongodb/log/mongod.log \
-       --auth --setParameter authenticationMechanisms=GSSAPI
+   env KRB5_KTNAME=/etc/krb5.keytab \
+       KRB5_TRACE=/logs/mongodb-kerberos.log \
+       mongod --dbpath /data/db --logpath /data/db/mongodb.log \
+       --auth --setParameter authenticationMechanisms=GSSAPI --fork
 
 Common Error Messages
 ---------------------
@@ -97,32 +109,6 @@ error messages are:
   This error occurs during the start of the :program:`mongod` or
   :program:`mongos` and reflects improper configuration of the system
   hostname or a missing or incorrectly configured keytab file.
-
-  If you encounter this problem, consider the items in the
-  :ref:`kerberos-troubleshooting-checklist`, in particular, whether the
-  SPN in the :ref:`keytab file <keytab-files>` matches the SPN for the
-  :program:`mongod` or :program:`mongos` instance.
-
-  To determine whether the SPNs match:
-
-  #. Examine the keytab file, with the following command:
-
-     .. code-block:: sh
-
-        klist -k <keytab>
-
-     Replace ``<keytab>`` with the path to your keytab file.
-
-  #. Check the configured hostname for your system, with the following
-     command:
-
-     .. code-block:: sh
-
-        hostname -f
-
-     Ensure that this name matches the name in the keytab file, or
-     start :program:`mongod` or :program:`mongos` with the
-     :parameter:`--setParameter saslHostName=\<hostname\> <saslHostName>`.
 
 .. seealso::
 


### PR DESCRIPTION
It would be lovely if we could backport this to 3.2 as well 😺

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2807)
<!-- Reviewable:end -->
