### PR TITLE
Fix spelling of "preference"

### DIFF
--- a/source/core/distributed-queries.txt
+++ b/source/core/distributed-queries.txt
@@ -83,7 +83,7 @@ Read operations from secondary members of replica sets may not reflect
 the current state of the primary. Read preferences that direct read
 operations to different servers may result in non-monotonic reads.
 
-You can configure the read preferece on a per-connection or
+You can configure the read preference on a per-connection or
 per-operation basis. For more information on read preference or on the
 read preference modes, see :doc:`/core/read-preference` and
 :ref:`replica-set-read-preference-modes`. 


### PR DESCRIPTION
Changed 'preferece' to 'preference' in distributed-queries.txt

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2878)
<!-- Reviewable:end -->
