### PR TITLE
DOCS-4578 Clarify global locks for index replication

### DIFF
--- a/source/core/index-creation.txt
+++ b/source/core/index-creation.txt
@@ -129,8 +129,9 @@ build on :term:`replica set` :term:`secondaries <secondary>`. The replication
 worker acquires a global DB lock that queues reads and writes to all databases
 on the indexing server.
 
-A background index build on a primary replicates as a background index build on
-secondaries. Secondary reads are not affected.
+A background index build on a primary replicates as background index builds on
+secondaries. The replication worker does not take a global DB lock, and
+secondary reads are not affected.
 
 In both cases, index operations on replica set secondaries begin after the
 primary finishes building the index.


### PR DESCRIPTION
Make it explicit that the replication worker does not take a global DB lock when building an index in the background on a secondary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3089)
<!-- Reviewable:end -->
