### PR TITLE
Docs 10475 - New agg operators dateToParts and dateFromParts

### DIFF
--- a/source/includes/fact-olson-tz-behavior.rst
+++ b/source/includes/fact-olson-tz-behavior.rst
@@ -1,0 +1,58 @@
+When using an Olson Timezone Identifier in the ``<timezone>``
+field, MongoDB applies the :abbr:`DST (Daylight Savings Time)` offset
+if applicable for the specified timezone.
+
+For example, consider a ``sales`` collection with the following document:
+
+.. code-block:: javascript
+
+   {
+      "_id" : 1,
+      "item" : "abc",
+      "price" : 20,
+      "quantity" : 5,
+      "date" : ISODate("2017-05-20T10:24:51.303Z")
+   }
+
+The following aggregation illustrates how MongoDB handles the DST
+offset for the Olson Timezone Identifier:
+
+.. cssclass:: copyable-code
+.. code-block:: javascript
+
+   db.sales.aggregate([
+   {
+      $project: { 
+         "nycHour": { 
+            $hour: { date: "$date", timezone: "-05:00" }
+          }, 
+          "nycMinute": { 
+             $minute: { date: "$date", timezone: "-05:00" }
+          },
+          "gmtHour": {
+             $hour: { date: "$date", timezone: "GMT" }
+          },
+          "gmtMinute": {
+             $minute: { date: "$date", timezone: "GMT" } },
+          "nycOlsonHour": {
+             $hour: { date: "$date", timezone: "America/New_York" }
+          },
+          "nycOlsonMinute": {
+             $minute: { date: "$date", timezone: "America/New_York" }
+          }
+      }
+   }])
+
+The operation returns the following result:
+
+.. code-block:: javascript
+
+   {
+      "_id": 1,
+      "nycHour" : 5,
+      "nycMinute" : 24,
+      "gmtHour" : 10,
+      "gmtMinute" : 24,
+      "nycOlsonHour" : 6,
+      "nycOlsonMinute" : 24
+   }

--- a/source/includes/fact-olson-tz-behavior.rst
+++ b/source/includes/fact-olson-tz-behavior.rst
@@ -15,7 +15,9 @@ For example, consider a ``sales`` collection with the following document:
    }
 
 The following aggregation illustrates how MongoDB handles the DST
-offset for the Olson Timezone Identifier:
+offset for the Olson Timezone Identifier. The example uses the
+:expression:`$hour` and :expression:`$minute` operators to return the
+corresponding portions of the ``date`` field:
 
 .. cssclass:: copyable-code
 .. code-block:: javascript

--- a/source/includes/ref-toc-aggregation-date.yaml
+++ b/source/includes/ref-toc-aggregation-date.yaml
@@ -59,17 +59,16 @@ file: /reference/operator/aggregation/dateToString
 description: |
   Returns the date as a formatted string.
 ---
-name: :expression:`$dateToParts`
-file: /reference/operator/aggregation/dateToParts
-description: |
-  Returns a document containing the constituent parts of a date as
-  individual object properties.
----
 name: :expression:`$dateFromParts`
 file: /reference/operator/aggregation/dateFromParts
 description: |
-  Constructs and returns a date object in ISO format given the date's
-  constituent properties.
+  Constructs a BSON Date object given the date's constituent
+  parts.
+---
+name: :expression:`$dateToParts`
+file: /reference/operator/aggregation/dateToParts
+description: |
+  Returns a document containing the constituent parts of a date.
 ---
 name: :expression:`$isoDayOfWeek`
 file: /reference/operator/aggregation/isoDayOfWeek

--- a/source/includes/ref-toc-aggregation-date.yaml
+++ b/source/includes/ref-toc-aggregation-date.yaml
@@ -59,6 +59,18 @@ file: /reference/operator/aggregation/dateToString
 description: |
   Returns the date as a formatted string.
 ---
+name: :expression:`$dateToParts`
+file: /reference/operator/aggregation/dateToParts
+description: |
+  Returns the constituent parts of a date as individual object 
+  properties.
+---
+name: :expression:`$dateFromParts`
+file: /reference/operator/aggregation/dateFromParts
+description: |
+  Constructs and returns a date object in ISO format given the date's
+  constituent properties.
+---
 name: :expression:`$isoDayOfWeek`
 file: /reference/operator/aggregation/isoDayOfWeek
 description: |

--- a/source/includes/ref-toc-aggregation-date.yaml
+++ b/source/includes/ref-toc-aggregation-date.yaml
@@ -62,8 +62,8 @@ description: |
 name: :expression:`$dateToParts`
 file: /reference/operator/aggregation/dateToParts
 description: |
-  Returns the constituent parts of a date as individual object 
-  properties.
+  Returns a document containing the constituent parts of a date as
+  individual object properties.
 ---
 name: :expression:`$dateFromParts`
 file: /reference/operator/aggregation/dateFromParts

