### PR TITLE
DOCS-10632: upserted response includes _id not nec. ObjectId

### DIFF
--- a/source/reference/command/findAndModify.txt
+++ b/source/reference/command/findAndModify.txt
@@ -285,7 +285,7 @@ and returns a document with the following fields:
 
 - The ``lastErrorObject`` field that contains the details of the
   command, including the field ``upserted`` that contains the
-  ``ObjectId`` of the newly inserted document, and
+  ``_id`` value of the newly inserted document, and
 
 - The ``value`` field containing ``null``.
 


### PR DESCRIPTION
For master and 3.4, please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2943)
<!-- Reviewable:end -->
