### PR TITLE
DOCSP-1008: 3.6: adds examples to positional-filtered and positional-all operators

### DIFF
--- a/source/reference/operator/update/positional-all.txt
+++ b/source/reference/operator/update/positional-all.txt
@@ -214,6 +214,42 @@ After the operation, the collection has the following documents:
       ]
    }
 
+Update Arrays Specified Using a Negation Query Operator
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Consider a collection ``results`` with the following documents:
+
+.. code-block:: javascript
+
+   { "_id" : 1, "grades" : [ 85, 82, 80 ] }
+   { "_id" : 2, "grades" : [ 88, 90, 92 ] }
+   { "_id" : 3, "grades" : [ 85, 100, 90 ] }
+
+To increment all elements in the ``grades`` array by ``10`` for all
+documents **except** those with the value ``100`` in the ``grades``
+array, use the all positional :update:`$[]` operator:
+
+.. cssclass:: copyable-code
+
+.. code-block:: javascript
+
+   db.results.update(
+      { "grades" : { $ne: 100 } },
+      { $inc: { "grades.$[]": 10 } },
+      { multi: true }
+   )
+
+The all positional :update:`$[]` operator acts as a
+placeholder for all elements in the array field.
+
+After the operation, the ``students`` collection contains the following
+documents:
+
+.. code-block:: javascript
+
+   { "_id" : 1, "grades" : [ 95, 92, 90 ] }
+   { "_id" : 2, "grades" : [ 98, 100, 102 ] }
+   { "_id" : 3, "grades" : [ 85, 100, 90 ] }
 
 .. _position-nested-arrays:
 

--- a/source/reference/operator/update/positional-filtered.txt
+++ b/source/reference/operator/update/positional-filtered.txt
@@ -55,14 +55,59 @@ Behavior
 ``upsert``
 ~~~~~~~~~~~
 
-
 If an :term:`upsert` operation results in an insert, the ``query`` must
 include an :ref:`exact equality match <array-match-exact>` on the array
 field in order to use ``$[<identifier>]`` in the update statement.
 
+For example, the following upsert operation, which uses ``$[<identifier>]``
+in the update document, specifies an exact equality match condition
+on the array field:
+
+.. cssclass:: copyable-code
+
+.. code-block:: javascript
+
+   db.collection.update(
+      { myArray: [ 0, 1 ] },
+      { $set: { "myArray.$[element]": 2 } },
+      { arrayFilters: [ { element: 0 } ],
+        upsert: true }
+   )
+
+If no such document exists, the operation would result in an insert of
+a document that resembles the following:
+
+.. code-block:: javascript
+
+   { "_id" : ObjectId(...), "myArray" : [ 2, 1 ] }
+
 If the upsert operation did not include an exact equality match and no
 matching documents were found to update, the upsert operation would
-error.
+error. For example, the following operations would error
+if no matching documents were found to update:
+
+.. code-block:: javascript
+
+   db.array.update(
+      { }, 
+      { $set: { "myArray.$[element]": 10 } },
+      { arrayFilters: [ { element: 9 } ], 
+        upsert: true }
+   )
+
+The operation would return an error that resembles the following:
+
+.. code-block:: javascript
+
+   WriteResult({
+      "nMatched" : 0,
+      "nUpserted" : 0,
+      "nModified" : 0,
+      "writeError" : {
+         "code" : 2,
+         "errmsg" : "The path 'myArray' must exist in the document in order to apply array updates."
+      }
+   })
 
 Nested Arrays
 ~~~~~~~~~~~~~
@@ -253,6 +298,99 @@ After the operation, the collection has the following documents:
          { "grade" : 87, "mean" : 100, "std" : 3 },
          { "grade" : 85, "mean" : 100, "std" : 4 }
       ]
+   }
+
+Update Array Elements Using a Negation Operator
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Consider a collection ``alumni`` with the following documents:
+
+.. code-block:: javascript
+
+   {
+      "_id": 1,
+      "name": "Christine Franklin",
+      "degrees": [
+         { "level": "Master",
+           "major": "Biology",
+           "completion_year": 2010,
+           "faculty": "Science"
+         },
+         {
+           "level": "Bachelor",
+           "major": "Biology",
+           "completion_year": 2008,
+           "faculty": "Science"
+         }
+      ],
+      "school_email": "cfranklin@example.edu",
+      "email": "christine@example.com"
+   }
+   {
+      "_id": 2,
+      "name": "Reyansh Sengupta",
+      "degrees": [
+         { "level": "Bachelor",
+           "major": "Chemical Engineering",
+           "completion_year": 2002,
+           "faculty": "Engineering"
+         }
+      ],
+      "school_email": "rsengupta2@example.edu"
+   }
+   
+To modify all elements in the ``degrees`` array that do not have 
+``"level": "Bachelor"``, use the positional :update:`[<identifier>]`
+operation with the :query:`$ne` query operator:
+
+.. cssclass:: copyable-code
+
+.. code-block:: javascript
+
+   db.alumni.update(
+      { },
+      { $set : { "degrees.$[degree].gradcampaign" : 1 } },
+      { arrayFilters : [ {"degree.level" : { $ne: "Bachelor" } } ],
+        multi : true }
+   )
+
+After the operation, the collection has the following documents:
+
+.. code-block:: javascript
+
+   {
+      "_id" : 1,
+      "name" : "Christine Franklin",
+      "degrees" : [
+         {
+            "level" : "Master",
+            "major" : "Biology",
+            "completion_year" : 2010,
+            "faculty" : "Science",
+            "gradcampaign" : 1
+         },
+         {
+            "level" : "Bachelor",
+            "major" : "Biology",
+            "completion_year" : 2008,
+            "faculty" : "Science"
+         }
+      ],
+      "school_email" : "cfranklin@example.edu",
+      "email" : "christine@example.com"
+   }
+   {
+      "_id" : 2,
+      "name" : "Reyansh Sengupta",
+      "degrees" : [
+         {
+            "level" : "Bachelor",
+            "major" : "Chemical Engineering",
+            "completion_year" : 2002,
+            "faculty" : "Engineering"
+         }
+      ],
+      "school_email" : "rsengupta2@example.edu"
    }
 
 .. _position-nested-arrays-filtered:


### PR DESCRIPTION
- Adds upsert example to positional-filtered
- Adds negation examples to both positional operators

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3030)
<!-- Reviewable:end -->