--- a/source/includes/ref-toc-aggregation-operators.yaml
+++ b/source/includes/ref-toc-aggregation-operators.yaml
@@ -95,8 +95,8 @@ description: |
 name: :expression:`$dateToParts`
 file: /reference/operator/aggregation/dateToParts
 description: |
-  Returns the constituent parts of a date as individual object 
-  properties.
+  Returns a document containing the constituent parts of a date as
+  individual object properties.
 ---
 name: :expression:`$dateFromString`
 file: /reference/operator/aggregation/dateFromString

--- a/source/includes/ref-toc-aggregation-operators.yaml
+++ b/source/includes/ref-toc-aggregation-operators.yaml
@@ -89,14 +89,13 @@ description: |
 name: :expression:`$dateFromParts`
 file: /reference/operator/aggregation/dateFromParts
 description: |
-  Constructs and returns a date in ISO 8601 format given the date's
-  constituent properties.
+  Constructs a BSON Date object given the date's constituent
+  parts.
 ---
 name: :expression:`$dateToParts`
 file: /reference/operator/aggregation/dateToParts
 description: |
-  Returns a document containing the constituent parts of a date as
-  individual object properties.
+  Returns a document containing the constituent parts of a date.
 ---
 name: :expression:`$dateFromString`
 file: /reference/operator/aggregation/dateFromString

--- a/source/includes/ref-toc-aggregation-operators.yaml
+++ b/source/includes/ref-toc-aggregation-operators.yaml
@@ -86,6 +86,18 @@ description: |
   Accepts either three expressions in an ordered list or three named
   parameters.
 ---
+name: :expression:`$dateFromParts`
+file: /reference/operator/aggregation/dateFromParts
+description: |
+  Constructs and returns a date in ISO 8601 format given the date's
+  constituent properties.
+---
+name: :expression:`$dateToParts`
+file: /reference/operator/aggregation/dateToParts
+description: |
+  Returns the constituent parts of a date as individual object 
+  properties.
+---
 name: :expression:`$dateFromString`
 file: /reference/operator/aggregation/dateFromString
 description: |

--- a/source/reference/operator/aggregation/dateFromParts.txt
+++ b/source/reference/operator/aggregation/dateFromParts.txt
@@ -17,8 +17,8 @@ Definition
 
    .. versionadded:: 3.6
 
-   Constructs and returns a date object in ISO format given the date's
-   constituent properties.
+   Constructs and returns a Date object given the date's constituent
+   properties.
    
    The :expression:`$dateFromParts` expression has the following syntax:
    
@@ -32,8 +32,9 @@ Definition
           }
       }
 
-   You can also specify your constituent date fields in ISO format using
-   the following syntax:
+   You can also specify your constituent date fields in
+   `ISO week date <https://en.wikipedia.org/wiki/ISO_week_date>`_
+   format using the following syntax:
    
    .. code-block:: javascript
    
@@ -58,53 +59,53 @@ Definition
 
       * - ``year``
         - Required if not using ``isoYear``
-        - Year (4 digits, zero padded)
-        - ``0000``-``9999``
+        - Calendar year.
+        - ``0``-``9999``
 
       * - ``isoYear``
         - Required if not using ``year``
-        - Year in ISO 8601 format
-        - ``0000``-``9999``
+        - ISO Week Date Year.
+        - ``0``-``9999``
 		
       * - ``month``
         - Optional
-        - Month (2 digits, zero padded). Defaults to ``01``.
-        - ``01``-``12``
+        - Month. Defaults to ``1``.
+        - ``1``-``12``
 		
       * - ``isoWeekYear``
         - Optional
-        - Week of year (2 digits, zero padded). Defaults to ``01``.
-        - ``01``-``53``
+        - Week of year. Defaults to ``1``.
+        - ``1``-``53``
 
       * - ``day``
         - Optional
-        - Day of month (2 digits, zero padded) Defaults to ``01``.
-        - ``01``-``31``
+        - Day of month. Defaults to ``1``.
+        - ``1``-``31``
 
       * - ``isoDayOfWeek``
         - Optional
-        - Day of week (1-Sunday, 7-Saturday). Defaults to ``1``.
+        - Day of week (Monday ``1`` - Sunday ``7``). Defaults to ``1``.
         - ``1``-``7``
 
       * - ``hour``
         - Optional
-        - Hour (2 digits, zero padded, 24-hour clock). Defaults to ``00``.
-        - ``00``-``23``
+        - Hour. Defaults to ``0``.
+        - ``0``-``23``
 
       * - ``minute``
         - Optional
-        - Minute (2 digits, zero padded). Defaults to ``00``.
-        - ``00``-``59``
+        - Minute. Defaults to ``0``.
+        - ``0``-``59``
 
       * - ``second``
         - Optional
-        - Second (2 digits, zero padded). Defaults to ``00``.
-        - ``00``-``60``
+        - Second. Defaults to ``0``.
+        - ``0``-``59``
 
       * - ``millisecond``
         - Optional
