### PR TITLE
DOCS-9454: Limit total memory utilization for bulk index builds

### DIFF
--- a/source/core/index-creation.txt
+++ b/source/core/index-creation.txt
@@ -97,6 +97,10 @@ method for your driver <>` and terminates if the proper indexes do not
 exist. Always build indexes in production instances using separate
 application code, during designated maintenance windows.
 
+.. versionchanged:: 3.4
+
+   .. include:: /includes/fact-index-build-default-memory-limit.rst
+
 Interrupted Index Builds
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/includes/fact-index-build-default-memory-limit.rst
+++ b/source/includes/fact-index-build-default-memory-limit.rst
@@ -1,0 +1,14 @@
+You can build one or more indexes on a collection with the database
+command :dbcommand:`createIndexes`. The default limit on memory usage
+for a :dbcommand:`createIndexes` operation is
+500 megabytes. You can override this limit by setting the
+:parameter:`maxIndexBuildMemoryUsageMegabytes` server parameter.
+
+:dbcommand:`createIndexes` uses a combination of memory and
+temporary files on disk to complete index builds. Once
+the memory limit is reached, :dbcommand:`createIndexes` uses
+temporary disk files in a subdirectory named ``_tmp`` within the
+:option:`--dbpath` directory for additional scratch space. The higher
+the memory limit is set, the faster the index build can complete, but
+be careful not to set this limit too high relative to available RAM or
+your system can run out of free memory.

--- a/source/includes/fact-index-build-memory-limit.rst
+++ b/source/includes/fact-index-build-memory-limit.rst
@@ -1,0 +1,13 @@
+Foreground index builds may be initiated either by a user command
+such as :doc:`Create Index </reference/method/db.collection.createIndex/>`
+or by an administrative process such as an
+:doc:`initial sync </core/replica-set-sync>`.
+Both are subject to the limit set by
+:parameter:`maxIndexBuildMemoryUsageMegabytes`.
+
+An :doc:`initial sync operation </core/replica-set-sync>` populates
+only one collection at a time and has no risk of exceeding the memory
+limit. However, it is possible for a user to start foreground index
+builds on multiple collections in multiple databases simultaneously
+and potentially consume an amount of memory greater than the limit
+set in :parameter:`maxIndexBuildMemoryUsageMegabytes`.

--- a/source/reference/command/createIndexes.txt
+++ b/source/reference/command/createIndexes.txt
@@ -89,6 +89,14 @@ command, the operation only scans the collection once, and if at least
 one index is to be built in the foreground, the operation will build
 all the specified indexes in the foreground.
 
+Memory Usage Limit
+~~~~~~~~~~~~~~~~~~
+
+.. versionchanged:: 3.4
+
+   .. include:: /includes/fact-index-build-default-memory-limit.rst
+
+
 Index Options
 ~~~~~~~~~~~~~
 

--- a/source/reference/limits.txt
+++ b/source/reference/limits.txt
@@ -210,6 +210,12 @@ Indexes
 
    .. include:: /includes/fact-geospatial-index-covered-query.rst
 
+.. limit:: Memory Usage in Foreground Index Builds
+
+   .. include:: /includes/fact-index-build-default-memory-limit.rst
+
+   .. include:: /includes/fact-index-build-memory-limit.rst
+
 Data
 ----
 

--- a/source/reference/parameters.txt
+++ b/source/reference/parameters.txt
@@ -526,6 +526,18 @@ General Parameters
 
       mongod --setParameter disableJavaScriptJIT=true
 
+.. parameter:: maxIndexBuildMemoryUsageMegabytes
+
+   .. versionadded:: 3.4
+
+   *Default*: 500
+
+   Limits the amount of memory that simultaneous foreground index
+   builds on one collection may consume for the duration of the
+   builds.
+
+   .. include:: /includes/fact-index-build-memory-limit.rst
+
 Logging Parameters
 ~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
https://mongodbcr.appspot.com/169250002/

For both 3.4 and 3.6 manuals

No release notes for this one, since it's all 3.4 material.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3054)
<!-- Reviewable:end -->
