### PR TITLE
Forgot to add the link to the Journaliing article.

### DIFF
--- a/source/reference/write-concern.txt
+++ b/source/reference/write-concern.txt
@@ -158,6 +158,12 @@ the write operation has been written to the :doc:`journal
      configuration setting determines the behavior. See
      :ref:`wc-ack-behavior` for details.
 
+   - The :doc:`WiredTiger </core/wiredtiger>` and :doc:`MMAPv1 </core/mmapv1>`
+     storage engines handle setting a write concern that includes ``j: true``
+     differently. ``WiredTiger`` forces an immediate, synchronous journal 
+     flush while ``MMAPv1`` waits for the next scheduled journal flush. See
+     :doc:`journaling </core/journaling>` for details.
+
 .. _wc-wtimeout:
 
 ``wtimeout``


### PR DESCRIPTION
Clarified the difference between the behavior of WiredTiger and MMAPv1 when journaling is turned on.