-        - Millisecond (3 digits, zero padded). Defaults to ``000``.
-        - ``000``-``999``
+        - Millisecond. Defaults to ``0``.
+        - ``0``-``999``
 
       * - ``timezone``
         - Optional
@@ -129,9 +130,14 @@ Definition
         - Timezone expression
 		
    .. important::
-       You cannot combine the use of ISO format and non-ISO format
+       You cannot combine the use of calendar dates and ISO week date
        fields when constructing your :expression:`$dateFromParts` input
        document.
+
+Behavior
+--------
+
+.. include:: /includes/fact-olson-tz-behavior.rst
 
 Example
 -------
@@ -139,10 +145,9 @@ The following aggregation uses :expression:`$dateFromParts` to
 construct three date objects from the provided input fields:
 
 .. cssclass:: copyable-code
-
 .. code-block:: javascript
 
-   db.sales.aggregate( [
+   db.sales.aggregate([
    {
       $project: {
          date: {
@@ -152,18 +157,17 @@ construct three date objects from the provided input fields:
          },
          date_iso: {
             $dateFromParts: {
-               'isoYear' : 2017, 'isoWeekYear' : 6, 'isoDayOfWeek': 3, 'hour' : 12
+               'isoYear' : 2017, 'isoWeekYear' : 6, 'isoDayOfWeek' : 3, 'hour' : 12
             }
          },
          date_timezone: {
             $dateFromParts: {
-               'year' : 2016, 'month' : 12, 'day': 31, 'hour' : 23,
-               'minute': 46, 'second': 12, 'timezone': "America/New_York"
+               'year' : 2016, 'month' : 12, 'day' : 31, 'hour' : 23,
+               'minute' : 46, 'second' : 12, 'timezone' : 'America/New_York'
             }
          }
       }
-   }
-   ] )
+   }])
 
 The operation returns the following result for each document in the
 ``sales`` collection.

--- a/source/reference/operator/aggregation/dateFromParts.txt
+++ b/source/reference/operator/aggregation/dateFromParts.txt
@@ -18,8 +18,7 @@ Definition
    .. versionadded:: 3.6
 
    Constructs and returns a date object in ISO format given the date's
-   constituent properties. You must specify a ``year`` property; all other
-   fields are optional.
+   constituent properties.
    
    The :expression:`$dateFromParts` expression has the following syntax:
    
@@ -27,10 +26,9 @@ Definition
 
       { 
           $dateFromParts : {
-              ‘year’: <year>, ‘month’: <month>, ‘day’: <day>,
-              ‘hour’: <hour>, ‘minute’: <minute>, ‘second’: <second>,
-              ‘milliseconds’: <ms>,
-              ‘timezone’: <tzExpression>
+              'year': <year>, 'month': <month>, 'day': <day>,
+              'hour': <hour>, 'minute': <minute>, 'second': <second>,
+              'milliseconds': <ms>, 'timezone': <tzExpression>
           }
       }
 
@@ -41,10 +39,9 @@ Definition
    
       {
           $dateFromParts : {
-              ‘isoYear’: <year>, ‘isoWeekYear: <month>, ‘isoDayOfWeek’: <day>,
-              ‘hour’: <hour>, ‘minute’: <minute>, ‘second’: <second>,
-              ‘milliseconds’: <ms>,
-              ‘timezone’: <tzExpression>
+              'isoYear': <year>, 'isoWeekYear': <month>, 'isoDayOfWeek': <day>,
+              'hour': <hour>, 'minute': <minute>, 'second': <second>,
+              'milliseconds': <ms>, 'timezone': <tzExpression>
           }
       }
 	  
@@ -71,42 +68,42 @@ Definition
 		
       * - ``month``
         - Optional
-        - Month (2 digits, zero padded)
+        - Month (2 digits, zero padded). Defaults to ``01``.
         - ``01``-``12``
 		
       * - ``isoWeekYear``
         - Optional
-        - Week of year (2 digits, zero padded)
-        - ``00``-``53``
+        - Week of year (2 digits, zero padded). Defaults to ``01``.
+        - ``01``-``53``
 
       * - ``day``
         - Optional
-        - Day of month (2 digits, zero padded)
+        - Day of month (2 digits, zero padded) Defaults to ``01``.
         - ``01``-``31``
 
       * - ``isoDayOfWeek``
         - Optional
-        - Day of week (1-Sunday, 7-Saturday)
+        - Day of week (1-Sunday, 7-Saturday). Defaults to ``1``.
         - ``1``-``7``
 
       * - ``hour``
         - Optional
-        - Hour (2 digits, zero padded, 24-hour clock)
+        - Hour (2 digits, zero padded, 24-hour clock). Defaults to ``00``.
         - ``00``-``23``
 
       * - ``minute``
         - Optional
-        - Minute (2 digits, zero padded)
+        - Minute (2 digits, zero padded). Defaults to ``00``.
         - ``00``-``59``
 
       * - ``second``
         - Optional
