### PR TITLE
DOCS-9977: Option `security.ldap.bind.saslMechanisms` is named incorrectly in sample configuration file

### DIFF
--- a/source/reference/configuration-options.txt
+++ b/source/reference/configuration-options.txt
@@ -372,7 +372,7 @@ Core Options
          servers: <string>
          bind:
             method: <string>
-            saslMechanism: <string>
+            saslMechanisms: <string>
             queryUser: <string>
             queryPassword: <string>
             useOSDefaults: <boolean>
@@ -463,7 +463,7 @@ Key Management Configuration Options
          servers: <string>
          bind:
             method: <string>
-            saslMechanism: <string>
+            saslMechanisms: <string>
             queryUser: <string>
             queryPassword: <string>
             useOSDefaults: <boolean>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2992)
<!-- Reviewable:end -->
