### PR TITLE
DOCS-10605 - Make catchup takeover timeout configurable

### DIFF
--- a/source/reference/replica-configuration.txt
+++ b/source/reference/replica-configuration.txt
@@ -502,6 +502,47 @@ Replica Set Configuration Fields
 
       The setting only applies when using :rsconf:`protocolVersion: 1`.
 
+   .. _repl-conf-catchup-takeover-delay:
+
+   .. rsconf::  settings.catchUpTakeoverDelayMillis
+
+      .. versionadded:: 3.6
+
+      *Optional*.
+
+      *Type*: int
+
+      *Default*: 30000 (30 seconds)
+
+      Time in milliseconds a node waits to initiate a
+      *catchup takeover* after determining it is ahead of the current
+      :term:`primary`. During a catchup takeover, the node ahead of the
+      current primary initiates an :term:`election` to become the new
+      primary of the :term:`replica set`.
+
+      After the node initiating the takeover determines that it is
+      ahead of the current :term:`primary`, it waits the specified
+      number of milliseconds and then verifies the following:
+
+      1. It is still ahead of the current primary,
+
+      #. It is the most up-to-date node among all available nodes,
+
+      #. The current primary is currently catching up to it.
+
+      Once determining that all of these conditions are met, the node
+      initiating the takeover immediately runs for election.
+
+      For more information on Replica
+      Set Elections, see :doc:`/core/replica-set-elections/`.
+
+      .. note::
+
+         Setting ``catchUpTakeoverDelayMillis`` to ``-1`` disables
+         catchup takeover. Setting :rsconf:`catchUpTimeoutMillis` to
+         ``0`` disables *primary catchup* and consequently also catchup
+         takeover.
+
    .. rsconf::  settings.heartbeatIntervalMillis
 
       .. versionadded:: 3.2

--- a/source/release-notes/3.6.txt
+++ b/source/release-notes/3.6.txt
@@ -289,6 +289,12 @@ Replica Sets
   resize a replica set member's oplog. Available for instances running
   the WiredTiger storage engine.
 
+- Added the
+  :ref:`catchUpTakeoverDelayMillis <repl-conf-catchup-takeover-delay>`
+  configuration option, dictating the amount of time a node waits to
+  run for election after determining that it is ahead of the current
+  :term:`primary`.
+
 - For replica sets that use the protocol version 1 (``pv1``), arbiters
   will vote no in elections if they detect a healthy primary of equal
   or greater priority to the candidate. For more information on replica


### PR DESCRIPTION
Documenting catchup takeover timeout as a repl config option.

Code review: https://mongodbcr.appspot.com/164260001/

Staging: https://docs-mongodbcom-staging.corp.mongodb.com/jeffreyallen/DOCS-10605/reference/replica-configuration.html#replica-set-configuration-fields

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3027)
<!-- Reviewable:end -->
