### PR TITLE
Docs 10023 get more with authentication

### DIFF
--- a/source/reference/command/getMore.txt
+++ b/source/reference/command/getMore.txt
@@ -36,4 +36,7 @@ Definition
 
    .. include:: /includes/apiargs/dbcommand-getMore-field.rst
 
+   If :doc:`authentication </core/authentication>` is turned on, you can only issue a :dbcommand:`getMore`
+   against cursors you created.
+
 .. seealso:: :ref:`3.2-driver-compatibility`

--- a/source/reference/command/getMore.txt
+++ b/source/reference/command/getMore.txt
@@ -36,7 +36,9 @@ Definition
 
    .. include:: /includes/apiargs/dbcommand-getMore-field.rst
 
-   If :doc:`authentication </core/authentication>` is turned on, you can only issue a :dbcommand:`getMore`
-   against cursors you created.
+   .. versionadded:: 3.6
+
+   If :doc:`authentication </core/authentication>` is turned on, you can 
+   only issue a :dbcommand:`getMore` against cursors you created.
 
 .. seealso:: :ref:`3.2-driver-compatibility`

--- a/source/release-notes/3.6.txt
+++ b/source/release-notes/3.6.txt
@@ -177,6 +177,7 @@ MongoDB 3.6 includes the following enhancements:
  
   .. note:: FTDC is enabled by default.
 
+
 - If authentication is turned on, you can only issue a :dbcommand:`getMore`
   against cursors you created
 

--- a/source/release-notes/3.6.txt
+++ b/source/release-notes/3.6.txt
@@ -169,7 +169,6 @@ MongoDB 3.6 includes the following enhancements:
   flush all in-memory data to disk, then verify the on-disk data. See
   also :ref:`3.6-validate-compatibility`.
 
-
 - An index can cover a query on fields within nested documents
 
 - Added support for Diagnostics Capture (also known as :term:`FTDC`) in
@@ -177,6 +176,9 @@ MongoDB 3.6 includes the following enhancements:
   :program:`mongod` only. See :ref:`param-ftdc`.
  
   .. note:: FTDC is enabled by default.
+
+- If authentication is turned on, you can only issue a :dbcommand:`getMore`
+  against cursors you created
 
 Changes Affecting Compatibility
 -------------------------------


### PR DESCRIPTION
added documentation to getMore.txt and 3.6.txt to ensure users only call getMore on cursors they created when authentication is on

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2945)
<!-- Reviewable:end -->
