### PR TITLE
DOCS-10822: Typo "caped" instead of "capped"

### DIFF
--- a/source/release-notes/3.4-compatibility.txt
+++ b/source/release-notes/3.4-compatibility.txt
@@ -145,7 +145,7 @@ For example, the following operation is no longer valid:
 
 .. code-block:: javascript
 
-   db.createCollection( "myCappedCollection", { caped: true,  size: 5242880 } )
+   db.createCollection( "myCappedCollection", { capped: true,  size: 5242880 } )
 
 .. _3.4-index-validation:
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2990)
<!-- Reviewable:end -->
