### PR TITLE
DOCS-10463: Mongorestore documentation for objcheck is misleading

### DIFF
--- a/source/includes/options-bsondump.yaml
+++ b/source/includes/options-bsondump.yaml
@@ -39,11 +39,6 @@ description: |
   format. By default, {{program}} enables {{role}}.
   For objects with a high degree of sub-document nesting,
   {{role}} can have a small impact on performance.
-
-  .. versionchanged:: 2.4
-     MongoDB enables {{role}} by default, to prevent any
-     client from inserting malformed or invalid BSON into a MongoDB
-     database.
 optional: true
 ---
 program: bsondump

--- a/source/includes/options-mongorestore.yaml
+++ b/source/includes/options-mongorestore.yaml
@@ -197,11 +197,6 @@ description: |
   upon receipt to ensure that clients never insert invalid documents into
   the database. For objects with a high degree of sub-document nesting,
   {{role}} can have a small impact on performance.
-
-  .. versionchanged:: 2.4
-     MongoDB enables {{role}} by default, to prevent any
-     client from inserting malformed or invalid BSON into a MongoDB
-     database.
 optional: true
 ---
 program: mongorestore


### PR DESCRIPTION
`--objcheck` is an option for `mongorestore` and `bsondump`. The versionchanged annotation is incorrectly conflating the tool options (disabled by default) with the change to BSON validation in the MongoDB server (enabled by default as of MongoDB 2.4).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3036)
<!-- Reviewable:end -->
