### PR TITLE
DOCS-9528: mmapv1 does not run on big endian architectures

### DIFF
--- a/source/administration/production-notes.txt
+++ b/source/administration/production-notes.txt
@@ -51,6 +51,8 @@ s390x (MongoDB Enterprise Edition)
 
 .. include:: /includes/fact-platform-s390x.rst
 
+.. include:: /includes/fact-mmapv1-big-endian.rst
+
 .. _prod-notes-recommended-platforms:
 
 Recommended Platforms

--- a/source/core/mmapv1.txt
+++ b/source/core/mmapv1.txt
@@ -16,6 +16,8 @@ MMAPv1 is MongoDB's original storage engine based on memory mapped
 files. It excels at workloads with high volume inserts, reads, and
 in-place updates.
 
+.. include:: /includes/fact-mmapv1-big-endian.rst
+
 .. versionchanged:: 3.2
 
    Starting in MongoDB 3.2, the MMAPv1 is no longer the default storage

--- a/source/includes/fact-mmapv1-big-endian.rst
+++ b/source/includes/fact-mmapv1-big-endian.rst
@@ -1,0 +1,5 @@
+.. important::
+
+   MMAPv1 is not supported on big-endian architectures such as s390x.
+   MongoDB returns an error if you set MMAPv1 as the
+   storage engine on a big-endian system.


### PR DESCRIPTION
Needs back-porting to 3.4 as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2939)
<!-- Reviewable:end -->
