### PR TITLE
DOCS-10525: Timezones in date aggregation operators

### DIFF
--- a/source/includes/fact-iso-date-objects.rst
+++ b/source/includes/fact-iso-date-objects.rst
@@ -1,5 +1,33 @@
-The argument can be any valid :ref:`expression
-<aggregation-expressions>` that resolves to a
-:doc:`BSON ISODate object </reference/bson-types>`,
-a :doc:`BSON Timestamp object </reference/bson-types>`,
-or a :doc:`Date object </reference/method/Date/>`.
+The argument must be a valid :ref:`expression
+<aggregation-expressions>` that resolves to one of the following:
+
+- A :ref:`Date <document-bson-type-date>` or
+  :ref:`Timestamp <document-bson-type-timestamp>`.
+
+- A document of the following form:
+
+  .. versionadded:: 3.6
+
+  .. code-block:: javascript
+
+     { date: <dateExpression>, timezone: <tzExpression> }
+
+  .. list-table::
+     :header-rows: 1
+     :widths: 25 75
+
+     * - Field
+
+       - Description
+
+     * - ``date``
+
+       - The date to which the operator is applied.
+         ``<dateExpression>`` must be a valid :ref:`expression
+         <aggregation-expressions>` that resolves to either a
+         :ref:`Date <document-bson-type-date>` or a
+         :ref:`Timestamp <document-bson-type-timestamp>`.
+
+     * - ``timezone``
+
+       - .. include:: /includes/fact-timezone-description.rst

--- a/source/includes/fact-timezone-description.rst
+++ b/source/includes/fact-timezone-description.rst
@@ -1,0 +1,30 @@
+``Optional.`` The timezone of the operation result.
+``<tzExpression>`` must be a valid :ref:`expression
+<aggregation-expressions>` that resolves to a string formatted as either
+an `Olson Timezone Identifier
+<https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>`_ or a
+`UTC Offset <https://en.wikipedia.org/wiki/List_of_UTC_time_offsets>`_.
+If no ``timezone`` is provided, the result is displayed in ``UTC/GMT``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: auto
+
+   * - ``Format``
+     - ``Examples``
+
+   * - `Olson Timezone Identifier`
+
+     - ::
+
+         "America/New_York"
+         "Europe/London"
+         "GMT"
+
+   * - `UTC Offset`
+
+     - ::
+
+         +/-[hh]:[mm], e.g. "+04:45"
+         +/-[hh][mm], e.g. "-0530"
+         +/-[hh], e.g. "+03"

--- a/source/reference/operator/aggregation/dateToString.txt
+++ b/source/reference/operator/aggregation/dateToString.txt
@@ -20,11 +20,16 @@ Definition
    Converts a date object to a string according to a user-specified
    format.
 
-   The :expression:`$dateToString` expression has the following syntax:
+   The :expression:`$dateToString` expression has the following
+   :ref:`operator expression syntax <aggregation-expressions>`:
 
    .. code-block:: javascript
 
-      { $dateToString: { format: <formatString>, date: <dateExpression>, timezone: <timezone> } }
+      { $dateToString: {
+          format: <formatString>,
+          date: <dateExpression>,
+          timezone: <tzExpression>
+      } }
 
    The :pipeline:`$dateToString` takes a document with the following fields:
 
@@ -43,34 +48,14 @@ Definition
 
       * - ``date``
 
-        - The date to convert to string. ``<dateExpression>`` can be
-          any :ref:`expression <aggregation-expressions>` that
-          evaluates to a date. For more information on expressions, see
-          :ref:`aggregation-expressions`.
+        - The date to convert to string. ``<dateExpression>`` must be a
+          valid :ref:`expression <aggregation-expressions>` that
+          resolves to either a :ref:`Date <document-bson-type-date>` or
+          a :ref:`Timestamp <document-bson-type-timestamp>`.
 
       * - ``timezone``
 
-        - Optional. The timezone to use to format the date. By default,
-          :pipeline:`$dateToString` uses UTC.
-
-          ``<timezone>`` can be any :ref:`expression
-          <aggregation-expressions>` that evaluates to a string whose
-          value is either:
-
-          - an `Olson Timezone Identifier
-            <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>`_, 
-            such as ``"Europe/London"`` or ``"America/New_York"``, or
-
-          - a UTC offset in the form:
-
-            - ``+/-[hh]:[mm]``, e.g. ``"+04:45"``, or
-
-            - ``+/-[hh][mm]``, e.g. ``"-0530"``, or
-
-            - ``+/-[hh]``, e.g. ``"+03"``.
-
-          For more information on expressions, see
-          :ref:`aggregation-expressions`.
+        - .. include:: /includes/fact-timezone-description.rst
 
 .. _format-specifiers:
 
@@ -184,6 +169,7 @@ Example
 
 Consider a ``sales`` collection with the following document:
 
