### PR TITLE
DOCS-9489: Update LDAP tutorial admonition

### DIFF
--- a/source/includes/admonition-mongodb-enterprise-windows-ldap.rst
+++ b/source/includes/admonition-mongodb-enterprise-windows-ldap.rst
@@ -1,2 +1,13 @@
-MongoDB Enterprise for Windows does not support binding via
-``saslauthd``.
+.. important::
+
+   :abbr:`Windows (Microsoft Windows)` does not support the ``saslauthd``
+   daemon. MongoDB servers running version 3.2 or prior cannot connect to an
+   LDAP server for authentication. You cannot apply this tutorial to a MongoDB
+   server running on :abbr:`Windows (Microsoft Windows)`.
+   
+   MongoDB 3.4 or later supports binding to an LDAP server via system
+   libraries for :ref:`LDAP authentication <security-ldap>` or :ref:`LDAP
+   authorization <security-ldap-external>`. To configure a MongoDB 3.4
+   deployment running on :abbr:`Windows (Microsoft Windows)` for LDAP proxy
+   authentication, see
+   :doc:`/tutorial/authenticate-nativeldap-activedirectory`.

--- a/source/tutorial/configure-ldap-sasl-activedirectory.txt
+++ b/source/tutorial/configure-ldap-sasl-activedirectory.txt
@@ -18,9 +18,8 @@ Lightweight Directory Access Protocol (LDAP) service.
 Considerations
 --------------
 
-.. warning::
 
-   .. include:: /includes/admonition-mongodb-enterprise-windows-ldap.rst
+.. include:: /includes/admonition-mongodb-enterprise-windows-ldap.rst
 
 .. include:: /includes/admonition-saslauthd-ldap-considerations.rst
 

--- a/source/tutorial/configure-ldap-sasl-openldap.txt
+++ b/source/tutorial/configure-ldap-sasl-openldap.txt
@@ -18,9 +18,7 @@ Lightweight Directory Access Protocol (LDAP) service.
 Considerations
 --------------
 
-.. warning::
-
-   .. include:: /includes/admonition-mongodb-enterprise-windows-ldap.rst
+.. include:: /includes/admonition-mongodb-enterprise-windows-ldap.rst
 
 .. include:: /includes/admonition-saslauthd-ldap-considerations.rst
 


### PR DESCRIPTION
`/tutorial/configure-ldap-sasl-activedirectory` and `/tutorial/configure-ldap-sasl-openldap` require updated admonition to point to new 3.4 LDAP support for Windows LDAP authentication and Authorization

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2812)
<!-- Reviewable:end -->
