### PR TITLE
DOCS-10958 networkMessageCompressors disabled by default in shell.

### DIFF
--- a/source/includes/fact-networkMessageCompressors.rst
+++ b/source/includes/fact-networkMessageCompressors.rst
@@ -6,7 +6,7 @@
 
 You can specify the following compressors:
 
-- :term:`snappy` (Default)
+- :term:`snappy`
 
 - :term:`zlib`
 

--- a/source/includes/options-conf.yaml
+++ b/source/includes/options-conf.yaml
@@ -707,10 +707,12 @@ description: |
    .. versionadded:: 3.4
 
    .. versionchanged:: 3.6
+      \ 
 
-      - Add support for :term:`zlib` compressor.
+   - Add support for :term:`zlib` compressor.
 
-      - Enabled by default. To disable, set to ``disabled``.
+   - Enabled by default using the :term:`snappy` compressor. To
+     disable compression, set this option to ``disabled``.
 
    Enables network compression for communication between this
    :program:`mongod` or :program:`mongos` instance and:
@@ -718,8 +720,9 @@ description: |
    - other members in the deployment, if a member of a replica set or a
      sharded cluster
 
-   - a :program:`mongo` shell
-   
+   - a :program:`mongo` shell when network compression is enabled
+     (disabled by default)
+
    - drivers that support the ``OP_COMPRESSED`` message format.
 
    .. include:: /includes/fact-networkMessageCompressors.rst

--- a/source/includes/options-mongo.yaml
+++ b/source/includes/options-mongo.yaml
@@ -411,9 +411,11 @@ description: |
    .. versionadded:: 3.4
 
    .. versionchanged:: 3.6
+      \ 
 
       - Add support for :term:`zlib` compressor.
-      - Enabled by default. To disable, set to ``disabled``.
+
+      - Disabled by default in the :program:`mongo` shell.
 
    Enables network compression for communication between this
    {{program}} shell and:

--- a/source/includes/options-mongod.yaml
+++ b/source/includes/options-mongod.yaml
@@ -2624,9 +2624,12 @@ description: |
    .. versionadded:: 3.4
 
    .. versionchanged:: 3.6
+      \ 
 
-      - Add support for :term:`zlib` compressor.
-      - Enabled by default. To disable, set to ``disabled``.
+   - Add support for :term:`zlib` compressor.
+
+   - Enabled by default using the :term:`snappy` compressor. To
+     disable compression, set this option to ``disabled``.
 
    Enables network compression for communication between this
    {{program}} instance and:
@@ -2637,7 +2640,8 @@ description: |
    - other members of the sharded cluster, if the instance is part of a
      sharded cluster
 
-   - a :program:`mongo` shell,
+   - a :program:`mongo` shell when network compression is enabled
+     (disabled by default)
 
    - drivers that support the ``OP_COMPRESSED`` message format.
 

--- a/source/includes/options-mongos.yaml
+++ b/source/includes/options-mongos.yaml
@@ -486,15 +486,22 @@ description: |
    .. versionadded:: 3.4
 
    .. versionchanged:: 3.6
+      \ 
 
-      Add support for :term:`zlib` compressor.
+   - Add support for :term:`zlib` compressor.
+
+   - Enabled by default using the :term:`snappy` compressor. To
+     disable compression, set this option to ``disabled``.
 
    Enables network compression for communication between this
    {{program}} instance and:
       
    - other members of the sharded cluster
 
-   - a :program:`mongo` shell.
+   - a :program:`mongo` shell when network compression is enabled
+     (disabled by default)
+
+   - drivers that support the ``OP_COMPRESSED`` message format.
 
    .. include:: /includes/fact-networkMessageCompressors.rst
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3083)
<!-- Reviewable:end -->
