### PR TITLE
Patch sharding-data-partitioning.txt

### DIFF
--- a/source/core/sharding-data-partitioning.txt
+++ b/source/core/sharding-data-partitioning.txt
@@ -165,8 +165,8 @@ chunk splitting and the balancer.
 ``moveChunk`` directory
 -----------------------
 
-Starting in MongoDB 2.6, :setting:`sharding.archiveMovedChunks` is
-enabled by default. With :setting:`sharding.archiveMovedChunks`
+In MongoDB 2.6 and MongoDB 3.0, :setting:`sharding.archiveMovedChunks` is
+enabled by default. All other MongoDB versions have this disabled by default. With :setting:`sharding.archiveMovedChunks`
 enabled, the source shard archives the documents in the migrated chunks
 in a directory named after the collection namespace under the
 ``moveChunk`` directory in the :setting:`storage.dbPath`.


### PR DESCRIPTION
Only MongoDB 2.6 and 3.0 enabled archiving chunks by default.
Other pages seem to have this right already, for example: https://docs.mongodb.com/manual/reference/configuration-options/#sharding.archiveMovedChunks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2895)
<!-- Reviewable:end -->
