### PR TITLE
DOCS-10541 added two phase drop to dropDatabase command docs

### DIFF
--- a/source/reference/command/dropDatabase.txt
+++ b/source/reference/command/dropDatabase.txt
@@ -40,6 +40,11 @@ Behavior
 
 .. include:: /includes/fact-drop-database-users.rst
 
+.. versionchanged:: 3.6
+   
+   :dbcommand:`dropDatabase` waits until all collections drops in the
+   database have propagated to a majority of the replica set members.
+
 Example
 -------
 

--- a/source/release-notes/3.6.txt
+++ b/source/release-notes/3.6.txt
@@ -352,6 +352,10 @@ MongoDB 3.6 includes the following enhancements:
   The default configuration file included with Linux packages sets this
   to ``/usr/share/zoneinfo``.
 
+- :dbcommand:`dropDatabase` waits until all collections drops in the
+  database have propagated to a majority of the replica set members.
+
+
 Changes Affecting Compatibility
 -------------------------------
 


### PR DESCRIPTION
updated dropDatabase.txt and 3.6.txt with the new behavior

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/2999)
<!-- Reviewable:end -->
