### PR TITLE
DOCS-7934 Warning for foreground index build server impact

### DIFF
--- a/source/reference/method/db.collection.createIndex.txt
+++ b/source/reference/method/db.collection.createIndex.txt
@@ -115,6 +115,10 @@ Behaviors
 The :method:`~db.collection.createIndex()` method has the behaviors
 described here.
 
+.. warning::
+
+   Foreground index builds block all other operations on the database.
+
 - .. versionchanged:: 3.4
 
   To add or change index options, other than collation, you must drop
@@ -134,13 +138,6 @@ described here.
   methods with the same index specification at the same time, only
   the first operation will succeed, all other operations will have
   no effect.
-
-- Non-background indexing operations block all other operations on a database.
-
-  .. warning::
-
-     Foreground index builds are resource intensive and impact server
-     performance.
 
 -  .. include:: /includes/fact-index-key-length-operation-behaviors.rst
       :start-after: index-field-limit-ensureIndex

--- a/source/reference/method/db.collection.createIndex.txt
+++ b/source/reference/method/db.collection.createIndex.txt
@@ -135,8 +135,12 @@ described here.
   the first operation will succeed, all other operations will have
   no effect.
 
-- Non-background indexing operations will block all other
-  operations on a database.
+- Non-background indexing operations block all other operations on a database.
+
+  .. warning::
+
+     Foreground index builds are resource intensive and impact server
+     performance.
 
 -  .. include:: /includes/fact-index-key-length-operation-behaviors.rst
       :start-after: index-field-limit-ensureIndex


### PR DESCRIPTION
Closes DOCS-7934

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2994)
<!-- Reviewable:end -->
