### PR TITLE
Use preferred spelling of map-reduce

### DIFF
--- a/source/aggregation.txt
+++ b/source/aggregation.txt
@@ -76,7 +76,7 @@ aggregation pipeline, in general, map-reduce is less efficient and more
 complex than the aggregation pipeline.
 
 Map-reduce can operate on a
-:doc:`sharded collection </sharding>`. Map reduce operations 
+:doc:`sharded collection </sharding>`. Map-reduce operations
 can also output to a sharded collection. See
 :doc:`/core/aggregation-pipeline-sharded-collections` and
 :doc:`/core/map-reduce-sharded-collections` for details.

--- a/source/core/map-reduce-concurrency.txt
+++ b/source/core/map-reduce-concurrency.txt
@@ -1,5 +1,5 @@
 ======================
-Map Reduce Concurrency
+Map-Reduce Concurrency
 ======================
 
 .. default-domain:: mongodb

--- a/source/core/map-reduce.txt
+++ b/source/core/map-reduce.txt
@@ -69,7 +69,7 @@ with previous results. See :dbcommand:`mapReduce` and
 :doc:`/tutorial/perform-incremental-map-reduce` for details and
 examples.
 
-When returning the results of a map reduce operation *inline*, the
+When returning the results of a map-reduce operation *inline*, the
 result documents must be within the :limit:`BSON Document Size` limit,
 which is currently 16 megabytes. For additional information on limits
 and restrictions on map-reduce operations, see the

--- a/source/includes/apiargs-method-db.collection.mapReduce-args-field.yaml
+++ b/source/includes/apiargs-method-db.collection.mapReduce-args-field.yaml
@@ -3,7 +3,7 @@ description: |
   Specifies the location of the result of the map-reduce operation.
   You can output to a collection, output to a collection with an
   action, or output inline. You may output to a collection when
-  performing map reduce operations on the primary members of the set;
+  performing map-reduce operations on the primary members of the set;
   on :term:`secondary` members you may only use the ``inline`` output.
 
   See :ref:`mapReduce-out-mtd` for more information.

--- a/source/reference/command/mapReduce.txt
+++ b/source/reference/command/mapReduce.txt
@@ -39,12 +39,12 @@ mapReduce
 
    Pass the name of the collection to the ``mapReduce`` command
    (i.e. ``<collection>``) to use as the source documents to perform
-   the map reduce operation. 
+   the map-reduce operation.
 
    .. note::
 
       .. include:: /includes/extracts/views-unsupported-mapReduce.rst
-   
+
    The command also accepts the following parameters:
 
    .. include:: /includes/apiargs/command-mapReduce-field.rst
@@ -68,7 +68,7 @@ mapReduce
                    )
 
    .. include:: /includes/extracts/admonition-js-prevalence-mapReduce.rst
-   
+
 .. _mapreduce-map-cmd:
 
 .. include:: /includes/parameters-map-reduce.rst


### PR DESCRIPTION
Use the preferred spelling of map-reduce as per
https://docs.mongodb.com/manual/meta/style-guide/#jargon-and-common-terms

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2908)
<!-- Reviewable:end -->
