### PR TITLE
DOCS-8229 - Removed waitedMS return value from geoNear examples.

### DIFF
--- a/source/reference/command/geoNear.txt
+++ b/source/reference/command/geoNear.txt
@@ -138,7 +138,6 @@ nearest to farthest:
 .. code-block:: javascript
 
    {
-     "waitedMS" : NumberLong(0),
      "results" : [
         {
           "dis" : 0,
@@ -203,7 +202,6 @@ The operation returns the following output:
 .. code-block:: javascript
 
    {
-     "waitedMS" : NumberLong(0),
      "results" : [
         {
           "dis" : 3245.988787957091,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2886)
<!-- Reviewable:end -->
