### PR TITLE
DOCS-6976: parallelCollectionScan command only returns one cursor for WiredTiger

### DIFF
--- a/source/reference/command/parallelCollectionScan.txt
+++ b/source/reference/command/parallelCollectionScan.txt
@@ -25,7 +25,11 @@ parallelCollectionScan
    The result of the database command identifies the cursors, but does not
    contain or constitute the cursors.
 
-   The server may return fewer cursors than requested.
+   .. important::
+
+      - The server may return fewer cursors than requested.
+
+      - This command will not return more than one cursor for the WiredTiger storage engine.
 
    The command has the following syntax:
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3064)
<!-- Reviewable:end -->
