### PR TITLE
Typo in description of `findOneAndUpdate` example

### DIFF
--- a/source/reference/method/db.collection.findOneAndUpdate.txt
+++ b/source/reference/method/db.collection.findOneAndUpdate.txt
@@ -126,7 +126,7 @@ The ``grades`` collection contains documents similar to the following:
    { _id: 6322, name : "A. MacDyver", "assignment" : 2, "points" : 14 },
    { _id: 6234, name : "R. Stiles", "assignment" : 1, "points" : 10 }
 
-The following operation updates a document where ``name : "A. MacGyver"``.  The
+The following operation updates a document where ``name : "A. MacDyver"``.  The
 operation sorts the matching documents by ``points`` ascending to update the
 matching document with the least points. 
 


### PR DESCRIPTION
It appears to be a typo as in all examples the name `A. MacDyver` is used, but in one occurrence `A. MacGyver` is used instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3029)
<!-- Reviewable:end -->
