### PR TITLE
Docs 10274

### DIFF
--- a/source/includes/ref-toc-aggregation-array.yaml
+++ b/source/includes/ref-toc-aggregation-array.yaml
@@ -14,6 +14,11 @@ description: |
   Selects a subset of the array to return an array with only the elements
   that match the filter condition.
 ---
+name: :expression:`$in`
+file: /reference/operator/aggregation/in
+description: |
+    Returns a boolean indicating whether a specified value is in an array.
+---
 name: :expression:`$indexOfArray`
 file: /reference/operator/aggregation/indexOfArray
 description: |
@@ -26,22 +31,28 @@ file: /reference/operator/aggregation/isArray
 description: |
   Determines if the operand is an array. Returns a boolean.
 ---
+name: :expression:`$map`
+file: /reference/operator/aggregation/map
+description: |
+    Applies a subexpression to each element of an array and returns the
+    array of resulting values in order. Accepts named parameters.
+---
 name: :expression:`$range`
 description: |
    Outputs an array containing a sequence of integers according to
    user-defined inputs.
 file: /reference/operator/aggregation/range
 ---
+name: :expression:`$reduce`
+file: /reference/operator/aggregation/reduce
+description: |
+    Applies an expression to each element in an array and combines them
+    into a single value.
+---
 name: :expression:`$reverseArray`
 file: /reference/operator/aggregation/reverseArray
 description: |
   Returns an array with the elements in reverse order.
----
-name: :expression:`$reduce`
-file: /reference/operator/aggregation/reduce
-description: |
-  Applies an expression to each element in an array and combines them
-  into a single value.
 ---
 name: :expression:`$size`
 file: /reference/operator/aggregation/size
@@ -56,11 +67,6 @@ file: /reference/operator/aggregation/slice
 ---
 name: :expression:`$zip`
 description: |
-  Merge two lists together.
+  Merge two arrays together.
 file: /reference/operator/aggregation/zip
----
-name: :expression:`$in`
-description: |
-  Returns a boolean indicating whether a specified value is in an array.
-file: /reference/operator/aggregation/in
 ...

--- a/source/includes/ref-toc-aggregation-projection-expressions.yaml
+++ b/source/includes/ref-toc-aggregation-projection-expressions.yaml
@@ -1,9 +1,3 @@
-name: :expression:`$map`
-file: /reference/operator/aggregation/map
-description: |
-  Applies a subexpression to each element of an array and returns the
-  array of resulting values in order. Accepts named parameters.
----
 name: :expression:`$let`
 file: /reference/operator/aggregation/let
 description: |

--- a/source/reference/operator/aggregation-literal.txt
+++ b/source/reference/operator/aggregation-literal.txt
@@ -1,5 +1,5 @@
 =============================
-Aggregation Literal Operators
+Literal Aggregation Operators
 =============================
 
 .. default-domain:: mongodb

--- a/source/reference/operator/aggregation-projection.txt
+++ b/source/reference/operator/aggregation-projection.txt
@@ -1,5 +1,5 @@
 ==============================
-Aggregation Variable Operators
+Variable Aggregation Operators
 ==============================
 
 .. default-domain:: mongodb


### PR DESCRIPTION
Reorganizing a few of the aggregation operators to make divisions a bit more intuitive.
Reordering the array aggregation operators alphabetically.
Slight rewording of the Variable and Literal Operators labels to keep a consistent format.

JIRA: https://jira.mongodb.org/browse/DOCS-10274
CR: https://mongodbcr.appspot.com/141280001/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2906)
<!-- Reviewable:end -->
