### PR TITLE
DOCS-9177: removes --upgrade option from mongos ref

### DIFF
--- a/source/includes/options-mongos.yaml
+++ b/source/includes/options-mongos.yaml
@@ -231,14 +231,6 @@ replacement:
   intro: "Specifies the"
 ---
 program: mongos
-name: upgrade
-args: null
-directive: option
-description: |
-  Updates the meta data format used by the :term:`config database`.
-optional: true
----
-program: mongos
 name: localThreshold
 args: null
 default: 15

--- a/source/reference/program/mongos.txt
+++ b/source/reference/program/mongos.txt
@@ -95,8 +95,6 @@ Sharded Cluster Options
 
 .. include:: /includes/option/option-mongos-localThreshold.rst
 
-.. include:: /includes/option/option-mongos-upgrade.rst
-
 TLS/SSL Options
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
`mongos --upgrade` was removed in 3.2 (it's also absent in 3.4, unsurprisingly). 

Patch should be backported to 3.2 as well, please! 😺

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2821)
<!-- Reviewable:end -->
