### PR TITLE
DOCS-5887: mongotop --locks is only supported for 2.6 and older instances

### DIFF
--- a/source/includes/options-mongotop.yaml
+++ b/source/includes/options-mongotop.yaml
@@ -171,11 +171,11 @@ directive: option
 args: null
 description: |
   Toggles the mode of :program:`mongotop` to report on use of per-database
-  :ref:`locks <locks>`. These data are useful for measuring concurrent
-  operations and lock percentage.
+  :ref:`locks <locks>`. This data is only available when connected to a
+  MongoDB 2.6 or older instance.
 post: |
-  {{role}} returns an error when called against a :program:`mongod` instance
-  that does not report lock usage.
+  {{role}} returns an error when called against a :program:`mongod` 3.0 or
+  newer instance that does not report per-database lock usage.
 optional: true
 ---
 program: mongotop

--- a/source/reference/program/mongotop.txt
+++ b/source/reference/program/mongotop.txt
@@ -218,21 +218,3 @@ following command:
 .. code-block:: sh
 
    mongotop 300
-
-To report the use of per-database locks, use :option:`--locks`,
-which produces the following output:
-
-.. code-block:: sh
-
-   $ mongotop --locks
-   connected to: 127.0.0.1
-
-                     db       total        read       write          2012-08-13T16:33:34
-                  local         0ms         0ms         0ms
-                  admin         0ms         0ms         0ms
-                      .         0ms         0ms         0ms
-
-.. versionchanged:: 3.0.0
-   When called against a :program:`mongod` that does not report lock
-   usage, :option:`--locks` will return a ``Failed: Server does not
-   support reporting locking information`` error.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3063)
<!-- Reviewable:end -->
