### PR TITLE
DOCS-9867 - Clarifying top command does not work from mongos

### DIFF
--- a/source/reference/command/top.txt
+++ b/source/reference/command/top.txt
@@ -29,10 +29,10 @@ top
 
    .. important::
 
-      You cannot run the :dbcommand:`top` command from a
-      :doc:`mongos </reference/program/mongos>` instance. You must run
-      :dbcommand:`top` from the base
-      :doc:`mongo </reference/program/mongo>` shell.
+      The :dbcommand:`top` command must be run from a
+      :doc:`mongod </reference/program/mongod>` instance. Running
+      :dbcommand:`top` from a :doc:`mongos </reference/program/mongos>`
+      instance will return an error stating there is ``no such command``.
 
    Issue the :dbcommand:`top` command against the :term:`admin
    database` in the form:

--- a/source/reference/command/top.txt
+++ b/source/reference/command/top.txt
@@ -29,10 +29,10 @@ top
 
    .. important::
 
-      The :dbcommand:`top` command must be run from a
+      The :dbcommand:`top` command must be run against a
       :doc:`mongod </reference/program/mongod>` instance. Running
-      :dbcommand:`top` from a :doc:`mongos </reference/program/mongos>`
-      instance will return an error stating there is ``no such command``.
+      :dbcommand:`top` against a :doc:`mongos </reference/program/mongos>`
+      instance will return an error.
 
    Issue the :dbcommand:`top` command against the :term:`admin
    database` in the form:

--- a/source/reference/command/top.txt
+++ b/source/reference/command/top.txt
@@ -27,6 +27,13 @@ top
    - remove
    - commands
 
+   .. important::
+
+      You cannot run the :dbcommand:`top` command from a
+      :doc:`mongos </reference/program/mongos>` instance. You must run
+      :dbcommand:`top` from the base
+      :doc:`mongo </reference/program/mongo>` shell.
+
    Issue the :dbcommand:`top` command against the :term:`admin
    database` in the form:
 


### PR DESCRIPTION
We want to make it clear that you cannot run "top" against a mongos instance, and instead it can only be run against mongod.

Staging: https://docs-mongodbcom-staging.corp.mongodb.com/jeffreyallen/DOCS-9867/reference/command/top.html

Code review: https://mongodbcr.appspot.com/155780001/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2953)
<!-- Reviewable:end -->
