### PR TITLE
Update deploy-sharded-cluster-hashed-sharding.txt

### DIFF
--- a/source/tutorial/deploy-sharded-cluster-hashed-sharding.txt
+++ b/source/tutorial/deploy-sharded-cluster-hashed-sharding.txt
@@ -179,4 +179,4 @@ The following operation shards the target collection using the
 
 .. code-block:: javascript
 
-   sh.shardCollection("<database>.<collection>", { <key> : <direction> } )
+   sh.shardCollection("<database>.<collection>", { <key> : "hashed" } )


### PR DESCRIPTION
direction is for range-based sharding. for hash-based it should surely be "hashed"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2826)
<!-- Reviewable:end -->
