### PR TITLE
DOCS-8996: clarify  behavior with non-existent fields

### DIFF
--- a/source/reference/operator/aggregation/avg.txt
+++ b/source/reference/operator/aggregation/avg.txt
@@ -52,11 +52,12 @@ Definition
 Behavior
 --------
 
-Non-numeric Values
-~~~~~~~~~~~~~~~~~~
+Non-numeric or Missing Values
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:group:`$avg` ignores non-numeric values. If all operands for the
-average are non-numeric, :group:`$avg` returns ``null``.
+:group:`$avg` ignores non-numeric values, including missing values. If all of the
+operands for the average are non-numeric, :group:`$avg` returns
+``null`` since the average of zero values is undefined.
 
 Array Operand
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Should ideally be backported to 3.2 and 3.4, as well.