### PR TITLE
DOCS-10366 Adding missing field to doc example

### DIFF
--- a/source/reference/operator/aggregation/bucket.txt
+++ b/source/reference/operator/aggregation/bucket.txt
@@ -78,7 +78,7 @@ Consider a collection ``artwork`` with the following documents:
   { "_id" : 3, "title" : "Dancer", "artist" : "Miro", "year" : 1925,
       "price" : NumberDecimal("76.04") }
   { "_id" : 4, "title" : "The Great Wave off Kanagawa", "artist" : "Hokusai",
-      "year" : 1832, "price" : NumberDecimal("167.30") }
+      "price" : NumberDecimal("167.30") }
   { "_id" : 5, "title" : "The Persistence of Memory", "artist" : "Dali", "year" : 1931,
       "price" : NumberDecimal("483.00") }
   { "_id" : 6, "title" : "Composition VII", "artist" : "Kandinsky", "year" : 1913,
@@ -268,7 +268,7 @@ The operation returns the following document:
        },
        {
          // Includes the document without a year, e.g., _id: 4
-         "_id" : "Other",
+         "_id" : "Unknown",
          "count" : 1,
          "artwork" : [
            {

--- a/source/reference/operator/aggregation/bucket.txt
+++ b/source/reference/operator/aggregation/bucket.txt
@@ -78,7 +78,7 @@ Consider a collection ``artwork`` with the following documents:
   { "_id" : 3, "title" : "Dancer", "artist" : "Miro", "year" : 1925,
       "price" : NumberDecimal("76.04") }
   { "_id" : 4, "title" : "The Great Wave off Kanagawa", "artist" : "Hokusai",
-      "price" : NumberDecimal("167.30") }
+      "year" : 1832, "price" : NumberDecimal("167.30") }
   { "_id" : 5, "title" : "The Persistence of Memory", "artist" : "Dali", "year" : 1931,
       "price" : NumberDecimal("483.00") }
   { "_id" : 6, "title" : "Composition VII", "artist" : "Kandinsky", "year" : 1913,


### PR DESCRIPTION
Minor text change - 'year' field has been added to the example document.

CR: https://mongodbcr.appspot.com/137640001/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2911)
<!-- Reviewable:end -->
