### PR TITLE
DOCS-10711: tcp_keepalive_time is applicable for ipv6 as well

### DIFF
--- a/source/administration/production-notes.txt
+++ b/source/administration/production-notes.txt
@@ -605,13 +605,13 @@ consider the following recommendations:
 For the **WiredTiger** storage engine:
 
 - Set the readahead setting to 0 regardless of storage media type (spinning,
-  SSD, etc.). 
-  
+  SSD, etc.).
+
   Setting a higher readahead benefits sequential I/O operations. However,
   since MongoDB disk access patterns are generally random, setting a higher
   readahead provides limited benefit or performance degradation. As such, for
   most workloads, a readahead of 0 provides optimal MongoDB performance.
-  
+
   In general, set the readahead setting to 0 unless testing shows a
   measurable, repeatable, and reliable benefit in a higher readahead value.
   `MongoDB Professional Support
@@ -743,11 +743,11 @@ instances directly from |MMS|. See :mms-docs:`Configure AWS Integration
 </tutorial/configure-aws-settings/>` for more details.
 
 When available, enable AWS's `Enhanced Networking
-<http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking>`_ 
+<http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking>`_
 for your instance. Not all instance types support Enhanced Networking.
 Refer to the `AWS documentation
 <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking>`_
-for more information. 
+for more information.
 
 .. _windows-azure-production-notes:
 
@@ -807,7 +807,7 @@ to another host and the :program:`mongod` instance on the virtual machine is the
 Follow the `networking best practices for vMotion
 <https://docs.vmware.com/en/VMware-vSphere/6.0/com.vmware.vsphere.vcenterhost.doc/GUID-7DAD15D4-7F41-4913-9F16-567289E22977.html>`_
 and the `VMKernel
-<https://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=2054994>`_. 
+<https://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=2054994>`_.
 Failure to follow the best practices can result in performance problems
 and affect :doc:`replica set </core/replica-set-high-availability>` and
 :doc:`sharded cluster </tutorial/troubleshoot-sharded-clusters>` high

--- a/source/faq/diagnostics.txt
+++ b/source/faq/diagnostics.txt
@@ -40,10 +40,10 @@ Does TCP ``keepalive`` time affect MongoDB Deployments?
 
 If you experience socket errors between clients and servers or between
 members of a sharded cluster or replica set that do not have other
-reasonable causes, check the TCP keepalive value (e.g. on Linux systems
-store, the ``tcp_keepalive_time`` value). A common keepalive period is
-``7200`` seconds (2 hours); however, different distributions and OS X
-may have different settings.
+reasonable causes, check the TCP keepalive value (for example, the
+``tcp_keepalive_time`` value on Linux systems). A common keepalive period is
+``7200`` seconds (2 hours); however, different distributions and OS X may have
+different settings.
 
 For MongoDB, you will have better results with shorter keepalive
 periods, on the order of ``120`` seconds (two minutes).
@@ -54,8 +54,8 @@ processes. This includes all machines hosting :program:`mongos` or
 :program:`mongod` processes and all machines hosting client processes
 that connect to MongoDB.
 
-.. note:: 
-   
+.. note::
+
    For non-Linux systems, values greater than or equal to 600 seconds
    (10 minutes) will be ignored by :program:`mongod` and
    :program:`mongos`. For Linux, values greater than 300 seconds (5

--- a/source/includes/fact-tcp-keepalive-linux.rst
+++ b/source/includes/fact-tcp-keepalive-linux.rst
@@ -15,6 +15,11 @@
 
   The value is measured in seconds.
 
+  .. note::
+
+     Although the path includes ``ipv4``, the ``tcp_keepalive_time`` value
+     applies to both IPv4 and IPv6.
+
 - To change the ``tcp_keepalive_time`` value, you can use one of the
   following command:
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2995)
<!-- Reviewable:end -->
