### PR TITLE
DOCS-10569 - Adding authentication restrictions for createUser and updateUser

### DIFF
--- a/source/includes/apiargs-dbcommand-createUser-field.yaml
+++ b/source/includes/apiargs-dbcommand-createUser-field.yaml
@@ -67,4 +67,18 @@ operation: createUser
 optional: true
 position: 6
 type: document
+---
+arg_name: field
+description: |
+  The authentication restrictions the server enforces on the created
+  user. Specifies a list of IP addresses and
+  :abbr:`CIDR (Classless Inter-Domain Routing)` ranges from which the
+  user is allowed to connect to the server or from which the server can
+  accept users.
+interface: dbcommand
+name: authenticationRestrictions
+operation: createUser
+optional: true
+position: 7
+type: array
 ...

--- a/source/includes/apiargs-dbcommand-updateUser-field.yaml
+++ b/source/includes/apiargs-dbcommand-updateUser-field.yaml
@@ -62,4 +62,18 @@ operation: updateUser
 optional: true
 position: 6
 type: document
+---
+arg_name: field
+description: |
+  The authentication restrictions the server enforces on the created
+  user. Specifies a list of IP addresses and
+  :abbr:`CIDR (Classless Inter-Domain Routing)` ranges from which the
+  user is allowed to connect to the server or from which the server can
+  accept users.
+interface: dbcommand
+name: authenticationRestrictions
+operation: updateUser
+optional: true
+position: 7
+type: array
 ...

--- a/source/includes/apiargs-method-db.createUser-user-doc-param.yaml
+++ b/source/includes/apiargs-method-db.createUser-user-doc-param.yaml
@@ -31,4 +31,12 @@ source:
   file: apiargs-dbcommand-createUser-field.yaml
   ref: roles
 position: 4
+---
+arg_name: field
+interface: method
+operation: db.createUser
+source:
+  file: apiargs-dbcommand-createUser-field.yaml
+  ref: authenticationRestrictions
+position: 5
 ...

--- a/source/includes/apiargs-method-db.updateUser-update-fields.yaml
+++ b/source/includes/apiargs-method-db.updateUser-update-fields.yaml
@@ -18,4 +18,11 @@ operation: db.updateUser
 source:
   file: apiargs-dbcommand-updateUser-field.yaml
   ref: pwd
+---
+position: 4
+interface: method
+operation: db.updateUser
+source:
+  file: apiargs-dbcommand-updateUser-field.yaml
+  ref: authenticationRestrictions
 ...

--- a/source/includes/fact-auth-restrictions-array-contents.rst
+++ b/source/includes/fact-auth-restrictions-array-contents.rst
@@ -1,0 +1,39 @@
+.. versionadded:: 3.6
+
+The ``authenticaionRestrictions`` document can contain the
+following fields:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 30 50
+
+   * - Field Name
+     - Value
+     - Description
+
+   * - ``clientSource``
+     - Array of IP addresses and/or
+       :abbr:`CIDR (Classless Inter-Domain Routing)` ranges
+     - If present, when authenticating a user, the server verifies
+       that the client's IP address is either in the given list or
+       belongs to a CIDR range in the list. If the client's IP address
+       is not present, the server does not authenticate the user.
+
+   * - ``serverAddress``
+     - Array of IP addresses and/or
+       :abbr:`CIDR (Classless Inter-Domain Routing)` ranges
+     - A list of IP addresses or CIDR ranges to which the client can
+       connect. If present, the server will verify that the client's
+       connection was accepted via an IP address in the given list. If
+       the connection was accepted via an unrecognized IP address, the
+       server does not authenticate the user.
+
+.. important::
+
+   These are the only fields recognized by the server in the
+   ``authenticationRestrictions`` document. When creating a user,
+   if the server does not recognize a field contained within the
+   ``authenticationRestrictions`` document, it throws an error.
+
+For more information on authentication in MongoDB, see
+:doc:`Authentication </core/authentication/>`.

