### PR TITLE
DOCS-10608, DOCS-9825 - Updates to batch size limit.

### DIFF
--- a/source/includes/fact-bulkwrite-operation-batches.rst
+++ b/source/includes/fact-bulkwrite-operation-batches.rst
@@ -1,9 +1,28 @@
-Each group of operations can have at most 
-:limit:`1000 operations <Write Command Operation Limit Size>`. 
-If a group exceeds this :limit:`limit<Write Command Operation Limit Size>`, 
-MongoDB will divide the group into
-smaller groups of 1000 or less. For example, if the queue consists of 2000 
-operations, MongoDB creates 2 groups, each with 1000 operations.
+The number of operations in each group cannot exceed the value of
+the :limit:`maxWriteBatchSize <Write Command Batch Limit Size>` of
+the database. As of MongoDB 3.6, this value is ``100,000``.
+This value is shown in the :data:`isMaster.maxWriteBatchSize` field.
+
+This limit prevents issues with oversized error messages. If a group
+exceeds this :limit:`limit<Write Command Operation Limit Size>`,
+the client driver divides the group into smaller groups with counts
+less than or equal to the value of the limit. For example, with the
+``maxWriteBatchSize`` value of ``100,000``, if the queue consists of
+``200,000`` operations, the driver creates 2 groups, each with
+``100,000`` operations.
+
+.. note::
+
+   The driver only divides the group into smaller groups when using
+   the high-level API. If using
+   :doc:`db.runCommand() </reference/method/db.runCommand/>` directly
+   (for example, when writing a driver), MongoDB throws an error when
+   attempting to execute a write batch which exceeds the limit.
+
+Starting in MongoDB 3.6, once the error report for a single batch grows
+too large, MongoDB truncates all remaining error messages to the empty
+string. Currently, begins once there are at least 2 error messages with
+total size greater than ``1MB``.
 
 The sizes and grouping mechanics are internal performance details and
 are subject to change in future versions.

--- a/source/reference/command/isMaster.txt
+++ b/source/reference/command/isMaster.txt
@@ -83,6 +83,23 @@ roles:
    The maximum permitted size of a :term:`BSON` wire protocol message.
    The default value is ``48000000`` bytes.
 
+.. data:: isMaster.maxWriteBatchSize
+
+   .. versionadded:: 2.6
+
+   The maximum number of write operations permitted in a write batch.
+   If a batch exceeds this
+   :limit:`limit<Write Command Batch Limit Size>`, the client
+   driver divides the batch into smaller groups each with counts less
+   than or equal to the value of this field.
+
+   The value of this limit is ``100,000`` writes.
+
+   .. versionchanged:: 3.6
+
+      The limit raises from ``1,000`` to ``100,000`` writes. This limit
+      also applies to legacy ``OP_INSERT`` messages.
+
 .. data:: isMaster.localTime
 
    Returns the local server time in UTC. This value is an

--- a/source/reference/limits.txt
+++ b/source/reference/limits.txt
@@ -389,10 +389,18 @@ Operations
 
    .. include:: /includes/fact-geometry-hemisphere-limitation.rst
 
-.. limit:: Write Command Operation Limit Size
+.. limit:: Write Command Batch Limit Size
 
-   :doc:`Write commands </reference/command/nav-crud>` can accept no
-   more than 1000 operations. The :method:`Bulk()` operations in the
+   ``100,000`` :doc:`writes </reference/command/nav-crud>` are
+   allowed in a single batch operation, defined by a single request to
+   the server.
+
+   .. versionchanged:: 3.6
+
+      The limit raises from ``1,000`` to ``100,000`` writes. This limit
+      also applies to legacy ``OP_INSERT`` messages.
+
+   The :method:`Bulk()` operations in the
    :program:`mongo` shell and comparable methods in the drivers do not
    have this limit.
 

--- a/source/release-notes/3.6.txt
+++ b/source/release-notes/3.6.txt
@@ -353,7 +353,7 @@ MongoDB 3.6 includes the following enhancements:
   for :program:`mongod` only. See :ref:`param-ftdc`.
 
   .. note:: FTDC is enabled by default.
-  
+
 - :program:`mongod` now offers a :option:`--timeZoneInfo` option. Use
   this option to specify the path to your system time zone database.
   The default configuration file included with Linux packages sets this
@@ -373,6 +373,10 @@ MongoDB 3.6 includes the following enhancements:
   </reference/mongodb-wire-protocol>` opcode called :ref:`wire-op-msg`.
   This opcode's message format is extensible and designed to subsume
   the functionality of other opcodes.
+
+- The :limit:`maxWriteBatchSize <Write Command Batch Limit Size>` limit
+  of a database, indicating the maximum number of write operating
+  permitted in a write batch, raises from ``1,000`` to ``100,000``.
 
 Indexes
 ~~~~~~~


### PR DESCRIPTION
Documenting change raising batch size limit from 1000 to 100000. Also adding documentation for maxWriteBatchSize field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3051)
<!-- Reviewable:end -->
