### PR TITLE
DOCS-10337: Include /t REG_DWORD to set correct registry value type for KeepAliveTime on Windows

### DIFF
--- a/source/includes/fact-tcp-keepalive-windows.rst
+++ b/source/includes/fact-tcp-keepalive-windows.rst
@@ -16,7 +16,7 @@
 
   .. code-block:: powershell
 
-     reg add HKLM\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\ /v KeepAliveTime /d <value>
+     reg add HKLM\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\ /t REG_DWORD /v KeepAliveTime /d <value>
 
   Windows users should consider the `Windows Server Technet Article on
   KeepAliveTime


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2993)
<!-- Reviewable:end -->
