### PR TITLE
DOCS-10527 added new currentOp and db.aggregate() pages

### DIFF
--- a/source/reference/command/aggregate.txt
+++ b/source/reference/command/aggregate.txt
@@ -13,10 +13,10 @@ aggregate
 .. dbcommand:: aggregate
 
    Performs aggregation operation using the :doc:`aggregation pipeline
-   </reference/operator/aggregation-pipeline>`. The pipeline allows
-   users to process data from a collection with a sequence of
+   </reference/operator/aggregation-pipeline>`. The pipeline allows users 
+   to process data from a collection or other source with a sequence of 
    stage-based manipulations.
-
+   
    The command has following syntax:
 
    .. versionchanged:: 3.6
@@ -24,7 +24,7 @@ aggregate
    .. code-block:: javascript
 
       {
-        aggregate: "<collection>",
+        aggregate: "<collection>" || 1,
         pipeline: [ <stage>, <...> ],
         explain: <boolean>,
         allowDiskUse: <boolean>,
@@ -71,8 +71,8 @@ Example
    their driver. In 2.6 and later, the
    :method:`db.collection.aggregate()` helper always returns a cursor.
 
-   Except for the first example which demonstrates the command syntax,
-   the examples in this page use the
+   Except for the first two examples which demonstrate the command 
+   syntax, the examples in this page use the
    :method:`db.collection.aggregate()` helper.
 
 Aggregate Data with Multi-Stage Pipeline
@@ -115,6 +115,37 @@ In the :program:`mongo` shell, this operation can use the
       { $unwind: "$tags" },
       { $group: { _id: "$tags", count: { $sum : 1 } } }
    ] )
+
+Use $currentOp on an Admin Database
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following example runs a pipeline with two stages on the admin
+database. The first stage runs the :pipeline:`$currentOp` operation 
+and the second stage filters the results of that operation. 
+
+.. code-block:: javascript
+
+   db.adminCommand( { 
+      aggregate : 1, 
+      pipeline : [ { 
+         $currentOp : { allUsers : true, idleConnections : true } }, { 
+         $match : { shard : "shard01" } 
+         } 
+      ], 
+      cursor : { } 
+   } )
+
+.. note::
+
+   The :dbcommand:`aggregate` command does not specify a collection and
+   instead takes the form `{aggregate: 1}`. This is because the initial 
+   :pipeline:`$currentOp` stage does not draw input from a collection. It
+   produces its own data that the rest of the pipeline uses. 
+
+   The new :method:`db.aggregate()` helper has been added to assist in
+   running collectionless aggregations such as this. The above aggregation
+   could also be run like :ref:`this <admin-pipeline-currentOp>` example.
+
    
 Return Information on the Aggregation Operation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -239,7 +270,7 @@ force the usage of the specified index:
    )
 
 Override Default Read Concern
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To override the default read concern level of :readconcern:`"local"`,
 use the ``readConcern`` option. The :dbcommand:`getMore` command uses

--- a/source/reference/method/db.aggregate.txt
+++ b/source/reference/method/db.aggregate.txt
@@ -1,0 +1,58 @@
+==============
+db.aggregate()
+==============
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. versionadded:: 3.6
+
+.. method:: db.aggregate()
+
+   Runs a specified admin/diagnostic pipeline which does not require an 
+   underlying collection. For aggregations on collection data, see
+   :method:`db.collection.aggregate()`.
+
+   The :method:`db.aggregate()` method has the following syntax:
+
+   .. code-block:: javascript
+
+      db.aggregate( [ <pipeline> ], { <options> } )
+
+   - The ``pipeline`` parameter is an array of stages to execute. It
+     must start with a compatible stage that does not require an
+     underlying collection, such as :pipeline:`$currentOp` or 
+     :pipeline:`$listLocalSessions`.
+
+   - The ``options`` document can contain the following fields and values:
+
+     .. include:: /includes/apiargs/method-db.collection.aggregate-options.rst
+
+Example
+-------
+
+.. _admin-pipeline-currentOp:
+
+Pipeline with ``$currentOp``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following example runs a pipeline with two stages. The first stage 
+runs the :pipeline:`$currentOp` operation and the second stage filters the
+results of that operation. 
+
+.. code-block:: javascript
+
+   use admin
+   db.aggregate( [ { 
+      $currentOp : { allUsers: true, idleConnections: true } }, { 
+      $match : { shard: "shard01" } 
+      }
+   ] } )

--- a/source/reference/operator/aggregation/currentOp.txt
+++ b/source/reference/operator/aggregation/currentOp.txt
@@ -1,0 +1,104 @@
+========================
+$currentOp (aggregation)
+========================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. versionadded:: 3.6
+
+.. pipeline:: $currentOp
+
+   Returns a stream of documents containing information on active
+   and/or dormant operations for the MongoDB deployment. To run
+   :pipeline:`$currentOp`, use the :method:`db.aggregate()` helper
+   on the ``admin`` database.
+
+   :pipeline:`$currentOp` offers a better alternative to the
+   :dbcommand:`currentOp` command and the :method:`db.currentOp` method.
+   The latter two commands are limited to returning all operations in 
+   a single document, which must not exceed the maximum 16MB BSON size. 
+   Since :pipeline:`$currentOp` pipelines return a cursor, they are not 
+   subject to these limitations. 
+
+   :pipeline:`$currentOp` also enables you to perform arbitrary
+   transformations of the results as the documents pass through the 
+   pipeline.
+
+   :pipeline:`$currentOp` takes an options document as its operand. 
+
+   .. code-block:: javascript
+
+      { $currentOp: { allUsers: <boolean>, idleConnections: <boolean> } }
+
+   Specify an empty document to use the default values.
+
+Behavior
+--------
+
+.. list-table::
+   :header-rows: 1
+ 
+   * - Option
+     - Description
+
+   * - ``allUsers``
+     - |
+       Boolean. If set to ``false``, :pipeline:`$currentOp` will only 
+       report operations belonging to the user who ran the command. 
+       If set to ``true``, :pipeline:`$currentOp` will report operations 
+       belonging to all users. 
+
+       .. note::
+
+          The ``inprog`` privilege is necessary to run 
+          :pipeline:`$currentOp` with ``{ allUsers : true }``.
+
+       Defaults to ``false``.
+
+   * - ``idleConnections``
+     - |
+       Boolean. If set to ``false``, :pipeline:`$currentOp` will 
+       only report active operations. If set to ``true``, all 
+       operations including idle connections will be returned.
+
+       Defaults to ``false``.
+
+Constraints
+-----------
+
+- :pipeline:`$currentOp` must be the first stage in the pipeline.
+
+- Pipelines that start with :pipeline:`$currentOp` can only be run on 
+  the ``admin`` database.
+
+- On a standalone or replica set with authentication enabled, the 
+  ``inprog`` privilege is required to run :pipeline:`$currentOp` if 
+  the ``allUsers`` parameter is set to `true`. 
+
+- On a sharded cluster, the ``inprog`` privilege is required to run 
+  all :pipeline:`$currentOp` pipelines.
+
+Example
+-------
+
+The following example runs the :pipeline:`$currentOp` operation
+in the first stage and filters the results of that operation in the
+second stage.
+
+.. code-block:: javascript
+
+   use admin
+   db.aggregate( [ { 
+      $currentOp : { allUsers: true, idleConnections: true } }, { 
+      $match : { shard: "shard01" } 
+      }
+   ] } )

--- a/source/release-notes/3.6.txt
+++ b/source/release-notes/3.6.txt
@@ -113,6 +113,20 @@ New Aggregation Operators
      - Allows the use of aggregation expressions within the
        query language.
 
+   * - :pipeline:`$currentOp`
+
+     - Returns a stream of documents containing information 
+       on active and/or dormant operations on a :program:`mongod` 
+       instance.
+
+New Aggregation Helper
+~~~~~~~~~~~~~~~~~~~~
+
+MongoDB 3.6 adds a helper, :method:`db.aggregate()`, to perform 
+aggregations that do not rely on an underlying collection, such 
+as those that start with :pipeline:`$currentOp` or 
+:pipeline:`$listLocalSessions`.
+
 New Aggregation Variable
 ~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Added pages for a new aggregation stage, $currentOp, and the db.aggregate() helper. The latter helps facilitate collectionless aggregations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3000)
<!-- Reviewable:end -->
