### PR TITLE
DOCS-10486: Add correct BulkWriteError output for db.products.insertMany() example

### DIFF
--- a/source/reference/method/db.collection.insertMany.txt
+++ b/source/reference/method/db.collection.insertMany.txt
@@ -205,16 +205,16 @@ Since ``_id: 13`` already exists, the following exception is thrown:
          {
             "index" : 0,
             "code" : 11000,
-            "errmsg" : "E11000 duplicate key error collection: restaurant.test index: _id_ dup key: { : 13.0 }",
+            "errmsg" : "E11000 duplicate key error collection: inventory.products index: _id_ dup key: { : 13.0 }",
             "op" : {
                "_id" : 13,
-               "item" : "envelopes",
-               "qty" : 60
+               "item" : "stamps",
+               "qty" : 110
             }
          }
       ],
       "writeConcernErrors" : [ ],
-      "nInserted" : 0,
+      "nInserted" : 1,
       "nUpserted" : 0,
       "nMatched" : 0,
       "nModified" : 0,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2981)
<!-- Reviewable:end -->
