### PR TITLE
DOCS-10272: According to the Jira, I changed the definition of caseFi…

### DIFF
--- a/source/includes/apiargs-option-collation-fields.yaml
+++ b/source/includes/apiargs-option-collation-fields.yaml
@@ -126,7 +126,7 @@ description: |
           for details of differences.
 
 optional: true
-type: boolean
+type: string
 interface: option
 operation: collation
 ---


### PR DESCRIPTION
…rst from boolean to string in the table describing the option.

This is a simple type change. I checked the type before making the change and it is correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3007)
<!-- Reviewable:end -->
