### PR TITLE
DOCS-10537 - Default Collection UUIDs

### DIFF
--- a/source/core/databases-and-collections.txt
+++ b/source/core/databases-and-collections.txt
@@ -110,6 +110,23 @@ To change the structure of the documents in a collection, such as add
 new fields, remove existing fields, or change the field values to a new
 type, update the documents to the new structure.
 
+
+.. _collections-uuids:
+
+Unique Identifiers
+~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 3.6
+
+Collections are assigned a :abbr:`UUID (Universally unique identifier)`
+upon creation. Once assigned, a collection's UUID does not change.
+The collection UUID remains the same across all members of a replica
+set and shards in a sharded cluster.
+
+To retrieve the UUID for a collection, run either the
+:manual:`listCollections </reference/command/listCollections>` command
+or the :method:`db.getCollectionInfos()` method.
+
 .. class:: hidden
 
    .. toctree::

--- a/source/includes/fact-uuid-restore-from-backup.rst
+++ b/source/includes/fact-uuid-restore-from-backup.rst
@@ -1,0 +1,12 @@
+.. note ::
+
+   *New in version 3.6:*
+
+   All MongoDB collections have
+   :abbr:`UUIDs (Universally unique identifiers)` by default. When
+   MongoDB restores collections, the restored collections retain their
+   original UUIDs. When restoring a collection where no UUID was
+   present, MongoDB generates a UUID for the restored collection. 
+
+   For more information on collection UUIDs, see
+   `Collections <https://docs.mongodb.com/v3.6/core/databases-and-collections/#collections>`_.

--- a/source/includes/steps-restore-primary-from-backup.yaml
+++ b/source/includes/steps-restore-primary-from-backup.yaml
@@ -24,6 +24,8 @@ action:
   language: sh
   code: |
     mongod --dbpath /data/db --replSet <replName>
+post: |
+  .. include:: /includes/fact-uuid-restore-from-backup.rst
 ---
 title: Connect a :program:`mongo` shell to the ``mongod`` instance.
 stepnum: 3

--- a/source/includes/steps-restore-sharded-cluster-database-dump.yaml
+++ b/source/includes/steps-restore-sharded-cluster-database-dump.yaml
@@ -74,6 +74,8 @@ action:
 post: |
   After you have finished restoring all the shards, shut down all shard
   instances.
+
+  .. include:: /includes/fact-uuid-restore-from-backup.rst
 ---
 title: "Restore the config server data."
 stepnum: 7

--- a/source/tutorial/backup-and-restore-tools.txt
+++ b/source/tutorial/backup-and-restore-tools.txt
@@ -170,6 +170,8 @@ running :program:`mongod` or :program:`mongos` directly.
 :program:`mongorestore` can restore either an entire database backup
 or a subset of the backup.
 
+.. include:: /includes/fact-uuid-restore-from-backup.rst
+
 To use :program:`mongorestore` to connect to an active
 :program:`mongod` or :program:`mongos`, use a command with the following prototype form:
 

--- a/source/tutorial/backup-with-filesystem-snapshots.txt
+++ b/source/tutorial/backup-with-filesystem-snapshots.txt
@@ -295,6 +295,8 @@ the following sequence of commands:
    dd if=/dev/vg0/mdb-snap01 of=/dev/vg0/mdb-new
    mount /dev/vg0/mdb-new /srv/mongodb
 
+.. include:: /includes/fact-uuid-restore-from-backup.rst
+
 Remote Backup Storage
 ~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Adding information for collection UUIDs. Also adding a note for how backups are affected.

Code review: https://mongodbcr.appspot.com/165190004/

Staging:
https://docs-mongodbcom-staging.corp.mongodb.com/jeffreyallen/DOCS-10537/core/databases-and-collections.html

https://docs-mongodbcom-staging.corp.mongodb.com/jeffreyallen/DOCS-10537/tutorial/backup-and-restore-tools.html

https://docs-mongodbcom-staging.corp.mongodb.com/jeffreyallen/DOCS-10537/tutorial/backup-with-filesystem-snapshots.html

https://docs-mongodbcom-staging.corp.mongodb.com/jeffreyallen/DOCS-10537/tutorial/restore-replica-set-from-backup.html

https://docs-mongodbcom-staging.corp.mongodb.com/jeffreyallen/DOCS-10537/tutorial/restore-sharded-cluster.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2977)
<!-- Reviewable:end -->
