### PR TITLE
DOCS-10527 switched currentOp from operators to stages section

### DIFF
--- a/source/release-notes/3.6.txt
+++ b/source/release-notes/3.6.txt
@@ -74,6 +74,12 @@ following new aggregation pipeline stages:
 
      - Lists sessions cached in memory by the server.
 
+   * - :pipeline:`$currentOp`
+
+     - Returns a stream of documents containing information 
+       on active and/or dormant operations on a :program:`mongod` 
+       instance.
+
 New Aggregation Operators
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -112,12 +118,6 @@ New Aggregation Operators
 
      - Allows the use of aggregation expressions within the
        query language.
-
-   * - :pipeline:`$currentOp`
-
-     - Returns a stream of documents containing information 
-       on active and/or dormant operations on a :program:`mongod` 
-       instance.
 
 New Aggregation Helper
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
$currentOp was mistakenly listed under aggregation operators, not stages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3015)
<!-- Reviewable:end -->
