### PR TITLE
Remove GMT from tzExpression default

### DIFF
--- a/source/includes/fact-timezone-description.rst
+++ b/source/includes/fact-timezone-description.rst
@@ -4,7 +4,7 @@
 an `Olson Timezone Identifier
 <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>`_ or a
 `UTC Offset <https://en.wikipedia.org/wiki/List_of_UTC_time_offsets>`_.
-If no ``timezone`` is provided, the result is displayed in ``UTC/GMT``.
+If no ``timezone`` is provided, the result is displayed in ``UTC``.
 
 .. list-table::
    :header-rows: 1


### PR DESCRIPTION
Per @atsansone's comment on https://github.com/mongodb/docs/pull/2961

> Note: UTC is a time standard and GMT is a UK time zone. When daylight savings time is in effect in the UK, they go to BST (British Standard Time). You should refer to this as UTC only. (https://www.timeanddate.com/time/gmt-utc-time.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2964)
<!-- Reviewable:end -->
