### PR TITLE
DOCS-10562: WT clock reliability issues 3.4.5 and earlier

### DIFF
--- a/source/administration/production-notes.txt
+++ b/source/administration/production-notes.txt
@@ -82,7 +82,6 @@ manager.
 
 .. include:: /includes/list-table-products-supported-architecture.rst
 
-
 MongoDB ``dbPath``
 ------------------
 
@@ -502,6 +501,17 @@ change the compression setting, see
 :setting:`storage.wiredTiger.collectionConfig.blockCompressor`.
 
 WiredTiger uses :term:`prefix compression` on all indexes by default.
+
+Clock Synchronization
+---------------------
+
+Use `NTP <http://www.ntp.org/>`_ to synchronize the clocks on all
+components of your MongoDB deployment. :term:`Replica sets <replica
+set>` and :term:`sharded clusters <sharded cluster>` running MongoDB
+3.4.5 or earlier with the :doc:`WiredTiger </core/wiredtiger>` storage
+engine may experience :ref:`checkpoint
+<storage-wiredtiger-checkpoints>` hangs on systems with unreliable
+clocks.
 
 .. _prod-notes-platform-considerations:
 

--- a/source/release-notes/3.4.txt
+++ b/source/release-notes/3.4.txt
@@ -969,4 +969,9 @@ List of known issues in the 3.4.0 release:
 - :issue:`SERVER-27207`: Find on view with sort through
   :program:`mongos` may incorrectly return empty result set.
 
+- :issue:`WT-3327`: :ref:`Checkpoints <storage-wiredtiger-checkpoints>`
+  can hang if time runs backwards (e.g.
+  on a system with an unreliable clock). 
+  (Fixed in :ref:`MongoDB 3.4.6 <3.4.6-release-notes>`.)
+
 .. include:: /includes/unicode-checkmark.rst


### PR DESCRIPTION
For master & 3.4 pleees. Or possibly just 3.4 if you think that's more practical…

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2936)
<!-- Reviewable:end -->
