### PR TITLE
DOCS-10365 - Minor text fix for strLenCP

### DIFF
--- a/source/reference/operator/aggregation/bucket.txt
+++ b/source/reference/operator/aggregation/bucket.txt
@@ -78,7 +78,7 @@ Consider a collection ``artwork`` with the following documents:
   { "_id" : 3, "title" : "Dancer", "artist" : "Miro", "year" : 1925,
       "price" : NumberDecimal("76.04") }
   { "_id" : 4, "title" : "The Great Wave off Kanagawa", "artist" : "Hokusai",
-      “year” : 1832, "price" : NumberDecimal("167.30") }
+      "year" : 1832, "price" : NumberDecimal("167.30") }
   { "_id" : 5, "title" : "The Persistence of Memory", "artist" : "Dali", "year" : 1931,
       "price" : NumberDecimal("483.00") }
   { "_id" : 6, "title" : "Composition VII", "artist" : "Kandinsky", "year" : 1913,

--- a/source/reference/operator/aggregation/bucket.txt
+++ b/source/reference/operator/aggregation/bucket.txt
@@ -78,7 +78,7 @@ Consider a collection ``artwork`` with the following documents:
   { "_id" : 3, "title" : "Dancer", "artist" : "Miro", "year" : 1925,
       "price" : NumberDecimal("76.04") }
   { "_id" : 4, "title" : "The Great Wave off Kanagawa", "artist" : "Hokusai",
-      "price" : NumberDecimal("167.30") }
+      “year” : 1832, "price" : NumberDecimal("167.30") }
   { "_id" : 5, "title" : "The Persistence of Memory", "artist" : "Dali", "year" : 1931,
       "price" : NumberDecimal("483.00") }
   { "_id" : 6, "title" : "Composition VII", "artist" : "Kandinsky", "year" : 1913,

--- a/source/reference/operator/aggregation/strLenCP.txt
+++ b/source/reference/operator/aggregation/strLenCP.txt
@@ -47,10 +47,10 @@ Definition
         - ``12``
    
       * - ``{ $strLenCP: "cafeteria" }``
-        - ``11``
+        - ``9``
    
       * - ``{ $strLenCP: "cafétéria" }``
-        - ``11``
+        - ``9``
       
       * - ``{ $strLenCP: "" }``
         - ``0``


### PR DESCRIPTION
Minor text fix - correcting the string length for 'cafeteria' from 11 to 9.

CR: https://mongodbcr.appspot.com/141360001/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2909)
<!-- Reviewable:end -->
