### PR TITLE
DOCS-5715: Add warning on lock scope for dropIndexes shell helpers

### DIFF
--- a/source/reference/method/db.collection.dropIndex.txt
+++ b/source/reference/method/db.collection.dropIndex.txt
@@ -32,6 +32,11 @@ Definition
    :method:`db.collection.dropIndex()` method, use the
    :method:`db.collection.getIndexes()` method.
 
+   .. warning::
+
+      This command obtains a write lock on the affected database and
+      will block other operations until it has completed.
+
 Example
 -------
 

--- a/source/reference/method/db.collection.dropIndexes.txt
+++ b/source/reference/method/db.collection.dropIndexes.txt
@@ -15,3 +15,8 @@ db.collection.dropIndexes()
    Drops all indexes other than the required index on the ``_id``
    field. Only call :method:`~db.collection.dropIndexes()` as a method on a
    collection object.
+
+.. warning::
+
+    This command obtains a write lock on the affected database and
+    will block other operations until it has completed.


### PR DESCRIPTION
Added the same warning as the `dropIndexes` command page: https://docs.mongodb.com/manual/reference/command/dropIndexes/#dbcmd.dropIndexes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3076)
<!-- Reviewable:end -->