--- a/source/includes/fact-roles-array-contents.rst
+++ b/source/includes/fact-roles-array-contents.rst
@@ -2,7 +2,7 @@
 
 In the ``roles`` field, you can specify both
 :ref:`built-in roles <built-in-roles>` and :ref:`user-defined
-role <user-defined-roles>`.
+roles <user-defined-roles>`.
 
 To specify a role that exists in the same database where
 |local-cmd-name| runs, you can either specify the role with the name of

--- a/source/reference/command/createUser.txt
+++ b/source/reference/command/createUser.txt
@@ -38,7 +38,15 @@ Definition
 
    .. include:: /includes/apiargs/dbcommand-createUser-field.rst
 
-   .. include:: /includes/fact-roles-array-contents.rst
+Roles
+~~~~~
+
+.. include:: /includes/fact-roles-array-contents.rst
+
+Authentication Restrictions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/fact-auth-restrictions-array-contents.rst
 
 .. TODO rename section (or make it subsection or something)
 

--- a/source/reference/command/updateUser.txt
+++ b/source/reference/command/updateUser.txt
@@ -20,7 +20,8 @@ Definition
 
    Updates the user's profile on the database on which you run the
    command. An update to a field **completely replaces** the previous
-   field's values, including updates to the user's ``roles`` array.
+   field's values, including updates to the user's ``roles`` and
+   ``authenticationRestrictions`` arrays.
 
    .. warning::
 
@@ -35,7 +36,8 @@ Definition
 
    .. code-block:: javascript
 
-      { updateUser: "<username>",
+      { 
+        updateUser: "<username>",
         pwd: "<cleartext password>",
         customData: { <any information> },
         roles: [
@@ -49,7 +51,15 @@ Definition
 
    .. include:: /includes/apiargs/dbcommand-updateUser-field.rst
 
-   .. include:: /includes/fact-roles-array-contents.rst
+Roles
+~~~~~
+
+.. include:: /includes/fact-roles-array-contents.rst
+
+Authentication Restrictions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/fact-auth-restrictions-array-contents.rst
 
 Behavior
 --------

--- a/source/reference/method/db.createUser.txt
+++ b/source/reference/method/db.createUser.txt
@@ -15,8 +15,9 @@ Definition
 
 .. method:: db.createUser ( user, writeConcern )
 
-   Creates a new user for the database where the method runs. :method:`db.createUser()`
-   returns a *duplicate user* error if the user already exists on the database.
+   Creates a new user for the database on which the method is run.
+   :method:`db.createUser()` returns a *duplicate user* error if the
+   user already exists on the database.
 
    The :method:`db.createUser()` method has the following syntax:
 
@@ -26,12 +27,20 @@ Definition
 
    .. code-block:: javascript
 
-      { user: "<name>",
+      { 
+        user: "<name>",
         pwd: "<cleartext password>",
         customData: { <any information> },
         roles: [
           { role: "<role>", db: "<database>" } | "<role>",
           ...
+        ],
+        authenticationRestrictions: [ 
+           { 
+             clientSource: ["<IP>" | "<CIDR range>", ...]
+             serverAddress: ["<IP>" | "<CIDR range>", ...]
+           },
+           ...
         ]
       }
 
@@ -40,10 +49,18 @@ Definition
    .. |local-cmd-name| replace:: :method:`db.createUser()`
    .. include:: /includes/apiargs/method-db.createUser-user-doc-param.rst
 
-   .. include:: /includes/fact-roles-array-contents.rst
+Roles
+~~~~~
 
-   The :method:`db.createUser()` method wraps the :dbcommand:`createUser`
-   command.
+.. include:: /includes/fact-roles-array-contents.rst
+
+Authentication Restrictions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/fact-auth-restrictions-array-contents.rst
+
+The :method:`db.createUser()` method wraps the :dbcommand:`createUser`
+command.
 
 Behavior
 --------
@@ -79,6 +96,7 @@ Examples
 The following :method:`db.createUser()` operation creates the
 ``accountAdmin01`` user on the ``products`` database.
 
+.. cssclass:: copyable-code
 .. code-block:: javascript
 
    use products
@@ -103,6 +121,7 @@ Create User with Roles
 The following operation creates ``accountUser`` in the ``products`` database
 and gives the user the ``readWrite`` and ``dbAdmin`` roles.
 
+.. cssclass:: copyable-code
 .. code-block:: javascript
 
    use products
@@ -114,12 +133,13 @@ and gives the user the ``readWrite`` and ``dbAdmin`` roles.
       }
    )
 
-Create User Without Roles
+Create User without Roles
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following operation creates a user named ``reportsUser`` in the ``admin``
 database but does not yet assign roles:
 
+.. cssclass:: copyable-code
 .. code-block:: javascript
 
    use admin
@@ -139,6 +159,7 @@ The following operation creates a user named ``appAdmin`` in the
 ``config`` database, which lets the user change certain settings for
 sharded clusters, such as to the balancer setting.
 
+.. cssclass:: copyable-code
 .. code-block:: javascript
 
    use admin
@@ -151,5 +172,28 @@ sharded clusters, such as to the balancer setting.
             { role: "readWrite", db: "config" },
             "clusterAdmin"
           ]
+      }
+   )
+
+Create User with Authentication Restrictions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following operation creates a user named ``restricted`` in the
+``admin`` database. This user may only authenticate if connecting from
+IP address ``192.0.2.0`` to IP address ``198.51.100.0``.
+
+.. cssclass:: copyable-code
+.. code-block:: javascript
+
+   use admin
+   db.createUser(
+      {
+        user: "restricted",
+        pwd: "password",
+        roles: [ ],
+        authenticationRestrictions: [ {
+           clientSource: ["192.0.2.0"],
+           serverAddress: ["198.51.100.0"]
+        } ]
       }
    )

--- a/source/reference/method/db.updateUser.txt
+++ b/source/reference/method/db.updateUser.txt
@@ -35,12 +35,19 @@ Definition
          {
            customData : { <any information> },
            roles : [
-                     { role: "<role>", db: "<database>" } | "<role>",
-                     ...
-                   ],
-           pwd: "<cleartext password>"
-          },
-          writeConcern: { <write concern> }
+             { role: "<role>", db: "<database>" } | "<role>",
+             ...
+           ],
+           pwd: "<cleartext password>",
+           authenticationRestrictions: [
+              { 
+                clientSource: ["<IP>" | "<CIDR range>", ...],
+                serverAddress: ["<IP>", ...]
+              },
+              ...
+           ]
+         },
+         writeConcern: { <write concern> }
       )
 
    The :method:`db.updateUser()` method has the following arguments.
@@ -55,11 +62,19 @@ Definition
 
    .. include:: /includes/apiargs/method-db.updateUser-update-fields.rst
 
-   .. |local-cmd-name| replace:: :method:`db.updateUser()`
-   .. include:: /includes/fact-roles-array-contents.rst
+Roles
+~~~~~
 
-   The :method:`db.updateUser()` method wraps the :dbcommand:`updateUser`
-   command.
+.. |local-cmd-name| replace:: :method:`db.updateUser()`
+.. include:: /includes/fact-roles-array-contents.rst
+
+Authentication Restrictions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/fact-auth-restrictions-array-contents.rst
+
+The :method:`db.updateUser()` method wraps the :dbcommand:`updateUser`
+command.
 
 Behavior
 --------
@@ -84,34 +99,40 @@ user info:
 .. code-block:: javascript
 
    {
-      "_id" : "products.appClient01",
-      "user" : "appClient01",
-      "db" : "products",
-      "customData" : { "empID" : "12345", "badge" : "9156" },
-      "roles" : [
-          { "role" : "readWrite",
-            "db" : "products"
+      _id : "products.appClient01",
+      user : "appClient01",
+      db : "products",
+      customData : { empID : "12345", badge : "9156" },
+      roles : [
+          { 
+            role : "readWrite",
+            db : "products"
           },
-          { "role" : "read",
-            "db" : "inventory"
+          { 
+            role : "read",
+            db : "inventory"
           }
-      ]
+      ],
+      authenticationRestrictions : [ {
+         clientSource: ["69.89.31.226"],
+         serverAddress: ["172.16.254.1"]
+      } ]
    }
 
 The following :method:`db.updateUser()` method **completely** replaces the
 user's ``customData`` and ``roles`` data:
 
+.. cssclass:: copyable-code
 .. code-block:: javascript
 
    use products
    db.updateUser( "appClient01",
-                  {
-                    customData : { employeeId : "0x3039" },
-                    roles : [
-                              { role : "read", db : "assets"  }
-                            ]
-                   }
-                )
+   {
+      customData : { employeeId : "0x3039" },
+      roles : [
+         { role : "read", db : "assets"  }
+      ]
+   } )
 
 The user ``appClient01`` in the ``products`` database now has the following
 user information:
@@ -119,13 +140,14 @@ user information:
 .. code-block:: javascript
 
    {
-      "_id" : "products.appClient01",
-      "user" : "appClient01",
-      "db" : "products",
-      "customData" : { "employeeId" : "0x3039" },
-      "roles" : [
-          { "role" : "read",
-            "db" : "assets"
+      _id : "products.appClient01",
+      user : "appClient01",
+      db : "products",
+      customData : { employeeId : "0x3039" },
+      roles : [
+          { 
+            role : "read",
+            db : "assets"
           }
       ]
    }


### PR DESCRIPTION
Documenting the new field for createUser and updateUser

Code review: https://mongodbcr.appspot.com/158820001/

Staging: 
https://docs-mongodbcom-staging.corp.mongodb.com/jeffreyallen/DOCS-10569/reference/method/db.createUser.html

https://docs-mongodbcom-staging.corp.mongodb.com/jeffreyallen/DOCS-10569/reference/method/db.updateUser.html

https://docs-mongodbcom-staging.corp.mongodb.com/jeffreyallen/DOCS-10569/reference/command/createUser.html

https://docs-mongodbcom-staging.corp.mongodb.com/jeffreyallen/DOCS-10569/reference/command/updateUser.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2986)
<!-- Reviewable:end -->
