### PR TITLE
DOCS-9447: remove emptycapped references

### DIFF
--- a/source/reference/built-in-roles.txt
+++ b/source/reference/built-in-roles.txt
@@ -77,7 +77,6 @@ Every database includes the following client roles:
    - :authaction:`dropCollection`
    - :authaction:`createIndex`
    - :authaction:`dropIndex`
-   - :authaction:`emptycapped`
    - :authaction:`find`
    - :authaction:`insert`
    - :authaction:`killCursors`

--- a/source/reference/privilege-actions.txt
+++ b/source/reference/privilege-actions.txt
@@ -214,11 +214,6 @@ Database Management Actions
    User can remove any user from the given database. Apply this action to
    database resources.
 
-.. authaction:: emptycapped
-
-   User can perform the :dbcommand:`emptycapped` command. Apply this
-   action to database or collection resources.
-
 .. authaction:: enableProfiler
 
    User can perform the :method:`db.setProfilingLevel()` method. Apply


### PR DESCRIPTION
emptycapped was an internal test command, since renamed, so I'm not sure why it was ever included in the list of privilege actions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2830)
<!-- Reviewable:end -->