-        - Second (2 digits, zero padded)
+        - Second (2 digits, zero padded). Defaults to ``00``.
         - ``00``-``60``
 
-      * - ``milliseconds``
+      * - ``millisecond``
         - Optional
-        - Milliseconds (3 digits, zero padded)
+        - Millisecond (3 digits, zero padded). Defaults to ``000``.
         - ``000``-``999``
 
       * - ``timezone``
@@ -135,38 +132,49 @@ Definition
        You cannot combine the use of ISO format and non-ISO format
        fields when constructing your :expression:`$dateFromParts` input
        document.
-	   
-   .. note::
-       ``month``, ``isoWeekYear``, ``day`` and ``isoDayOfWeek`` will
-       default to ``1`` if not provided.
-
-       ``hour``, ``minute``, ``second`` and ``milliseconds`` will
-       default to ``0`` if not provided.
 
 Example
 -------
 The following aggregation uses :expression:`$dateFromParts` to
-construct a date object from the provided input fields:
+construct three date objects from the provided input fields:
 
 .. cssclass:: copyable-code
 
 .. code-block:: javascript
 
-   db.tz.aggregate( [ 
-   { 
-       date: 
-       {
-           $dateFromParts: 
-           {
-               ‘year’ : 2017, ‘month’ : 2, ‘day’: 8, ‘hour’ : 12
-           }
-       }
-   } ] );
+   db.sales.aggregate( [
+   {
+      $project: {
+         date: {
+            $dateFromParts: {
+               'year' : 2017, 'month' : 2, 'day': 8, 'hour' : 12
+            }
+         },
+         date_iso: {
+            $dateFromParts: {
+               'isoYear' : 2017, 'isoWeekYear' : 6, 'isoDayOfWeek': 3, 'hour' : 12
+            }
+         },
+         date_timezone: {
+            $dateFromParts: {
+               'year' : 2016, 'month' : 12, 'day': 31, 'hour' : 23,
+               'minute': 46, 'second': 12, 'timezone': "America/New_York"
+            }
+         }
+      }
+   }
+   ] )
 
-The operation returns the following result:
+The operation returns the following result for each document in the
+``sales`` collection.
 
 .. code-block:: javascript
 
-   { date: ISODate( “2017-02-08T12:00:00Z” ) }
+   {
+     "_id" : ObjectId("<id>"),
+     "date" : ISODate("2017-02-08T12:00:00Z"),
+     "date_iso" : ISODate("2017-02-08T12:00:00Z"),
+     "date_timezone" : ISODate("2017-01-01T04:46:12Z")
+   }
    
    

