### PR TITLE
Specify scanAndOrder removal version

### DIFF
--- a/source/reference/explain-results.txt
+++ b/source/reference/explain-results.txt
@@ -227,8 +227,8 @@ information:
    .. data:: explain.executionStats.totalKeysExamined
 
       Number of index entries scanned.
-      :data:`~explain.executionStats.totalKeysExamined` corresponds to the 
-      ``nscanned`` field returned by ``cursor.explain()`` in 
+      :data:`~explain.executionStats.totalKeysExamined` corresponds to the
+      ``nscanned`` field returned by ``cursor.explain()`` in
       earlier versions of MongoDB.
 
    .. data:: explain.executionStats.totalDocsExamined
@@ -291,41 +291,41 @@ information:
            returns more than the specified limit, the ``LIMIT`` stage
            will report ``isEOF: 1``, but its underlying ``IXSCAN`` stage
            will report ``isEOF: 0``.
-           
+
       .. data:: explain.executionStats.executionStages.inputStage.keysExamined
-         
-         For query execution stages that scan an index (e.g. IXSCAN), 
-         ``keysExamined`` is the total number of in-bounds and out-of-bounds 
-         keys that are examined in the process of the index scan. If the 
-         index scan consists of a single contiguous range of keys, only 
-         in-bounds keys need to be examined. If the index bounds consists of 
-         several key ranges, the index scan execution process may examine 
-         out-of-bounds keys in order to skip from the end of one range to the 
+
+         For query execution stages that scan an index (e.g. IXSCAN),
+         ``keysExamined`` is the total number of in-bounds and out-of-bounds
+         keys that are examined in the process of the index scan. If the
+         index scan consists of a single contiguous range of keys, only
+         in-bounds keys need to be examined. If the index bounds consists of
+         several key ranges, the index scan execution process may examine
+         out-of-bounds keys in order to skip from the end of one range to the
          beginning of the next.
 
-         Consider the following example, where there is an index of field 
-         ``x`` and the collection contains 100 documents with ``x`` values 
-         1 through 100: 
+         Consider the following example, where there is an index of field
+         ``x`` and the collection contains 100 documents with ``x`` values
+         1 through 100:
 
          .. code-block:: javascript
 
             db.keys.find( { x : { $in : [ 3, 4, 50, 74, 75, 90 ] } } ).explain( "executionStats" )
-   
-         The query will scan keys ``3`` and ``4``. It will then scan the key 
-         ``5``, detect that it is out-of-bounds, and skip to the next key 
-         ``50``. 
 
-         Continuing this process, the query scans keys 
-         3, 4, 5, 50, 51, 74, 75, 76, 90, and 91. Keys 
-         ``5``, ``51``, ``76``, and ``91`` are out-of-bounds keys that are 
-         still examined. The value of ``keysExamined`` is 10. 
+         The query will scan keys ``3`` and ``4``. It will then scan the key
+         ``5``, detect that it is out-of-bounds, and skip to the next key
+         ``50``.
+
+         Continuing this process, the query scans keys
+         3, 4, 5, 50, 51, 74, 75, 76, 90, and 91. Keys
+         ``5``, ``51``, ``76``, and ``91`` are out-of-bounds keys that are
+         still examined. The value of ``keysExamined`` is 10.
 
       .. data:: explain.executionStats.executionStages.inputStage.docsExamined
-      
-         Specifies the number of documents scanned during the 
+
+         Specifies the number of documents scanned during the
          query execution stage.
-         
-         Present for the ``COLLSCAN`` stage, as well as for stages that 
+
+         Present for the ``COLLSCAN`` stage, as well as for stages that
          retrieve documents from the collection (e.g. ``FETCH``)
 
    .. data:: explain.executionStats.allPlansExecution
@@ -534,6 +534,6 @@ the result will **not** include a ``SORT`` stage. Otherwise, if MongoDB
 cannot use the index to sort, the ``explain`` result will include a
 ``SORT`` stage.
 
-In previous versions of MongoDB, ``cursor.explain()`` returned the
+Prior to MongoDB 3.0, ``cursor.explain()`` returned the
 ``scanAndOrder`` field to specify whether MongoDB could use the index
 order to return sorted results.


### PR DESCRIPTION
scanAndOrder is not a field in explain() results as of MongoDB 3.0.

Looks like my editor cleaned line-ending whitespace as well. Sorry about that! The actual change is line 537.

Backport to 3.2 and 3.0 manuals.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2941)
<!-- Reviewable:end -->
