### PR TITLE
Use "mongod processes" rather than "mongod servers"

### DIFF
--- a/source/faq/diagnostics.txt
+++ b/source/faq/diagnostics.txt
@@ -51,7 +51,7 @@ periods, on the order of ``120`` seconds (two minutes).
 If your MongoDB deployment experiences keepalive-related issues, you
 must alter the keep alive value on *all* machines hosting MongoDB
 processes. This includes all machines hosting :program:`mongos` or
-:program:`mongod` servers and all machines hosting client processes
+:program:`mongod` processes and all machines hosting client processes
 that connect to MongoDB.
 
 .. note:: 
@@ -69,7 +69,7 @@ that connect to MongoDB.
 .. include:: /includes/fact-tcp-keepalive-windows.rst
 
 You will need to restart :program:`mongod` and :program:`mongos`
-servers for new system-wide keepalive settings to take effect.
+processes for new system-wide keepalive settings to take effect.
 
 Why does MongoDB log so many "Connection Accepted" events?
 ----------------------------------------------------------


### PR DESCRIPTION
Since the word "server" can often be misinterpreted as the host itself, giving different meaning to "restart the mongod server".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2815)
<!-- Reviewable:end -->
