### PR TITLE
DOCS-10862 dates coerced into strings differently

### DIFF
--- a/source/release-notes/3.6-compatibility.txt
+++ b/source/release-notes/3.6-compatibility.txt
@@ -301,6 +301,45 @@ For more information on sorting with the
 :doc:`Aggregation Pipeline </reference/operator/aggregation/>`, see
 :doc:`$sort </reference/operator/aggregation/sort/>`.
 
+Aggregation Date to String Coercion
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Starting in 3.6, a date coerced to a string in an aggregation expression will
+include milliseconds and is appended with the letter 'Z'.
+
+.. example::
+
+   .. code-block:: javascript
+
+      // Documents.
+      {_id: 0, d: ISODate("2017-10-18T20:04:27.978Z")}
+      {_id: 1, d: ISODate("2017-10-18T20:04:28.192Z")}
+
+      // Query.
+      db.coll.aggregate({$project: {d: {$toLower: "$d"}}})
+
+Prior to 3.6, this would return the dates as ``d: "2017-10-18t20:04:27"`` and
+``d: "2017-10-18t20:04:28"`` respectively. In 3.6, the results include the
+milliseconds and letter 'Z': ``d: "2017-10-18t20:04:27.978z"`` and ``d:
+"2017-10-18t20:04:28.192z"``.
+
+The change applies to the following aggregation operators:
+
+- :expression:`$concat`
+
+- :expression:`$substr`
+
+- :expression:`$substrBytes`
+
+- :expression:`$substrCP`
+
+- :expression:`$strcasecmp`
+
+- :expression:`$toLower`
+
+- :expression:`$toUpper`
+
+
 .. _3.6-index-asterisk:
 
 Indexes Named ``*``


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3040)
<!-- Reviewable:end -->
