### PR TITLE
DOCS-9901: Add restriction to compound index: text fields must be adjacent

### DIFF
--- a/source/includes/fact-compound-index-with-text-restrictions.rst
+++ b/source/includes/fact-compound-index-with-text-restrictions.rst
@@ -6,3 +6,5 @@
   ``text`` index key, to perform a :query:`$text` search, the query
   predicate must include **equality match conditions** on the preceding
   keys.
+
+- When creating a compound index all ``text`` fields must be adjacent.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3042)
<!-- Reviewable:end -->
