### PR TITLE
DOCS-10858 Minor grammar fixes

### DIFF
--- a/source/core/sharded-cluster-query-router.txt
+++ b/source/core/sharded-cluster-query-router.txt
@@ -164,7 +164,7 @@ determine which shard or subset of shards stores this data.
 
 .. include:: /images/sharded-cluster-scatter-gather-query.rst
 
-Once the :program:`mongos` has received a response from all shard, it merges
+After the :program:`mongos` receives responses from all shards, it merges
 the data and returns the result document. The performance of a broadcast
 operation depends on the overall load of the cluster, as well as variables
 like network latency, individual shard load, and number of documents returned


### PR DESCRIPTION
- fix adjective-noun agreement
- use 'after' in place of 'once'
- use present tense in place of present perfect
- use plural for 'responses'

Closes DOCS-10858

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2974)
<!-- Reviewable:end -->
