### PR TITLE
DOCS-9751: Regarding the TCP keepalive setting on Azure

### DIFF
--- a/source/administration/production-checklist-operations.txt
+++ b/source/administration/production-checklist-operations.txt
@@ -162,14 +162,14 @@ Deployments to Cloud Hardware
 .. cssclass:: checklist
 
    - Windows Azure: Adjust the TCP keepalive (``tcp_keepalive_time``) to
-     100-120. The default TTL for TCP connections on Windows Azure load
-     balancers is too slow for MongoDB's connection pooling behavior.
+     100-120. The TCP idle timeout on the Azure load balancer is too
+     slow for MongoDB's connection pooling behavior. See:
+     :ref:`Azure Production Notes <windows-azure-production-notes>`
+     for more information.
 
    - Use MongoDB version 2.6.4 or later on systems with high-latency
      storage, such as Windows Azure, as these versions include
-     performance improvements for those systems. See: :ecosystem:`Azure
-     Deployment Recommendations </platforms/windows-azure>` for more
-     information.
+     performance improvements for those systems.
 
 Operating System Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/administration/production-notes.txt
+++ b/source/administration/production-notes.txt
@@ -783,10 +783,14 @@ restart :program:`mongod` at any time following this event.
 The performance characteristics of MongoDB may change with
 ``READ/WRITE`` caching enabled.
 
-The TCP keepalive on the Azure load balancer is 240 seconds by
+The TCP idle timeout on the Azure load balancer is 240 seconds by
 default, which can cause it to silently drop connections if the TCP
 keepalive on your Azure systems is greater than this value.  You
 should set ``tcp_keepalive_time`` to 120 to ameliorate this problem.
+
+.. note::
+   You will need to restart :program:`mongod` and :program:`mongos`
+   processes for new system-wide keepalive settings to take effect.
 
 .. include:: /includes/fact-tcp-keepalive-linux.rst
 


### PR DESCRIPTION
 - adjust wording per https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-tcp-idle-timeout
 - link Production Checklist directly to production notes on Azure instead of ecosystem => production notes
 - add note that `mongod`/`mongos` restart is required after changing `tcp_keep_alive`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3035)
<!-- Reviewable:end -->
