### PR TITLE
DOCSP-1327: Fix Stitch admonition

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -10,10 +10,12 @@ The MongoDB |version| Release Candidate Manual
 .. admonition:: MongoDB Stitch (Beta)
    :class: note
 
-   `MongoDB Stitch <https://docs.mongodb.com/stitch/>`_ is a backend as
-   a service that provides an HTTP API to MongoDB, integration with
-   other services, and a declarative rules infrastructure which spans
-   database and service actions. For more information
+   `MongoDB Stitch <https://www.mongodb.com/cloud/stitch/>`_ is a
+   backend as a service that provides an HTTP API to MongoDB,
+   integration with other services, and a declarative rules
+   infrastructure which spans database and service actions. For complete
+   documentation on MongoDB Stitch, see the `MongoDB Stitch
+   documentation <https://docs.mongodb.com/stitch/>`_.
 
 .. admonition:: MongoDB 3.6 Release Candidate Available
    :class: note


### PR DESCRIPTION
@kay-kim if this looks good, we will need to publish to 3.6 and 3.4 branches. 

I switched the order of what I think was original (docs first, then a link to the product). If you prefer the other way around I can do that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3085)
<!-- Reviewable:end -->