--- a/source/reference/operator/aggregation/dateFromParts.txt
+++ b/source/reference/operator/aggregation/dateFromParts.txt
@@ -1,0 +1,172 @@
+============================
+$dateFromParts (aggregation)
+============================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+   
+Definition
+----------
+
+.. expression:: $dateFromParts
+
+   .. versionadded:: 3.6
+
+   Constructs and returns a date object in ISO format given the date's
+   constituent properties. You must specify a ``year`` property; all other
+   fields are optional.
+   
+   The :expression:`$dateFromParts` expression has the following syntax:
+   
+   .. code-block:: javascript
+
+      { 
+          $dateFromParts : {
+              ‘year’: <year>, ‘month’: <month>, ‘day’: <day>,
+              ‘hour’: <hour>, ‘minute’: <minute>, ‘second’: <second>,
+              ‘milliseconds’: <ms>,
+              ‘timezone’: <tzExpression>
+          }
+      }
+
+   You can also specify your constituent date fields in ISO format using
+   the following syntax:
+   
+   .. code-block:: javascript
+   
+      {
+          $dateFromParts : {
+              ‘isoYear’: <year>, ‘isoWeekYear: <month>, ‘isoDayOfWeek’: <day>,
+              ‘hour’: <hour>, ‘minute’: <minute>, ‘second’: <second>,
+              ‘milliseconds’: <ms>,
+              ‘timezone’: <tzExpression>
+          }
+      }
+	  
+   The :pipeline:`$dateFromParts` takes a document with the following fields:
+   
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 20 50 10
+
+      * - Field
+        - Required/Optional
+        - Description
+        - Possible Values
+
+      * - ``year``
+        - Required if not using ``isoYear``
+        - Year (4 digits, zero padded)
+        - ``0000``-``9999``
+
+      * - ``isoYear``
+        - Required if not using ``year``
+        - Year in ISO 8601 format
+        - ``0000``-``9999``
+		
+      * - ``month``
+        - Optional
+        - Month (2 digits, zero padded)
+        - ``01``-``12``
+		
+      * - ``isoWeekYear``
+        - Optional
+        - Week of year (2 digits, zero padded)
+        - ``00``-``53``
+
+      * - ``day``
+        - Optional
+        - Day of month (2 digits, zero padded)
+        - ``01``-``31``
+
+      * - ``isoDayOfWeek``
+        - Optional
+        - Day of week (1-Sunday, 7-Saturday)
+        - ``1``-``7``
+
+      * - ``hour``
+        - Optional
+        - Hour (2 digits, zero padded, 24-hour clock)
+        - ``00``-``23``
+
+      * - ``minute``
+        - Optional
+        - Minute (2 digits, zero padded)
+        - ``00``-``59``
+
+      * - ``second``
+        - Optional
+        - Second (2 digits, zero padded)
+        - ``00``-``60``
+
+      * - ``milliseconds``
+        - Optional
+        - Milliseconds (3 digits, zero padded)
+        - ``000``-``999``
+
+      * - ``timezone``
+        - Optional
+        - ``<timezone>`` can be any :ref:`expression
+          <aggregation-expressions>` that evaluates to a string whose
+          value is either:
+
+          - an `Olson Timezone Identifier
+            <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>`_, 
+            such as ``"Europe/London"`` or ``"America/New_York"``, or
+
+          - a UTC offset in the form:
+
+            - ``+/-[hh]:[mm]``, e.g. ``"+04:45"``, or
+
+            - ``+/-[hh][mm]``, e.g. ``"-0530"``, or
+
+            - ``+/-[hh]``, e.g. ``"+03"``.
+
+          For more information on expressions, see
+          :ref:`aggregation-expressions`.
+        - Timezone expression
+		
+   .. important::
+       You cannot combine the use of ISO format and non-ISO format
+       fields when constructing your :expression:`$dateFromParts` input
+       document.
+	   
+   .. note::
+       ``month``, ``isoWeekYear``, ``day`` and ``isoDayOfWeek`` will
+       default to ``1`` if not provided.
+
+       ``hour``, ``minute``, ``second`` and ``milliseconds`` will
+       default to ``0`` if not provided.
+
+Example
+-------
+The following aggregation uses :expression:`$dateFromParts` to
+construct a date object from the provided input fields:
+
+.. cssclass:: copyable-code
+
+.. code-block:: javascript
+
+   db.tz.aggregate( [ 
+   { 
+       date: 
+       {
+           $dateFromParts: 
+           {
+               ‘year’ : 2017, ‘month’ : 2, ‘day’: 8, ‘hour’ : 12
+           }
+       }
+   } ] );
+
+The operation returns the following result:
+
+.. code-block:: javascript
+
+   { date: ISODate( “2017-02-08T12:00:00Z” ) }
+   
+   

--- a/source/reference/operator/aggregation/dateFromParts.txt
+++ b/source/reference/operator/aggregation/dateFromParts.txt
@@ -40,7 +40,7 @@ Definition
    
       {
           $dateFromParts : {
-              'isoYear': <year>, 'isoWeekYear': <month>, 'isoDayOfWeek': <day>,
+              'isoYear': <year>, 'isoWeekYear': <week>, 'isoDayOfWeek': <day>,
               'hour': <hour>, 'minute': <minute>, 'second': <second>,
               'milliseconds': <ms>, 'timezone': <tzExpression>
           }
@@ -169,13 +169,12 @@ construct three date objects from the provided input fields:
       }
    }])
 
-The operation returns the following result for each document in the
-``sales`` collection.
+The operation returns the following result:
 
 .. code-block:: javascript
 
    {
-     "_id" : ObjectId("<id>"),
+     "_id" : 1,
      "date" : ISODate("2017-02-08T12:00:00Z"),
      "date_iso" : ISODate("2017-02-08T12:00:00Z"),
      "date_timezone" : ISODate("2017-01-01T04:46:12Z")

--- a/source/reference/operator/aggregation/dateToParts.txt
+++ b/source/reference/operator/aggregation/dateToParts.txt
@@ -17,8 +17,15 @@ Definition
 
    .. versionadded:: 3.6
 
-   Returns the constituent parts of a given ISO-formatted date as
-   individual object properties.
+   Returns a document that contains the constituent parts of a given
+   ISO-formatted date as individual properties. The properties returned
+   are ``year``, ``month``, ``day``, ``hour``, ``minute``, ``second``
+   and ``millisecond``.
+
+   You can set the ``iso8601`` property to ``true`` to return the parts
+   in ISO-format instead. This will return a document where the
+   properties are ``isoYear``, ``isoWeekYear``, ``isoDayOfWeek``,
+   ``hour``, ``minute``, ``second`` and ``millisecond``.
 
    The :expression:`$dateToParts` expression has the following syntax:
 
@@ -26,9 +33,9 @@ Definition
 
       { 
           $dateToParts: {
-              ‘date’ : <isoDateExpression>,
-              ‘timezone’ : <timezone>,
-              ‘iso8601’ : <boolean>
+              'date' : <isoDateExpression>,
+              'timezone' : <timezone>,
+              'iso8601' : <boolean>
           }
       }
 	  
@@ -44,10 +51,10 @@ Definition
 
       * - ``date``
         - Required 
-        - The date to convert to string. ``<isoDateExpression>`` can be
-          any :ref:`expression <aggregation-expressions>` that
-          evaluates to an ISO-formatted date. For more information on
-          expressions, see :ref:`aggregation-expressions`.
+        - The input date for which to return parts.
+          ``<isoDateExpression>`` can be any :ref:`expression <aggregation-expressions>`
+          that evaluates to an ISO-formatted date. For more information
+          on expressions, see :ref:`aggregation-expressions`.
 
       * - ``timezone``
         - Optional
@@ -93,62 +100,63 @@ Consider a ``sales`` collection with the following document:
      "date" : ISODate("2017-02-08T12:29:09.123Z")
    }
 
