### PR TITLE
DOCS-10886: adding allowPartialResults cursor method into cursor methods doc

### DIFF
--- a/source/includes/ref-toc-method-cursor.yaml
+++ b/source/includes/ref-toc-method-cursor.yaml
@@ -2,6 +2,10 @@ name: ":method:`cursor.addOption()`"
 file: /reference/method/cursor.addOption
 description: "Adds special wire protocol flags that modify the behavior of the query.'"
 ---
+name: ":method:`cursor.allowPartialResults()`"
+file: /reference/method/cursor.allowPartialResults
+description: "For a find query against a sharded cluster, allows return of partial results rather than reaising error when one or more shards are unavailable."
+---
 name: ":method:`cursor.batchSize()`"
 file: /reference/method/cursor.batchSize
 description: "Controls the number of documents MongoDB will return to the client in a single network message."

--- a/source/includes/ref-toc-method-cursor.yaml
+++ b/source/includes/ref-toc-method-cursor.yaml
@@ -4,7 +4,7 @@ description: "Adds special wire protocol flags that modify the behavior of the q
 ---
 name: ":method:`cursor.allowPartialResults()`"
 file: /reference/method/cursor.allowPartialResults
-description: "For a find query against a sharded cluster, allows return of partial results rather than reaising error when one or more shards are unavailable."
+description: "For a find query against a sharded cluster, returns partial results rather than error when one or more shards are unavailable."
 ---
 name: ":method:`cursor.batchSize()`"
 file: /reference/method/cursor.batchSize

--- a/source/reference/method/cursor.allowPartialResults.txt
+++ b/source/reference/method/cursor.allowPartialResults.txt
@@ -1,0 +1,20 @@
+========================
+cursor.allowPartialResults()
+========================
+
+.. default-domain:: mongodb
+
+Definition
+----------
+
+.. method:: cursor.allowPartialResults()
+
+   For a find query against a sharded cluster, returns partial results 
+   rather than error when one or more shards are unavailable.
+
+   The :method:`~cursor.allowPartialResults()` method has the following
+   prototype form:
+
+   .. code-block:: javascript
+
+      db.collection.find(<query>).allowPartialResults()


### PR DESCRIPTION
added allowPartialResults into table of contents and created its entry under cursor methods

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2996)
<!-- Reviewable:end -->
