### PR TITLE
autoIndexId was not in fact removed in 3.4

### DIFF
--- a/source/includes/apiargs-method-db.createCollection-options-param.yaml
+++ b/source/includes/apiargs-method-db.createCollection-options-param.yaml
@@ -19,7 +19,7 @@ description: |
      For replica sets, do not set ``autoIndexId`` to ``false``.
 
   .. deprecated:: 3.2
-     The ``autoIndexId`` option will be removed in version 3.4.
+     
 interface: method
 name: autoIndexId
 operation: db.createCollection


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2935)
<!-- Reviewable:end -->