-The following aggregation uses :expression:`$dateToParts` to
-return the constituent parts of the ``date`` field in a new document:
+The following aggregation uses :expression:`$dateToParts` to return the
+constituent parts of the ``date`` field in new documents.
 
 .. cssclass:: copyable-code
 
 .. code-block:: javascript
 
-   db.sales.aggregate(
-      [
-        { 
-            date: { 
-                $dateToParts: {date: ISODate(“2017-02-08T12:29:09.123Z”)} 
-            } 
-        }
-      ]
-   )
-
-The operation returns the following result:
-
-.. code-block:: javascript
-
+   db.sales.aggregate( [
    {
-     date: {
-       ‘year’: 2017, ‘month’: 2, ‘day’: 8,
-       ‘hour’: 12, ‘minute’: 29, ‘second’: 9, ‘millisecond’: 123
-     }
+      $project: {
+         date: {
+            $dateToParts: { date: "$date" } 
+         },
+         date_iso: { 
+            $dateToParts: { date: "$date", iso8601: true }
+         },
+         date_timezone: {
+            $dateToParts: {
+               date: ISODate("2017-01-01T01:29:09.123Z"),
+               timezone: "America/New_York"
+            }
+         }  
+      }
    }
-   
-The following aggregation implements the ``iso8601`` option of
-:expression:`$dateToParts` to return the constituent parts of the ``date``
-field in ISO format.
-
-.. cssclass:: copyable-code
-
-.. code-block:: javascript
-
-   db.sales.aggregate(
-      [
-        { 
-            date: { 
-                $dateToParts: {
-                    date: ISODate(“2017-02-08T12:29:09.123Z”),
-                    iso8601: true
-                } 
-            } 
-        }
-      ]
-   )
+   ] )
 
 The operation returns the following result:
 
 .. code-block:: javascript
 
    {
-     date: {
-         ‘isoYear’: 2017, ‘isoWeekYear’: 6, ‘isoDayOfWeek’: 3,
-         ‘hour’: 12, ‘minute’: 29, ‘second’: 9, ‘millisecond’: 123
-       }
+     "_id" : 1,
+     "date" : {
+       "year" : 2017,
+       "month" : 2,
+       "day" : 8,
+       "hour" : 12,
+       "minute" : 29,
+       "second" : 9,
+       "millisecond" : 123
+     },
+     "date_iso" : {
+       "isoYear" : 2017,
+       "isoWeekYear" : 6,
+       "isoDayOfWeek" : 3,
+       "hour" : 12,
+       "minute" : 29,
+       "second" : 9,
+       "millisecond" : 123
+     },
+     "date_timezone" : {
+       "year" : 2016,
+       "month" : 12,
+       "day" : 31,
+       "hour" : 20,
+       "minute" : 29,
+       "second" : 9,
+       "millisecond" : 123
+     }
    }

