### PR TITLE
Typo corrected

### DIFF
--- a/source/reference/read-preference.txt
+++ b/source/reference/read-preference.txt
@@ -117,7 +117,7 @@ Read Preference Modes
    how stale each secondary is by comparing the secondary's last write
    to that of the primary, if available, or to the secondary with the
    most recent write if there is no primary. The client will then
-   filter out any secondary whose estimated lag is greater than
+   filter out any secondary whose estimated lag is less than
    ``maxStalenessSeconds`` and randomly direct the read to a remaining
    member (primary or secondary) whose network latency falls within the
    :ref:`acceptable latency window


### PR DESCRIPTION
In case of maxStalenessSeconds mentioned as part read preference, the reads will be redirected to the secondary whose estimated lag less than the maxStalenessSeconds value and not greater than maxStalenessSeconds value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2851)
<!-- Reviewable:end -->
