### PR TITLE
Add note about collections beginning with numbers

### DIFF
--- a/source/reference/limits.txt
+++ b/source/reference/limits.txt
@@ -79,9 +79,9 @@ Naming Restrictions
    - begin with the ``system.`` prefix. (Reserved for internal use.)
 
    If your collection name includes special characters, such as the
-   underscore character, then to access the collection use the
-   :method:`db.getCollection()` method in the :program:`mongo` shell or
-   a :api:`similar method for your driver <>`.
+   underscore character, or begins with numbers, then to access the
+   collection use the :method:`db.getCollection()` method in the
+   :program:`mongo` shell or a :api:`similar method for your driver <>`.
 
    .. include:: /includes/fact-collection-namespace-limit.rst
 


### PR DESCRIPTION
If a collection name begins with a number, eg. 2custom, you cannot
access the collection as db.2custom.find(), instead you must use
db.getCollection('2custom').

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2811)
<!-- Reviewable:end -->
