### PR TITLE
Fixed mongo shell data types Date() description

### DIFF
--- a/source/core/shell-types.txt
+++ b/source/core/shell-types.txt
@@ -33,8 +33,7 @@ either as a string or as a ``Date`` object:
 
 - ``Date()`` method which returns the current date as a string.
 
-- ``new Date()`` constructor which returns a ``Date`` object using the
-  ``ISODate()`` wrapper.
+- ``new Date()`` constructor which returns a ``Date`` object.
 
 - ``ISODate()`` constructor which returns a ``Date`` object using the
   ``ISODate()`` wrapper.


### PR DESCRIPTION
new Date() constructor returns a Date() object, but NOT using the ISODate() wrapper. That description belongs to the line below, where ISODate() constructor is described.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2855)
<!-- Reviewable:end -->
