### PR TITLE
add missing field name

### DIFF
--- a/source/reference/operator/query/near.txt
+++ b/source/reference/operator/query/near.txt
@@ -34,14 +34,16 @@ Definition
    .. code-block:: javascript
 
       {
-        $near: {
-           $geometry: {
-              type: "Point" ,
-              coordinates: [ <longitude> , <latitude> ]
-           },
-           $maxDistance: <distance in meters>,
-           $minDistance: <distance in meters>
-        }
+         <location field>: {
+           $near: {
+             $geometry: {
+                type: "Point" ,
+                coordinates: [ <longitude> , <latitude> ]
+             },
+             $maxDistance: <distance in meters>,
+             $minDistance: <distance in meters>
+           }
+         }
       }
 
    When specifying a :term:`GeoJSON` point, you can use the *optional*


### PR DESCRIPTION
Example less confusion when showing that location-field is required.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2840)
<!-- Reviewable:end -->