+.. class:: copyable-code
 .. code-block:: javascript
 
    {
@@ -198,7 +184,6 @@ The following aggregation uses :expression:`$dateToString` to
 return the ``date`` field as formatted strings:
 
 .. cssclass:: copyable-code
-
 .. code-block:: javascript
 
    db.sales.aggregate(

--- a/source/reference/operator/aggregation/dayOfMonth.txt
+++ b/source/reference/operator/aggregation/dayOfMonth.txt
@@ -17,29 +17,101 @@ Definition
 
    Returns the day of the month for a date as a number between 1 and 31.
 
-   The :expression:`$dayOfMonth` expression has the following syntax:
+   The :expression:`$dayOfMonth` expression has the following
+   :ref:`operator expression syntax <aggregation-expressions>`:
 
    .. code-block:: javascript
 
-      { $dayOfMonth: <expression> }
+      { $dayOfMonth: <dateExpression> }
 
-   The argument can be any :ref:`expression
-   <aggregation-expressions>` as long as it resolves to a
-   date. For more information on expressions, see
-   :ref:`aggregation-expressions`.
+   .. include:: /includes/fact-iso-date-objects.rst
+
+Behavior
+--------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 90 10
+
+   * - Example
+     - Result
+
+   * - .. code-block:: javascript
+
+          { $dayOfMonth: new Date("2016-01-01") }
+
+     - 1
+
+   * - .. code-block:: javascript
+
+          { $dayOfMonth: { date: new Date("Jan 7, 2003") } }
+
+     - 7
+
+   * - .. code-block:: javascript
+
+          { $dayOfMonth: {
+              date: new Date("August 14, 2011"),
+              timezone: "America/Chicago"
+          } }
+
+     - 14
+
+   * - .. code-block:: javascript
+
+          { $dayOfMonth: ISODate("1998-11-07T00:00:00Z") }
+
+     - 7
+
+   * - .. code-block:: javascript
+
+          { $dayOfMonth: {
+              date: ISODate("1998-11-07T00:00:00Z"),
+              timezone: "-0400"
+          } }
+
+     - 6
+
+   * - .. code-block:: javascript
+
+          { $dayOfMonth: "March 28, 1976" }
+
+     - ``error``
+
+   * - .. code-block:: javascript
+
+          { $dayOfMonth: Date("2016-01-01") }
+
+     - ``error``
+
+   * - .. code-block:: javascript
+
+          { $dayOfMonth: "2009-04-09" }
+
+     - ``error``
+
+.. note:: ``$dayOfMonth`` cannot take a string as an argument.
 
 Example
 -------
 
 Consider a ``sales`` collection with the following document:
 
+.. class:: copyable-code
 .. code-block:: javascript
 
-   { "_id" : 1, "item" : "abc", "price" : 10, "quantity" : 2, "date" : ISODate("2014-01-01T08:15:39.736Z") }
+   {
+     "_id" : 1,
+     "item" : "abc",
+     "price" : 10,
+     "quantity" : 2,
+     "date" : ISODate("2014-01-01T08:15:39.736Z")
+   }
 
 The following aggregation uses the :expression:`$dayOfMonth` and other
 date operators to break down the ``date`` field:
 
+.. class:: copyable-code
 .. code-block:: javascript
    :emphasize-lines: 8
 

--- a/source/reference/operator/aggregation/dayOfWeek.txt
+++ b/source/reference/operator/aggregation/dayOfWeek.txt
@@ -18,28 +18,101 @@ Definition
    Returns the day of the week for a date as a number between 1
    (Sunday) and 7 (Saturday).
 
-   The :expression:`$dayOfWeek` expression has the following syntax:
+   The :expression:`$dayOfWeek` expression has the following
+   :ref:`operator expression syntax <aggregation-expressions>`:
 
    .. code-block:: javascript
 
-      { $dayOfWeek: <expression> }
+      { $dayOfWeek: <dateExpression> }
 
-   The argument can be any :ref:`expression <aggregation-expressions>`
-   as long as it resolves to a date. For more information on
-   expressions, see :ref:`aggregation-expressions`.
+   .. include:: /includes/fact-iso-date-objects.rst
+
+Behavior
+--------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 90 10
+
+   * - Example
+     - Result
+
+   * - .. code-block:: javascript
+
+          { $dayOfWeek: new Date("2016-01-01") }
+
+     - 6
+
+   * - .. code-block:: javascript
+
+          { $dayOfWeek: { date: new Date("Jan 7, 2003") } }
+
+     - 3
+
+   * - .. code-block:: javascript
+
+          { $dayOfWeek: {
+              date: new Date("August 14, 2011"),
+              timezone: "America/Chicago"
+          } }
+
+     - 1
+
+   * - .. code-block:: javascript
+
+          { $dayOfWeek: ISODate("1998-11-07T00:00:00Z") }
+
+     - 7
+
+   * - .. code-block:: javascript
+
+          { $dayOfWeek: {
+              date: ISODate("1998-11-07T00:00:00Z"),
+              timezone: "-0400"
+          } }
+
+     - 6
+
+   * - .. code-block:: javascript
+
+          { $dayOfWeek: "March 28, 1976" }
+
+     - ``error``
+
+   * - .. code-block:: javascript
+
+          { $dayOfWeek: Date("2016-01-01") }
+
+     - ``error``
+
+   * - .. code-block:: javascript
+
+          { $dayOfWeek: "2009-04-09" }
+
+     - ``error``
+
+.. note:: ``$dayOfWeek`` cannot take a string as an argument.
 
 Example
 -------
 
 Consider a ``sales`` collection with the following document:
 
+.. class:: copyable-code
 .. code-block:: javascript
 
-   { "_id" : 1, "item" : "abc", "price" : 10, "quantity" : 2, "date" : ISODate("2014-01-01T08:15:39.736Z") }
+   {
+     "_id" : 1,
+     "item" : "abc",
+     "price" : 10,
+     "quantity" : 2,
+     "date" : ISODate("2014-01-01T08:15:39.736Z")
+   }
 
 The following aggregation uses the :expression:`$dayOfWeek` and other
 date operators to break down the ``date`` field:
 
+.. class:: copyable-code
 .. code-block:: javascript
    :emphasize-lines: 14
 

--- a/source/reference/operator/aggregation/dayOfYear.txt
+++ b/source/reference/operator/aggregation/dayOfYear.txt
@@ -17,28 +17,101 @@ Definition
 
    Returns the day of the year for a date as a number between 1 and 366.
 
-   The :expression:`$dayOfYear` expression has the following syntax:
+   The :expression:`$dayOfYear` expression has the following
+   :ref:`operator expression syntax <aggregation-expressions>`:
 
    .. code-block:: javascript
 
-      { $dayOfYear: <expression> }
+      { $dayOfYear: <dateExpression> }
 
-   The argument can be any :ref:`expression <aggregation-expressions>`
-   as long as it resolves to a date. For more information on
-   expressions, see :ref:`aggregation-expressions`.
+   .. include:: /includes/fact-iso-date-objects.rst
+
+Behavior
+--------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 90 10
+
+   * - Example
+     - Result
+
+   * - .. code-block:: javascript
+
+          { $dayOfYear: new Date("2016-01-01") }
+
+     - 1
+
+   * - .. code-block:: javascript
+
+          { $dayOfYear: { date: new Date("Jan 7, 2003") } }
+
+     - 7
+
+   * - .. code-block:: javascript
+
+          { $dayOfYear: {
+              date: new Date("August 14, 2011"),
+              timezone: "America/Chicago"
+          } }
+
+     - 226
+
+   * - .. code-block:: javascript
+
+          { $dayOfYear: ISODate("1998-11-07T00:00:00Z") }
+
+     - 311
+
+   * - .. code-block:: javascript
+
+          { $dayOfYear: {
+              date: ISODate("1998-11-07T00:00:00Z"),
+              timezone: "-0400"
+          } }
+
+     - 310
+
+   * - .. code-block:: javascript
+
+          { $dayOfYear: "March 28, 1976" }
+
+     - ``error``
+
+   * - .. code-block:: javascript
+
+          { $dayOfYear: Date("2016-01-01") }
+
+     - ``error``
+
+   * - .. code-block:: javascript
+
+          { $dayOfYear: "2009-04-09" }
+
+     - ``error``
+
+.. note:: ``$dayOfYear`` cannot take a string as an argument.
 
 Example
 -------
 
 Consider a ``sales`` collection with the following document:
 
+.. class:: copyable-code
 .. code-block:: javascript
 
-   { "_id" : 1, "item" : "abc", "price" : 10, "quantity" : 2, "date" : ISODate("2014-01-01T08:15:39.736Z") }
+   {
+     "_id" : 1,
+     "item" : "abc",
+     "price" : 10,
+     "quantity" : 2,
+     "date" : ISODate("2014-01-01T08:15:39.736Z")
+   }
 
 The following aggregation uses the :expression:`$dayOfYear` and other date
 expressions to break down the ``date`` field:
 
+.. class:: copyable-code
 .. code-block:: javascript
    :emphasize-lines: 13
 

--- a/source/reference/operator/aggregation/hour.txt
+++ b/source/reference/operator/aggregation/hour.txt
@@ -17,28 +17,101 @@ Definition
 
    Returns the hour portion of a date as a number between 0 and 23.
 
-   The :expression:`$hour` expression has the following syntax:
+   The :expression:`$hour` expression has the following
+   :ref:`operator expression syntax <aggregation-expressions>`:
 
    .. code-block:: javascript
 
-      { $hour: <expression> }
+      { $hour: <dateExpression> }
 
-   The argument can be any :ref:`expression <aggregation-expressions>`
-   as long as it resolves to a date. For more information on
-   expressions, see :ref:`aggregation-expressions`.
+   .. include:: /includes/fact-iso-date-objects.rst
+
+Behavior
+--------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 90 10
+
+   * - Example
+     - Result
+
+   * - .. code-block:: javascript
+
+          { $hour: new Date("2016-01-01T12:00:00Z") }
+
+     - 12
+
+   * - .. code-block:: javascript
+
+          { $hour: { date: new Date("Jan 7, 2003Z") } }
+
+     - 0
+
+   * - .. code-block:: javascript
+
+          { $hour: {
+              date: new Date("August 14, 2011Z"),
+              timezone: "America/Chicago"
+          } }
+
+     - 18
+
+   * - .. code-block:: javascript
+
+          { $hour: ISODate("2017-10-19T00:00:00Z") }
+
+     - 0
+
+   * - .. code-block:: javascript
+
+          { $hour: {
+              date: ISODate("2017-10-19T00:00:00Z"),
+              timezone: "+0530"
+          } }
+
+     - 5
+
+   * - .. code-block:: javascript
+
+          { $hour: "March 28, 1976" }
+
+     - ``error``
+
+   * - .. code-block:: javascript
+
+          { $hour: Date("2016-01-01") }
+
+     - ``error``
+
+   * - .. code-block:: javascript
+
+          { $hour: "2009-04-09" }
+
+     - ``error``
+
+.. note:: ``$hour`` cannot take a string as an argument.
 
 Example
 -------
 
 Consider a ``sales`` collection with the following document:
 
+.. class:: copyable-code
 .. code-block:: javascript
 
-   { "_id" : 1, "item" : "abc", "price" : 10, "quantity" : 2, "date" : ISODate("2014-01-01T08:15:39.736Z") }
+   {
+     "_id" : 1,
+     "item" : "abc",
+     "price" : 10,
+     "quantity" : 2,
+     "date" : ISODate("2014-01-01T08:15:39.736Z")
+   }
 
 The following aggregation uses the :expression:`$hour` and other date
 expressions to break down the ``date`` field:
 
+.. class:: copyable-code
 .. code-block:: javascript
    :emphasize-lines: 9
 

--- a/source/reference/operator/aggregation/isoDayOfWeek.txt
+++ b/source/reference/operator/aggregation/isoDayOfWeek.txt
@@ -20,12 +20,12 @@ Definition
    Returns the weekday number in ISO 8601 format, ranging from
    ``1`` (for Monday) to ``7`` (for Sunday).
 
-   :expression:`$isoDayOfWeek` has the following
+   The :expression:`$isoDayOfWeek` expression has the following
    :ref:`operator expression syntax <aggregation-expressions>`:
 
    .. code-block:: javascript
 
-      { $isoDayOfWeek: <date expression> }
+      { $isoDayOfWeek: <dateExpression> }
 
    .. include:: /includes/fact-iso-date-objects.rst
 
@@ -39,27 +39,57 @@ Behavior
    * - Example
      - Result
 
-   * - ``{ $isoDayOfWeek: new Date("2016-01-01") }``
+   * - .. code-block:: javascript
+
+          { $isoDayOfWeek: new Date("2016-01-01") }
 
      - 5
 
-   * - ``{ $isoDayOfWeek: new Date("Jan 7, 2003") }``
+   * - .. code-block:: javascript
+
+          { $isoDayOfWeek: { date: new Date("Jan 7, 2003") } }
 
      - 2
 
-   * - ``{ $isoDayOfWeek: new Date("August 14, 2011") }``
+   * - .. code-block:: javascript
+
+          { $isoDayOfWeek: {
+              date: new Date("August 14, 2011"),
+              timezone: "America/Chicago"
+          } }
 
      - 7
 
-   * - ``{ $isoDayOfWeek: ISODate("1998-11-07T00:00:00Z") }``
+   * - .. code-block:: javascript
+
+          { $isoDayOfWeek: ISODate("1998-11-07T00:00:00Z") }
 
      - 6
 
-   * - ``{ $isoDayOfWeek: "March 28, 1976" }``
+   * - .. code-block:: javascript
+
+          { $isoDayOfWeek: {
+              date: ISODate("1998-11-07T00:00:00Z"),
+              timezone: "-0400"
+          } }
+
+     - 5
+
+   * - .. code-block:: javascript
+
+          { $isoDayOfWeek: "March 28, 1976" }
 
      - ``error``
 
-   * - ``{ $isoDayOfWeek: "2009-04-09" }``
+   * - .. code-block:: javascript
+
+          { $isoDayOfWeek: Date("2016-01-01") }
+
+     - ``error``
+
+   * - .. code-block:: javascript
+
+          { $isoDayOfWeek: "2009-04-09" }
 
      - ``error``
 
@@ -70,6 +100,7 @@ Example
 
 A collection called ``birthdays`` contains the following documents:
 
+.. class:: copyable-code
 .. code-block:: javascript
 
    { "_id" : 1, "name" : "Betty", "birthday" : ISODate("1993-09-21T00:00:00Z") }
@@ -78,6 +109,7 @@ A collection called ``birthdays`` contains the following documents:
 The following operation returns the weekday number for each
 ``birthday`` field.
 
+.. class:: copyable-code
 .. code-block:: javascript
 
    db.dates.aggregate( [

--- a/source/reference/operator/aggregation/isoWeek.txt
+++ b/source/reference/operator/aggregation/isoWeek.txt
@@ -21,12 +21,12 @@ Definition
    ``53``. Week numbers start at ``1`` with the week (Monday through
    Sunday) that contains the year's first Thursday.
 
-   $isoWeek has the following
+   The :expression:`$isoWeek` expression has the following
    :ref:`operator expression syntax <aggregation-expressions>`:
 
    .. code-block:: javascript
 
-      { $isoWeek: <date expression> }
+      { $isoWeek: <dateExpression> }
 
    .. include:: /includes/fact-iso-date-objects.rst
 
@@ -40,27 +40,57 @@ Behavior
    * - Example
      - Result
 
-   * - ``{ $isoWeek: new Date("2016-01-01") }``
+   * - .. code-block:: javascript
 
-     - 53
-
-   * - ``{ $isoWeek: new Date("2015-01-01") }``
+          { $isoWeek: { date: new Date("Jan 4, 2016") } }
 
      - 1
 
-   * - ``{ $isoWeek: new Date("August 14, 2011") }``
+   * - .. code-block:: javascript
+
+          { $isoWeek: new Date("2016-01-01") }
+
+     - 53
+
+   * - .. code-block:: javascript
+
+          { $isoWeek: {
+              date: new Date("August 14, 2011"),
+              timezone: "America/Chicago"
+          } }
 
      - 32
 
-   * - ``{ $isoWeek: ISODate("1998-11-07T00:00:00Z") }``
+   * - .. code-block:: javascript
+
+          { $isoWeek: ISODate("1998-11-02T00:00:00Z") }
 
      - 45
 
-   * - ``{ $isoWeek: "March 28, 1976" }``
+   * - .. code-block:: javascript
+
+          { $isoWeek: {
+              date: ISODate("1998-11-02T00:00:00Z"),
+              timezone: "-0500"
+          } }
+
+     - 44
+
+   * - .. code-block:: javascript
+
+          { $isoWeek: "March 28, 1976" }
 
      - ``error``
 
-   * - ``{ $isoWeek: "2009-04-09" }``
+   * - .. code-block:: javascript
+
+          { $isoWeek: Date("2016-01-01") }
+
+     - ``error``
+
+   * - .. code-block:: javascript
+
+          { $isoWeek: "2009-04-09" }
 
      - ``error``
 
@@ -71,6 +101,7 @@ Example
 
 A collection called ``deliveries`` contains the following documents:
 
+.. class:: copyable-code
 .. code-block:: javascript
 
    { "_id" : 1, "date" : ISODate("2006-10-24T00:00:00Z"), "city" : "Boston" }
@@ -78,6 +109,7 @@ A collection called ``deliveries`` contains the following documents:
 
 The following operation returns the week number for each ``date`` field.
 
+.. class:: copyable-code
 .. code-block:: javascript
 
    db.deliveries.aggregate( [

--- a/source/reference/operator/aggregation/isoWeekYear.txt
+++ b/source/reference/operator/aggregation/isoWeekYear.txt
@@ -18,15 +18,15 @@ Definition
    .. versionadded:: 3.4
 
    Returns the year number in ISO 8601 format. The year starts
-   with the Monday of week 1 (ISO 8601) and ends with the Sunday of the
-   last week (ISO 8601).
+   with the Monday of week 1 and ends with the Sunday of the
+   last week.
 
-   $isoWeekYear has the following
+   The :expression:`$isoWeekYear` expression has the following
    :ref:`operator expression syntax <aggregation-expressions>`:
 
    .. code-block:: javascript
 
-      { $isoWeekYear: <date expression> }
+      { $isoWeekYear: <dateExpression> }
 
    .. include:: /includes/fact-iso-date-objects.rst
 
@@ -40,19 +40,57 @@ Behavior
    * - Example
      - Result
 
-   * - ``{ $isoWeekYear: new Date("2016-01-01") }``
+   * - .. code-block:: javascript
+
+          { $isoWeekYear: new Date("2015-05-26") }
 
      - 2015
 
-   * - ``{ $isoWeekYear: new Date("2015-01-01") }``
+   * - .. code-block:: javascript
 
-     - 2015
+          { $isoWeekYear: { date: new Date("Jan 7, 2003") } }
 
-   * - ``{ $isoWeekYear: new Date("2016-01-04") }``
+     - 2003
+
+   * - .. code-block:: javascript
+
+          { $isoWeekYear: ISODate("2017-01-02T00:00:00Z") }
+
+     - 2017
+
+   * - .. code-block:: javascript
+
+          { $isoWeekYear: {
+              date: ISODate("2017-01-02T00:00:00Z"),
+              timezone: "-0500"
+          } }
 
      - 2016
 
-   * - ``{ $isoWeekYear: "2016-01-01" }``
+   * - .. code-block:: javascript
+
+          { $isoWeekYear: {
+              date: new Date("April 08, 2024"),
+              timezone: "America/Chicago"
+          } }
+
+     - 2024
+
+   * - .. code-block:: javascript
+
+          { $isoWeekYear: "March 28, 1976" }
+
+     - ``error``
+
+   * - .. code-block:: javascript
+
+          { $isoWeekYear: Date("2016-01-01") }
+
+     - ``error``
+
+   * - .. code-block:: javascript
+
+          { $isoWeekYear: "2009-04-09" }
 
      - ``error``
 
@@ -63,6 +101,7 @@ Example
 
 A collection called ``anniversaries`` contains the following documents:
 
+.. class:: copyable-code
 .. code-block:: javascript
 
    { "_id" : 1, "date" : ISODate("2016-01-01T00:00:00Z") }
@@ -73,6 +112,7 @@ A collection called ``anniversaries`` contains the following documents:
 The following operation returns the year number in ISO 8601
 format for each ``date`` field.
 
+.. class:: copyable-code
 .. code-block:: javascript
 
    db.anniversaries.aggregate( [

--- a/source/reference/operator/aggregation/millisecond.txt
+++ b/source/reference/operator/aggregation/millisecond.txt
@@ -18,28 +18,101 @@ Definition
    Returns the millisecond portion of a date as an integer between 0
    and 999.
 
-   The :expression:`$millisecond` expression has the following syntax:
+   The :expression:`$millisecond` expression has the following
+   :ref:`operator expression syntax <aggregation-expressions>`:
 
    .. code-block:: javascript
 
-      { $millisecond: <expression> }
+      { $millisecond: <dateExpression> }
 
-   The argument can be any :ref:`expression <aggregation-expressions>`
-   as long as it resolves to a date. For more information on
-   expressions, see :ref:`aggregation-expressions`.
+   .. include:: /includes/fact-iso-date-objects.rst
+
+Behavior
+--------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 90 10
+
+   * - Example
+     - Result
+
+   * - .. code-block:: javascript
+
+          { $millisecond: new Date("2016-01-01") }
+
+     - 0
+
+   * - .. code-block:: javascript
+
+          { $millisecond: { date: new Date("Jan 7, 2003") } }
+
+     - 0
+
+   * - .. code-block:: javascript
+
+          { $millisecond: {
+              date: new Date("August 14, 2011"),
+              timezone: "America/Chicago"
+          } }
+
+     - 0
+
+   * - .. code-block:: javascript
+
+          { $millisecond: ISODate("1998-11-07T00:00:00Z") }
+
+     - 0
+
+   * - .. code-block:: javascript
+
+          { $millisecond: {
+              date: ISODate("1998-11-07T00:00:00Z"),
+              timezone: "-0400"
+          } }
+
+     - 0
+
+   * - .. code-block:: javascript
+
+          { $millisecond: "March 28, 1976" }
+
+     - ``error``
+
+   * - .. code-block:: javascript
+
+          { $millisecond: Date("2016-01-01") }
+
+     - ``error``
+
+   * - .. code-block:: javascript
+
+          { $millisecond: "2009-04-09" }
+
+     - ``error``
+
+.. note:: ``$millisecond`` cannot take a string as an argument.
 
 Example
 -------
 
 Consider a ``sales`` collection with the following document:
 
+.. class:: copyable-code
 .. code-block:: javascript
 
-   { "_id" : 1, "item" : "abc", "price" : 10, "quantity" : 2, "date" : ISODate("2014-01-01T08:15:39.736Z") }
+   {
+     "_id" : 1,
+     "item" : "abc",
+     "price" : 10,
+     "quantity" : 2,
+     "date" : ISODate("2014-01-01T08:15:39.736Z")
+   }
 
 The following aggregation uses the :expression:`$millisecond` and other
 date operators to break down the ``date`` field:
 
+.. class:: copyable-code
 .. code-block:: javascript
    :emphasize-lines: 12
 

--- a/source/reference/operator/aggregation/minute.txt
+++ b/source/reference/operator/aggregation/minute.txt
@@ -17,28 +17,95 @@ Definition
 
    Returns the minute portion of a date as a number between 0 and 59.
 
-   The :expression:`$minute` expression has the following syntax:
+   The :expression:`$minute` expression has the following
+   :ref:`operator expression syntax <aggregation-expressions>`:
 
    .. code-block:: javascript
 
-      { $minute: <expression> }
+      { $minute: <dateExpression> }
 
-   The argument can be any :ref:`expression <aggregation-expressions>`
-   as long as it resolves to a date. For more information on
-   expressions, see :ref:`aggregation-expressions`.
+   .. include:: /includes/fact-iso-date-objects.rst
+
+Behavior
+--------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 90 10
+
+   * - Example
+     - Result
+
+   * - .. code-block:: javascript
+
+          { $minute: new Date("2016-01-01T12:01:00Z") }
+
+     - 1
+
+   * - .. code-block:: javascript
+
+          { $minute: { date: new Date("Jan 7, 2003") } }
+
+     - 0
+
+   * - .. code-block:: javascript
+
+          { $minute: {
+              date: new Date("2016-01-01T12:01:00Z"),
+              timezone: "Canada/Newfoundland"
+          } }
+
+     - 31
+
+   * - .. code-block:: javascript
+
+          { $minute: {
+              date: ISODate("1998-11-07T00:40:00Z"),
+              timezone: "+0530"
+          } }
+
+     - 10
+
+   * - .. code-block:: javascript
+
+          { $minute: "March 28, 1976" }
+
+     - ``error``
+
+   * - .. code-block:: javascript
+
+          { $minute: Date("2016-01-01") }
+
+     - ``error``
+
+   * - .. code-block:: javascript
+
+          { $minute: "2009-04-09" }
+
+     - ``error``
+
+.. note:: ``$minute`` cannot take a string as an argument.
 
 Example
 -------
 
 Consider a ``sales`` collection with the following document:
 
+.. class:: copyable-code
 .. code-block:: javascript
 
-   { "_id" : 1, "item" : "abc", "price" : 10, "quantity" : 2, "date" : ISODate("2014-01-01T08:15:39.736Z") }
+   {
+     "_id" : 1,
+     "item" : "abc",
+     "price" : 10,
+     "quantity" : 2,
+     "date" : ISODate("2014-01-01T08:15:39.736Z")
+   }
 
 The following aggregation uses the :expression:`$minute` and other date
 expressions to break down the ``date`` field:
 
+.. class:: copyable-code
 .. code-block:: javascript
    :emphasize-lines: 10
 

--- a/source/reference/operator/aggregation/month.txt
+++ b/source/reference/operator/aggregation/month.txt
@@ -17,28 +17,105 @@ Definition
 
    Returns the month of a date as a number between 1 and 12.
 
-   The :expression:`$month` expression has the following syntax:
+   The :expression:`$month` expression has the following
+   :ref:`operator expression syntax <aggregation-expressions>`:
 
    .. code-block:: javascript
 
-      { $month: <expression> }
+      { $month: <dateExpression> }
 
-   The argument can be any :ref:`expression <aggregation-expressions>`
-   as long as it resolves to a date. For more information on
-   expressions, see :ref:`aggregation-expressions`.
+   .. include:: /includes/fact-iso-date-objects.rst
+
+Behavior
+--------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 90 10
+
+   * - Example
+     - Result
+
+   * - .. code-block:: javascript
+
+          { $month: new Date("2016-01-01") }
+
+     - 1
+
+   * - .. code-block:: javascript
+
+          { $month: { date: new Date("Nov 7, 2003") } }
+
+     - 11
+
+   * - .. code-block:: javascript
+
+          { $month: ISODate("2000-01-01T00:00:00Z") }
+
+     - 1
+
+   * - .. code-block:: javascript
+
+          { $month: {
+              date: new Date("August 14, 2011"),
+              timezone: "America/Chicago"
+          } }
+
+     - 8
+
+
+   * - .. code-block:: javascript
+
+          { $month: {
+              date: ISODate("2000-01-01T00:00:00Z"),
+              timezone: "-0500"
+          } }
+
+     - 12
+
+   * - .. code-block:: javascript
+
+          { $month: "March 28, 1976" }
+
+     - ``error``
+
+   * - .. code-block:: javascript
+
+          { $month: {
+              date: Date("2016-01-01"),
+              timezone: "-0500"
+          } }
+
+     - ``error``
+
+   * - .. code-block:: javascript
+
+          { $month: "2009-04-09" }
+
+     - ``error``
+
+.. note:: ``$month`` cannot take a string as an argument.
 
 Example
 -------
 
 Consider a ``sales`` collection with the following document:
 
+.. class:: copyable-code
 .. code-block:: javascript
 
-   { "_id" : 1, "item" : "abc", "price" : 10, "quantity" : 2, "date" : ISODate("2014-01-01T08:15:39.736Z") }
+   {
+     "_id" : 1,
+     "item" : "abc",
+     "price" : 10,
+     "quantity" : 2,
+     "date" : ISODate("2014-01-01T08:15:39.736Z")
+   }
 
 The following aggregation uses the :expression:`$month` and other
 date operators to break down the ``date`` field:
 
+.. class:: copyable-code
 .. code-block:: javascript
    :emphasize-lines: 7
 

--- a/source/reference/operator/aggregation/second.txt
+++ b/source/reference/operator/aggregation/second.txt
@@ -18,28 +18,101 @@ Definition
    Returns the second portion of a date as a number between 0 and 59,
    but can be 60 to account for leap seconds.
 
-   The :expression:`$second` expression has the following syntax:
+   The :expression:`$second` expression has the following
+   :ref:`operator expression syntax <aggregation-expressions>`:
 
    .. code-block:: javascript
 
-      { $second: <expression> }
+      { $second: <dateExpression> }
 
-   The argument can be any valid :ref:`expression
-   <aggregation-expressions>` as long as it resolves to a date. For
-   more information on expressions, see :ref:`aggregation-expressions`.
+   .. include:: /includes/fact-iso-date-objects.rst
+
+Behavior
+--------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 90 10
+
+   * - Example
+     - Result
+
+   * - .. code-block:: javascript
+
+          { $second: new Date("2012-11-06T00:14:20") }
+
+     - 20
+
+   * - .. code-block:: javascript
+
+          { $second: { date: new Date("Jan 7, 2003") } }
+
+     - 0
+
+   * - .. code-block:: javascript
+
+          { $second: {
+              date: new Date("August 14, 2011"),
+              timezone: "America/Chicago"
+          } }
+
+     - 0
+
+   * - .. code-block:: javascript
+
+          { $second: ISODate("1998-11-07T00:00:42Z") }
+
+     - 42
+
+   * - .. code-block:: javascript
+
+          { $second: {
+              date: ISODate("1998-11-07T00:00:09Z"),
+              timezone: "+0530"
+          } }
+
+     - 9
+
+   * - .. code-block:: javascript
+
+          { $second: "March 28, 1976" }
+
+     - ``error``
+
+   * - .. code-block:: javascript
+
+          { $second: Date("2016-01-01") }
+
+     - ``error``
+
+   * - .. code-block:: javascript
+
+          { $second: "2009-04-09" }
+
+     - ``error``
+
+.. note:: ``$second`` cannot take a string as an argument.
 
 Example
 -------
 
 Consider a ``sales`` collection with the following document:
 
+.. class:: copyable-code
 .. code-block:: javascript
 
-   { "_id" : 1, "item" : "abc", "price" : 10, "quantity" : 2, "date" : ISODate("2014-01-01T08:15:39.736Z") }
+   {
+     "_id" : 1,
+     "item" : "abc",
+     "price" : 10,
+     "quantity" : 2,
+     "date" : ISODate("2014-01-01T08:15:39.736Z")
+   }
 
 The following aggregation uses the :expression:`$second` and other date
 expressions to break down the ``date`` field:
 
+.. class:: copyable-code
 .. code-block:: javascript
    :emphasize-lines: 11
 

--- a/source/reference/operator/aggregation/week.txt
+++ b/source/reference/operator/aggregation/week.txt
@@ -22,28 +22,101 @@ Definition
    week 0. This behavior is the same as the "``%U``" operator to the
    ``strftime`` standard library function.
 
-   The :expression:`$week` expression has the following syntax:
+   The :expression:`$week` expression has the following
+   :ref:`operator expression syntax <aggregation-expressions>`:
 
    .. code-block:: javascript
 
-      { $week: <expression> }
+      { $week: <dateExpression> }
 
-   The argument can be any valid :ref:`expression
-   <aggregation-expressions>` as long as it resolves to a date. For
-   more information on expressions, see :ref:`aggregation-expressions`.
+   .. include:: /includes/fact-iso-date-objects.rst
+
+Behavior
+--------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 90 10
+
+   * - Example
+     - Result
+
+   * - .. code-block:: javascript
+
+          { $week: new Date("Jan 1, 2016") }
+
+     - 0
+
+   * - .. code-block:: javascript
+
+          { $week: { date: new Date("2016-01-04") } }
+
+     - 1
+
+   * - .. code-block:: javascript
+
+          { $week: {
+              date: new Date("August 14, 2011"),
+              timezone: "America/Chicago"
+          } }
+
+     - 33
+
+   * - .. code-block:: javascript
+
+          { $week: ISODate("1998-11-01T00:00:00Z") }
+
+     - 44
+
+   * - .. code-block:: javascript
+
+          { $week: {
+              date: ISODate("1998-11-01T00:00:00Z"),
+              timezone: "-0500"
+          } }
+
+     - 43
+
+   * - .. code-block:: javascript
+
+          { $week: "March 28, 1976" }
+
+     - ``error``
+
+   * - .. code-block:: javascript
+
+          { $week: Date("2016-01-01") }
+
+     - ``error``
+
+   * - .. code-block:: javascript
+
+          { $week: "2009-04-09" }
+
+     - ``error``
+
+.. note:: ``$week`` cannot take a string as an argument.
 
 Example
 -------
 
 Consider a ``sales`` collection with the following document:
 
+.. class:: copyable-code
 .. code-block:: javascript
 
-   { "_id" : 1, "item" : "abc", "price" : 10, "quantity" : 2, "date" : ISODate("2014-01-01T08:15:39.736Z") }
+   {
+     "_id" : 1,
+     "item" : "abc",
+     "price" : 10,
+     "quantity" : 2,
+     "date" : ISODate("2014-01-01T08:15:39.736Z")
+   }
 
 The following aggregation uses the :expression:`$week` and other
 date operators to break down the ``date`` field:
 
+.. class:: copyable-code
 .. code-block:: javascript
    :emphasize-lines: 15
 

--- a/source/reference/operator/aggregation/year.txt
+++ b/source/reference/operator/aggregation/year.txt
@@ -17,28 +17,101 @@ Definition
 
    Returns the year portion of a date.
 
-   The :expression:`$year` expression has the following syntax:
+   The :expression:`$year` expression has the following
+   :ref:`operator expression syntax <aggregation-expressions>`:
 
    .. code-block:: javascript
 
-      { $year: <expression> }
+      { $year: <dateExpression> }
 
-   The argument can be any :ref:`expression <aggregation-expressions>`
-   as long as it resolves to a date. For more information on
-   expressions, see :ref:`aggregation-expressions`.
+   .. include:: /includes/fact-iso-date-objects.rst
+
+Behavior
+--------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 90 10
+
+   * - Example
+     - Result
+
+   * - .. code-block:: javascript
+
+          { $year: new Date("2016-01-01") }
+
+     - 2016
+
+   * - .. code-block:: javascript
+
+          { $year: { date: new Date("Jan 7, 2003") } }
+
+     - 2003
+
+   * - .. code-block:: javascript
+
+          { $year: {
+              date: new Date("August 14, 2011"),
+              timezone: "America/Chicago"
+          } }
+
+     - 2011
+
+   * - .. code-block:: javascript
+
+          { $year: ISODate("1998-11-07T00:00:00Z") }
+
+     - 1998
+
+   * - .. code-block:: javascript
+
+          { $year: {
+              date: ISODate("1998-11-07T00:00:00Z"),
+              timezone: "-0400"
+          } }
+
+     - 1998
+
+   * - .. code-block:: javascript
+
+          { $year: "March 28, 1976" }
+
+     - ``error``
+
+   * - .. code-block:: javascript
+
+          { $year: Date("2016-01-01") }
+
+     - ``error``
+
+   * - .. code-block:: javascript
+
+          { $year: "2009-04-09" }
+
+     - ``error``
+
+.. note:: ``$year`` cannot take a string as an argument.
 
 Example
 -------
 
 Consider a ``sales`` collection with the following documents:
 
+.. class:: copyable-code
 .. code-block:: javascript
 
-   { "_id" : 1, "item" : "abc", "price" : 10, "quantity" : 2, "date" : ISODate("2014-01-01T08:15:39.736Z") }
+   {
+     "_id" : 1,
+     "item" : "abc",
+     "price" : 10,
+     "quantity" : 2,
+     "date" : ISODate("2014-01-01T08:15:39.736Z")
+   }
 
 The following aggregation uses the :expression:`$year` and other
 date operators to break down the ``date`` field:
 
+.. class:: copyable-code
 .. code-block:: javascript
    :emphasize-lines: 6
 


### PR DESCRIPTION
[**Jira Ticket**](https://jira.mongodb.org/browse/DOCS-10525)
[**Staged Changes**](https://docs-mongodbcom-staging.corp.mongodb.com/nick/DOCS-10525/reference/operator/aggregation-date.html)
[**Code Review**](https://mongodbcr.appspot.com/160310001/)

Adds documentation for timezone conversion on date aggregation operators.
All new behavior examples have been tested on v3.5.12 and are confirmed to be accurate.

NOTE: This only covers existing timezone operators. The new date operators for 3.6 are being documented in [DOCS-10475](https://jira.mongodb.org/browse/DOCS-10475) and may require a quick pass for consistency with these changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2961)
<!-- Reviewable:end -->
