### PR TITLE
minor: add collation to db.collection.update synopsis

### DIFF
--- a/source/reference/method/db.collection.update.txt
+++ b/source/reference/method/db.collection.update.txt
@@ -36,7 +36,8 @@ Definition
          {
            upsert: <boolean>,
            multi: <boolean>,
-           writeConcern: <document>
+           writeConcern: <document>,
+           collation: <document>
          }
       )
 


### PR DESCRIPTION
I noticed that the [`db.collection.update()` page](https://docs.mongodb.com/manual/reference/method/db.collection.update/) was missing "collation" in the general form specification.

Perhaps the `versionchanged` should also be modified to reflect that "collation" is a new option in version 3.4? Or a blurb at the bottom? I leave that up to you guys!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2816)
<!-- Reviewable:end -->
