### PR TITLE
Fix readPref usage.

### DIFF
--- a/source/reference/read-preference.txt
+++ b/source/reference/read-preference.txt
@@ -235,8 +235,7 @@ from nearby members with the following read preference:
 
 .. code-block:: javascript
 
-   db.collection.find().readPref( { mode: 'nearest',
-                                    tags: [ {'dc': 'east'} ] } )
+   db.collection.find().readPref('nearest', [ {'dc': 'east'} ])
 
 Although :readmode:`nearest` already favors members with low network latency,
 including the tag makes the choice more predictable.

--- a/source/reference/read-preference.txt
+++ b/source/reference/read-preference.txt
@@ -235,7 +235,7 @@ from nearby members with the following read preference:
 
 .. code-block:: javascript
 
-   db.collection.find().readPref('nearest', [ {'dc': 'east'} ])
+   db.collection.find().readPref('nearest', [ { 'dc': 'east' } ])
 
 Although :readmode:`nearest` already favors members with low network latency,
 including the tag makes the choice more predictable.


### PR DESCRIPTION
This page had an incorrect usage of `readPref()`. I've updated it accordingly.

I also checked, and this is the only incorrect usage across the docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2850)
<!-- Reviewable:end -->
