### PR TITLE
Use the default port for config servers

### DIFF
--- a/source/includes/steps-deploy-sharded-cluster-config-server-noauth.yaml
+++ b/source/includes/steps-deploy-sharded-cluster-config-server-noauth.yaml
@@ -90,9 +90,9 @@ action:
           _id: "<replSetName>",
           configsvr: true,
           members: [
-            { _id : 0, host : "cfg1.example.net:27017" },
-            { _id : 1, host : "cfg2.example.net:27017" },
-            { _id : 2, host : "cfg3.example.net:27017" }
+            { _id : 0, host : "cfg1.example.net:27019" },
+            { _id : 1, host : "cfg2.example.net:27019" },
+            { _id : 2, host : "cfg3.example.net:27019" }
           ]
         }
       )


### PR DESCRIPTION
By default, a config server listens on port 27019, so use that in the example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2900)
<!-- Reviewable:end -->
