### PR TITLE
Change "Query Operator Array" to "Array Query Operators"

### DIFF
--- a/source/reference/operator/query-array.txt
+++ b/source/reference/operator/query-array.txt
@@ -1,6 +1,6 @@
-====================
-Query Operator Array
-====================
+=====================
+Array Query Operators
+=====================
 
 .. default-domain:: mongodb
 


### PR DESCRIPTION
The original name is inconsistent and awkward.
The new name would be consistent with names of other categories of query operators.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2817)
<!-- Reviewable:end -->