--- a/source/reference/operator/aggregation/dateToParts.txt
+++ b/source/reference/operator/aggregation/dateToParts.txt
@@ -1,0 +1,154 @@
+==========================
+$dateToParts (aggregation)
+==========================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+   
+Definition
+----------
+
+.. expression:: $dateToParts
+
+   .. versionadded:: 3.6
+
+   Returns the constituent parts of a given ISO-formatted date as
+   individual object properties.
+
+   The :expression:`$dateToParts` expression has the following syntax:
+
+   .. code-block:: javascript
+
+      { 
+          $dateToParts: {
+              ‘date’ : <isoDateExpression>,
+              ‘timezone’ : <timezone>,
+              ‘iso8601’ : <boolean>
+          }
+      }
+	  
+   The :pipeline:`$dateToParts` takes a document with the following fields:
+   
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 20 60
+
+      * - Field
+        - Required/Optional
+        - Description
+
+      * - ``date``
+        - Required 
+        - The date to convert to string. ``<isoDateExpression>`` can be
+          any :ref:`expression <aggregation-expressions>` that
+          evaluates to an ISO-formatted date. For more information on
+          expressions, see :ref:`aggregation-expressions`.
+
+      * - ``timezone``
+        - Optional
+        - The timezone to use to format the date. By default,
+          :pipeline:`$dateToParts` uses UTC.
+
+          ``<timezone>`` can be any :ref:`expression
+          <aggregation-expressions>` that evaluates to a string whose
+          value is either:
+
+          - an `Olson Timezone Identifier
+            <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>`_, 
+            such as ``"Europe/London"`` or ``"America/New_York"``, or
+
+          - a UTC offset in the form:
+
+            - ``+/-[hh]:[mm]``, e.g. ``"+04:45"``, or
+
+            - ``+/-[hh][mm]``, e.g. ``"-0530"``, or
+
+            - ``+/-[hh]``, e.g. ``"+03"``.
+
+          For more information on expressions, see
+          :ref:`aggregation-expressions`.
+		  
+      * - ``iso8601``
+        - Optional
+        - If set to ``true``, modifies the output document to use ISO
+          formatting. Defaults to ``false``.
+
+Example
+-------
+
+Consider a ``sales`` collection with the following document:
+
+.. code-block:: javascript
+
+   {
+     "_id" : 1,
+     "item" : "abc",
+     "price" : 10,
+     "quantity" : 2,
+     "date" : ISODate("2017-02-08T12:29:09.123Z")
+   }
+
+The following aggregation uses :expression:`$dateToParts` to
+return the constituent parts of the ``date`` field in a new document:
+
+.. cssclass:: copyable-code
+
+.. code-block:: javascript
+
+   db.sales.aggregate(
+      [
+        { 
+            date: { 
+                $dateToParts: {date: ISODate(“2017-02-08T12:29:09.123Z”)} 
+            } 
+        }
+      ]
+   )
+
+The operation returns the following result:
+
+.. code-block:: javascript
+
+   {
+     date: {
+       ‘year’: 2017, ‘month’: 2, ‘day’: 8,
+       ‘hour’: 12, ‘minute’: 29, ‘second’: 9, ‘millisecond’: 123
+     }
+   }
+   
+The following aggregation implements the ``iso8601`` option of
+:expression:`$dateToParts` to return the constituent parts of the ``date``
+field in ISO format.
+
+.. cssclass:: copyable-code
+
+.. code-block:: javascript
+
+   db.sales.aggregate(
+      [
+        { 
+            date: { 
+                $dateToParts: {
+                    date: ISODate(“2017-02-08T12:29:09.123Z”),
+                    iso8601: true
+                } 
+            } 
+        }
+      ]
+   )
+
+The operation returns the following result:
+
+.. code-block:: javascript
+
+   {
+     date: {
+         ‘isoYear’: 2017, ‘isoWeekYear’: 6, ‘isoDayOfWeek’: 3,
+         ‘hour’: 12, ‘minute’: 29, ‘second’: 9, ‘millisecond’: 123
+       }
+   }

--- a/source/reference/operator/aggregation/dateToParts.txt
+++ b/source/reference/operator/aggregation/dateToParts.txt
@@ -18,14 +18,16 @@ Definition
    .. versionadded:: 3.6
 
    Returns a document that contains the constituent parts of a given
-   ISO-formatted date as individual properties. The properties returned
+   BSON Date value as individual properties. The properties returned
    are ``year``, ``month``, ``day``, ``hour``, ``minute``, ``second``
    and ``millisecond``.
 
    You can set the ``iso8601`` property to ``true`` to return the parts
-   in ISO-format instead. This will return a document where the
-   properties are ``isoYear``, ``isoWeekYear``, ``isoDayOfWeek``,
-   ``hour``, ``minute``, ``second`` and ``millisecond``.
+   representing an
+   `ISO week date <https://en.wikipedia.org/wiki/ISO_week_date>`_
+   instead. This will return a document where the properties are
+   ``isoYear``, ``isoWeekYear``, ``isoDayOfWeek``, ``hour``,
+   ``minute``, ``second`` and ``millisecond``.
 
    The :expression:`$dateToParts` expression has the following syntax:
 
@@ -52,9 +54,11 @@ Definition
       * - ``date``
         - Required 
         - The input date for which to return parts.
-          ``<isoDateExpression>`` can be any :ref:`expression <aggregation-expressions>`
-          that evaluates to an ISO-formatted date. For more information
-          on expressions, see :ref:`aggregation-expressions`.
+          ``<isoDateExpression>`` can be any
+          :ref:`expression <aggregation-expressions>` that evaluates to
+          a BSON Date, Timestamp or ObjectID value. For more
+          information on expressions, see
+          :ref:`aggregation-expressions`.
 
       * - ``timezone``
         - Optional
@@ -83,7 +87,13 @@ Definition
       * - ``iso8601``
         - Optional
         - If set to ``true``, modifies the output document to use ISO
-          formatting. Defaults to ``false``.
+          week date fields. Defaults to ``false``.
+
+Behavior
+--------
+
+.. include:: /includes/fact-olson-tz-behavior.rst
+
 
 Example
 -------
