### PR TITLE
Docs 10365 - Minor text fix for string length example

### DIFF
--- a/source/reference/operator/aggregation/strLenCP.txt
+++ b/source/reference/operator/aggregation/strLenCP.txt
@@ -47,10 +47,10 @@ Definition
         - ``12``
    
       * - ``{ $strLenCP: "cafeteria" }``
-        - ``11``
+        - ``9``
    
       * - ``{ $strLenCP: "cafétéria" }``
-        - ``11``
+        - ``9``
       
       * - ``{ $strLenCP: "" }``
         - ``0``


### PR DESCRIPTION
Correcting the string length of 'cafeteria' to be 9 instead of 11.

CR: https://mongodbcr.appspot.com/141360001/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2910)
<!-- Reviewable:end -->
