### PR TITLE
DOCS-10228 intra cluster compression is not on by default in 3.4.6

### DIFF
--- a/source/includes/options-mongod.yaml
+++ b/source/includes/options-mongod.yaml
@@ -2639,6 +2639,7 @@ description: |
 
    .. include:: /includes/fact-networkMessageCompressors.rst
 
+   Intra-cluster compression is on by default.
 
 optional: true
 ---

--- a/source/release-notes/3.6.txt
+++ b/source/release-notes/3.6.txt
@@ -411,6 +411,8 @@ Commands
 - :dbcommand:`dropDatabase` waits until all collections drops in the
   database have propagated to a majority of the replica set members.
 
+- Intra-cluster compression is on by default in 3.6.
+
 Changes Affecting Compatibility
 -------------------------------
 


### PR DESCRIPTION
Ticket didn't make it through code review while on Docs rotation, currently being reviewed by Jonathan Reams.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3047)
<!-- Reviewable:end -->
