### PR TITLE
Fix DOCS-10213: MongoDB 3.4 manual doesn't note `versionadded` for listDatabases' nameOnly option

### DIFF
--- a/source/includes/apiargs-dbcommand-listDatabases-field.yaml
+++ b/source/includes/apiargs-dbcommand-listDatabases-field.yaml
@@ -7,6 +7,9 @@ description: |
 
    Default is ``false``; i.e. :dbcommand:`listDatabases` returns the
    name and size information of the databases.
+
+   .. versionadded:: 3.4.3
+
 interface: dbcommand
 operation: listDatabases
 arg_name: field

--- a/source/reference/command/listDatabases.txt
+++ b/source/reference/command/listDatabases.txt
@@ -95,6 +95,8 @@ The following is an example of a :dbcommand:`listDatabases` result:
 List Database Names Only
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. versionadded:: 3.4.3
+
 Run :dbcommand:`listDatabases` against the ``admin`` database. Specify
 the ``nameOnly: true`` option:
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2876)
<!-- Reviewable:end -->
