### PR TITLE
Corrected ordered duplicate key thrown exception

### DIFF
--- a/source/reference/method/db.collection.insertMany.txt
+++ b/source/reference/method/db.collection.insertMany.txt
@@ -203,18 +203,18 @@ Since ``_id: 13`` already exists, the following exception is thrown:
    BulkWriteError({
       "writeErrors" : [
          {
-            "index" : 0,
+            "index" : 1,
             "code" : 11000,
-            "errmsg" : "E11000 duplicate key error collection: restaurant.test index: _id_ dup key: { : 13.0 }",
+            "errmsg" : "E11000 duplicate key error collection: inventory.products.$_id_ dup key: { : 13.0 }",
             "op" : {
                "_id" : 13,
-               "item" : "envelopes",
-               "qty" : 60
+               "item" : "stamps",
+               "qty" : 110
             }
          }
       ],
       "writeConcernErrors" : [ ],
-      "nInserted" : 0,
+      "nInserted" : 1,
       "nUpserted" : 0,
       "nMatched" : 0,
       "nModified" : 0,


### PR DESCRIPTION
The thrown exception did not match what is explained in the text above and below it.
It was showing an error while inserting the first document (_id:13), but actually the error is thrown while inserting the second document (_id:13 again). So, "index", "op" and "nInserted" were corrected, as well as the database and collection names in the "errmsg" to be consistent with the other examples in the same documentation.