@@ -93,21 +103,20 @@ Consider a ``sales`` collection with the following document:
 .. code-block:: javascript
 
    {
-     "_id" : 1,
+     "_id" : 2,
      "item" : "abc",
      "price" : 10,
      "quantity" : 2,
-     "date" : ISODate("2017-02-08T12:29:09.123Z")
+     "date" : ISODate("2017-01-01T01:29:09.123Z")
    }
 
-The following aggregation uses :expression:`$dateToParts` to return the
-constituent parts of the ``date`` field in new documents.
+The following aggregation uses :expression:`$dateToParts` to return a
+document that contains the constituent parts of the ``date`` field.
 
 .. cssclass:: copyable-code
-
 .. code-block:: javascript
 
-   db.sales.aggregate( [
+   db.sales.aggregate([
    {
       $project: {
          date: {
@@ -117,46 +126,42 @@ constituent parts of the ``date`` field in new documents.
             $dateToParts: { date: "$date", iso8601: true }
          },
          date_timezone: {
-            $dateToParts: {
-               date: ISODate("2017-01-01T01:29:09.123Z"),
-               timezone: "America/New_York"
-            }
+            $dateToParts: { date: "$date", timezone: "America/New_York" }
          }  
       }
-   }
-   ] )
+  }])
 
 The operation returns the following result:
 
 .. code-block:: javascript
 
    {
-     "_id" : 1,
-     "date" : {
-       "year" : 2017,
-       "month" : 2,
-       "day" : 8,
-       "hour" : 12,
-       "minute" : 29,
-       "second" : 9,
-       "millisecond" : 123
-     },
-     "date_iso" : {
-       "isoYear" : 2017,
-       "isoWeekYear" : 6,
-       "isoDayOfWeek" : 3,
-       "hour" : 12,
-       "minute" : 29,
-       "second" : 9,
-       "millisecond" : 123
-     },
-     "date_timezone" : {
-       "year" : 2016,
-       "month" : 12,
-       "day" : 31,
-       "hour" : 20,
-       "minute" : 29,
-       "second" : 9,
-       "millisecond" : 123
-     }
+      "_id" : 2,
+      "date" : {
+         "year" : 2017,
+         "month" : 1,
+         "day" : 1,
+         "hour" : 1,
+         "minute" : 29,
+         "second" : 9,
+         "millisecond" : 123
+      },
+      "date_iso" : {
+         "isoYear" : 2016,
+         "isoWeekYear" : 52,
+         "isoDayOfWeek" : 7,
+         "hour" : 1,
+         "minute" : 29,
+         "second" : 9,
+         "millisecond" : 123
+      },
+      "date_timezone" : {
+         "year" : 2016,
+         "month" : 12,
+         "day" : 31,
+         "hour" : 20,
+         "minute" : 29,
+         "second" : 9,
+         "millisecond" : 123
+      }
    }

--- a/source/reference/operator/aggregation/dateToString.txt
+++ b/source/reference/operator/aggregation/dateToString.txt
@@ -194,7 +194,7 @@ Consider a ``sales`` collection with the following document:
      "date" : ISODate("2014-01-01T08:15:39.736Z")
    }
 
-The following aggregation uses the :expression:`$dateToString` to
+The following aggregation uses :expression:`$dateToString` to
 return the ``date`` field as formatted strings:
 
 .. cssclass:: copyable-code

--- a/source/release-notes/3.6.txt
+++ b/source/release-notes/3.6.txt
@@ -81,7 +81,6 @@ New Aggregation Operators
 
    * - :expression:`$dateToParts`
      - Returns a document containing the constituent parts of a date.
->>>>>>> DOCS-10475 - Updates per Derick's feedback
 
 New Aggregation Variable
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/release-notes/3.6.txt
+++ b/source/release-notes/3.6.txt
@@ -75,6 +75,14 @@ New Aggregation Operators
 
      - Converts a date/time string to a date object.
 
+   * - :expression:`$dateFromParts`
+     - Constructs a BSON Date object given the date's constituent
+       parts.
+
+   * - :expression:`$dateToParts`
+     - Returns a document containing the constituent parts of a date.
+>>>>>>> DOCS-10475 - Updates per Derick's feedback
+
 New Aggregation Variable
 ~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Hi @kay-kim this is ready for a final look and merge into master.

Also updating release notes and aggregation definition toc trees with these new operators.

Code review: https://mongodbcr.appspot.com/158260001/

Staging: 
https://docs-mongodbcom-staging.corp.mongodb.com/jeffreyallen/DOCS-10475/reference/operator/aggregation.html

https://docs-mongodbcom-staging.corp.mongodb.com/jeffreyallen/DOCS-10475/reference/operator/aggregation/dateFromParts.html

https://docs-mongodbcom-staging.corp.mongodb.com/jeffreyallen/DOCS-10475/release-notes/3.6.html

https://docs-mongodbcom-staging.corp.mongodb.com/jeffreyallen/DOCS-10475/reference/operator/aggregation/dateToParts.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2962)
<!-- Reviewable:end -->
