### PR TITLE
Add maxTimeMS to syntax block for aggregate command

### DIFF
--- a/source/reference/command/aggregate.txt
+++ b/source/reference/command/aggregate.txt
@@ -31,6 +31,7 @@ aggregate
         explain: <boolean>,
         allowDiskUse: <boolean>,
         cursor: <document>,
+        maxTimeMS: <int>,
         bypassDocumentValidation: <boolean>,
         readConcern: <document>,
         collation: <document>


### PR DESCRIPTION
It is included below in the list of option descriptions but isn't in the block showing syntax.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2914)
<!-- Reviewable:end -->
