### PR TITLE
DOCS-4578 Clarify index builds on secondaries

### DIFF
--- a/source/core/index-creation.txt
+++ b/source/core/index-creation.txt
@@ -120,11 +120,16 @@ Building Indexes on Secondaries
    background. Previously all index builds on secondaries were in the
    foreground.
 
-Background index operations on a :term:`replica set`
-:term:`secondaries <secondary>` begin after the :term:`primary`
-completes building the index. If MongoDB builds an index in the
-background on the primary, the secondaries will then build that index
-in the background.
+A foreground index build on a :term:`primary` replicates as a foreground index
+build on :term:`replica set` :term:`secondaries <secondary>`. The replication
+worker acquires a global DB lock that queues reads and writes to all databases
+on the indexing server.
+
+A background index build on a primary replicates as a background index build on
+secondaries. Secondary reads are not affected.
+
+In both cases, index operations on replica set secondaries begin after the
+primary finishes building the index.
 
 To build large indexes on secondaries the best approach is to
 restart one secondary at a time in :term:`standalone` mode and build


### PR DESCRIPTION
Clarify when index builds on secondaries are in the foreground or the background.

Closes DOCS-4578

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2979)
<!-- Reviewable:end -->
