### PR TITLE
[mongorestore] Added note about = sign for archive filename

### DIFF
--- a/source/includes/options-mongorestore.yaml
+++ b/source/includes/options-mongorestore.yaml
@@ -388,6 +388,9 @@ description: |
      - {{program}} still supports the positional ``-`` parameter to
        restore a *single* collection from the standard input.
 
+     - You must use a ``=`` between ``--archive`` and the archive filename
+       when restoring from an archive file.
+     
 optional: true
 ---
 program: mongorestore


### PR DESCRIPTION
It is not clear form the mongorestore option docs that you have to supply `--archive=<filename>` while most other options can be supplied without the `=` sign.  Although the examples at the bottom of the page do show the = sign, it is nowhere mentioned in the docs that the `=` sign is required which was quite confusing. This commit should better explain that

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2917)
<!-- Reviewable:end -->
