### PR TITLE
DOCS-10225: Clarify compression and filesystem vs WT internal cache

### DIFF
--- a/source/includes/extracts-wired-tiger.yaml
+++ b/source/includes/extracts-wired-tiger.yaml
@@ -144,6 +144,26 @@ content: |
 
    .. include:: /includes/extracts/wt-cache-default-setting.rst
 
+   By default, WiredTiger uses Snappy block compression for all collections
+   and prefix compression for all indexes. Compression defaults are configurable
+   at a global level and can also be set on a per-collection and per-index
+   basis during collection and index creation.
+
+   Different representations are used for data in the WiredTiger internal cache
+   versus the on-disk format:
+
+   - Data in the filesystem cache is the same as the on-disk format, including
+     benefits of any compression for data files. The filesystem cache is used
+     by the operating system to reduce disk I/O.
+   - Indexes loaded in the WiredTiger internal cache have a different data
+     representation to the on-disk format, but can still take advantage of
+     index prefix compression to reduce RAM usage. Index prefix compression
+     deduplicates common prefixes from indexed fields.
+   - Collection data in the WiredTiger internal cache is uncompressed
+     and uses a different representation from the on-disk format. Block
+     compression can provide significant on-disk storage savings, but
+     data must be uncompressed to be manipulated by the server.
+
    .. include:: /includes/extracts/wt-filesystem-cache.rst
 ---
 ref: wt-cache-default-setting
@@ -159,8 +179,7 @@ content: |
 ref: wt-filesystem-cache
 content: |
   Via the filesystem cache, MongoDB automatically uses all free memory
-  that is not used by the WiredTiger cache or by other processes. Data
-  in the filesystem cache is compressed.
+  that is not used by the WiredTiger cache or by other processes.
 ---
 ref: wt-snapshot-frequency
 content: |


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3017)
<!-- Reviewable:end -->
