### PR TITLE
minor: increase depth of server parameters TOC to 2

### DIFF
--- a/source/reference/parameters.txt
+++ b/source/reference/parameters.txt
@@ -7,7 +7,7 @@ MongoDB Server Parameters
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 1
+   :depth: 2
    :class: singlecol
 
 Synopsis


### PR DESCRIPTION
The table of contents on the server parameters page isn't that useful, since it only points to the top-level headings. It would be nice if it also had quick links to jump to all of the subheadings.

I haven't built this locally or tested it in staging, so sorry if this is wrong :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2864)
<!-- Reviewable:end -->
