### PR TITLE
DOCS-10924: emphasize what happens when the field doesn't exist for $type

### DIFF
--- a/source/reference/operator/aggregation/type.txt
+++ b/source/reference/operator/aggregation/type.txt
@@ -98,6 +98,9 @@ Available Types
 
 .. include:: /includes/fact-bson-types.rst
 
+If the argument is a field that is missing in the input document,
+:expression:`$type` returns the string ``"missing"``.
+
 Example
 -------
 


### PR DESCRIPTION
A user missed the `"missing"` explanation earlier on in the page, so I'm just stating it again under the BSON types table (where he looked for it).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3039)
<!-- Reviewable:end -->
