### PR TITLE
DOCS-10935: hacky solution to make non-linking methods link

### DIFF
--- a/source/includes/ref-toc-method-connection.yaml
+++ b/source/includes/ref-toc-method-connection.yaml
@@ -1,4 +1,4 @@
-name: ":method:`connect()`"
+name: ":doc:`/reference/method/connect`"
 file: /reference/method/connect
 description: "Connects to a MongoDB instance and to a specified database on that instance."
 ---

--- a/source/includes/ref-toc-method-constructor.yaml
+++ b/source/includes/ref-toc-method-constructor.yaml
@@ -22,7 +22,7 @@ name: ":method:`ObjectId.valueOf()`"
 file: /reference/method/ObjectId.valueOf
 description: "Displays the ``str`` attribute of an ObjectId as a hexadecimal string."
 ---
-name: ":method:`UUID()`"
+name: ":doc:`/reference/method/UUID`"
 file: /reference/method/UUID
 description: "Converts a 32-byte hexadecimal string to the UUID BSON subtype."
 ---

--- a/source/includes/ref-toc-method-native.yaml
+++ b/source/includes/ref-toc-method-native.yaml
@@ -1,8 +1,8 @@
-name: ":method:`cat()`"
+name: ":doc:`/reference/method/cat`"
 file: /reference/method/cat
 description: "Returns the contents of the specified file."
 ---
-name: ":method:`cd()`"
+name: ":doc:`/reference/method/cd`"
 file: /reference/method/cd
 description: "Changes the current working directory to the specified path."
 ---
@@ -22,7 +22,7 @@ name: ":method:`getMemInfo()`"
 file: /reference/method/getMemInfo
 description: "Returns a document that reports the amount of memory used by the shell."
 ---
-name: ":method:`hostname()`"
+name: ":doc:`/reference/method/hostname`"
 file: /reference/method/hostname
 description: "Returns the hostname of the system running the shell."
 ---
@@ -30,11 +30,11 @@ name: ":method:`listFiles()`"
 file: /reference/method/listFiles
 description: "Returns an array of documents that give the name and size of each object in the directory."
 ---
-name: ":method:`load()`"
+name: ":doc:`/reference/method/load`"
 file: /reference/method/load
 description: "Loads and runs a JavaScript file in the shell."
 ---
-name: ":method:`ls()`"
+name: ":doc:`/reference/method/ls`"
 file: /reference/method/ls
 description: "Returns a list of the files in the current directory."
 ---
@@ -42,15 +42,15 @@ name: ":method:`md5sumFile()`"
 file: /reference/method/md5sumFile
 description: "The :term:`md5` hash of the specified file."
 ---
-name: ":method:`mkdir()`"
+name: ":doc:`/reference/method/mkdir`"
 file: /reference/method/mkdir
 description: "Creates a directory at the specified path."
 ---
-name: ":method:`pwd()`"
+name: ":doc:`/reference/method/pwd`"
 file: /reference/method/pwd
 description: "Returns the current directory."
 ---
-name: ":method:`quit()`"
+name: ":doc:`/reference/method/quit`"
 file: /reference/method/quit
 description: "Exits the current shell session."
 ---
@@ -62,7 +62,7 @@ name: ":method:`resetDbpath()`"
 file: /reference/method/resetDbpath
 description: "Removes a local :setting:`~storage.dbPath`. For internal use."
 ---
-name: ":method:`sleep()`"
+name: ":doc:`/reference/method/sleep`"
 file: /reference/method/sleep
 description: "Suspends the :program:`mongo` shell for a given period of time."
 ---
@@ -70,7 +70,7 @@ name: ":method:`setVerboseShell()`"
 file: /reference/method/setVerboseShell
 description: "Configures the :program:`mongo` shell to report operation timing."
 ---
-name: ":method:`version()`"
+name: ":doc:`/reference/method/version`"
 file: /reference/method/version
 description: "Returns the current version of the :program:`mongo` shell instance."
 ---

--- a/source/includes/ref-toc-method-subprocess.yaml
+++ b/source/includes/ref-toc-method-subprocess.yaml
@@ -6,7 +6,7 @@ name: ":method:`rawMongoProgramOutput()`"
 file: /reference/method/rawMongoProgramOutput
 description: "For internal use."
 ---
-name: ":method:`run()`"
+name: ":doc:`/reference/method/run`"
 file: /reference/method/run
 description: "For internal use."
 ---
@@ -18,7 +18,7 @@ name: ":method:`runProgram()`"
 file: /reference/method/runProgram
 description: "For internal use."
 ---
-name: ":method:`startMongoProgram()`"
+name: ":doc:`/reference/method/startMongoProgram`"
 file: /reference/method/startMongoProgram
 description: "For internal use."
 ---


### PR DESCRIPTION
For whatever reason, giza/sphinx isn't building links for a bunch of methods. This is a hacky solution to make the links display on the /reference/methods page (though they're not literals, it seems more practical to have a link and no-monospace than the alternative). It doesn't seem worth the effort to figure out why sphinx is behaving weirdly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3056)
<!-- Reviewable:end -->
