### PR TITLE
DOCS-10113 collMod and planCacheSetFilter use index name

### DIFF
--- a/source/includes/apiargs-dbcommand-planCacheSetFilter-field.yaml
+++ b/source/includes/apiargs-dbcommand-planCacheSetFilter-field.yaml
@@ -51,11 +51,18 @@ type: document
 ---
 arg_name: field
 description: |
-  An array of index specification documents that act as the index
-  filter for the specified :term:`query shape`. Because the
-  :doc:`query optimizer </core/query-plans>` chooses among the
-  collection scan and these indexes, if the indexes are non-existent,
+  An array of index filters for the specified :term:`query shape`.
+
+  Specify the index filters as either: 
+  - an array of index specification documents, e.g. ``[ { x : 1 }, ... ]``
+  - an array of index names, e.g. ``[ "x_1", ... ]``
+
+  Because the :doc:`query optimizer </core/query-plans>` chooses among 
+  the collection scan and these indexes, if the indexes are non-existent,
   the optimizer will choose the collection scan.
+
+  In cases of multiple indexes with the same key pattern, you must 
+  specify the index by name.
 interface: dbcommand
 name: indexes
 operation: planCacheSetFilter

--- a/source/reference/command/collMod.txt
+++ b/source/reference/command/collMod.txt
@@ -49,15 +49,16 @@ TTL Collections
    The :collflag:`index` option changes the expiration time of a
    :doc:`TTL Collection </tutorial/expire-data>`.
 
-   Specify the key and new expiration time with a document of the form:
+   Specify the key or index name, and new expiration time with a document of the form:
 
    .. code-block:: javascript
 
-      {keyPattern: <index_spec>, expireAfterSeconds: <seconds> }
+      {keyPattern: <index_spec> || name: <index_name>, expireAfterSeconds: <seconds> }
 
    In this example, ``<index_spec>`` is an existing index in the
-   collection and ``seconds`` is the number of seconds to subtract
-   from the current time.
+   collection. In cases of multiple indexes with the same key pattern, 
+   the user is required to specify the index by name. ``seconds`` is the number 
+   of seconds to subtract from the current time.
 
    On success :dbcommand:`collMod` returns a document with fields
    ``expireAfterSeconds_old`` and ``expireAfterSeconds_new`` set to


### PR DESCRIPTION
if multiple indexes have same key pattern, you must specify an index name instead of the specification document

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2960)
<!-- Reviewable:end -->
