### PR TITLE
DOCS-6228: clarifies replacement settings for sslOnNormalPorts

### DIFF
--- a/source/includes/options-conf.yaml
+++ b/source/includes/options-conf.yaml
@@ -563,6 +563,7 @@ directive: setting
 replacement:
   program: ":program:`mongos` or :program:`mongod`"
   verb: "Enable or disable"
+  alternative: ":setting:`net.ssl.mode: requireSSL <~net.ssl.mode>`"
 inherit:
   name: sslOnNormalPorts
   program: mongod

--- a/source/includes/options-mongod.yaml
+++ b/source/includes/options-mongod.yaml
@@ -1163,19 +1163,20 @@ name: sslOnNormalPorts
 args: null
 directive: option
 description: |
-  .. deprecated:: 2.6
+  .. deprecated:: 2.6 Use {{alternative}} instead.
 
   {{verb}} TLS/SSL for {{program}}.
 
   With {{role}}, a {{program}} requires TLS/SSL encryption for all
   connections on the default MongoDB port, or the port specified by
-  :option:`--port`. By default, :option:`--sslOnNormalPorts` is
+  :option:`--port`. By default, {{role}} is
   disabled.
 
   .. include:: /includes/fact-ssl-supported.rst
 optional: true
 replacement:
   verb: "Enables"
+  alternative: ":option:`--sslMode requireSSL <--sslMode>`"
 ---
 program: mongod
 name: sslMode


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2926)
<!-- Reviewable:end -->
