### PR TITLE
Fix typo in tutorial rotate-log-files

### DIFF
--- a/source/includes/steps-log-rotate-rename.yaml
+++ b/source/includes/steps-log-rotate-rename.yaml
@@ -6,7 +6,7 @@ action:
   code: |
     mongod -v --logpath /var/log/mongodb/server1.log
 post: |
-  You can also explicitly specify :option:`logRotate --rename
+  You can also explicitly specify :option:`--logRotate rename
   <--logRotate>`.
 ---
 stepnum: 2


### PR DESCRIPTION
"logRotate --rename" should be "--logRotate rename"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3003)
<!-- Reviewable:end -->
