### PR TITLE
DOCS-9003: adds method ref for db.collection.createIndexes()

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1342,6 +1342,7 @@ raw: /master/release-notes/3.0-general-improvements -> ${base}/release-notes/3.0
 [*-v3.4]: /${version}/reference/method/db.aggregate -> ${base}/${version}/reference/method/db.collection.aggregate
 [*-v3.4]: /${version}/reference/operator/query/jsonSchema -> ${base}/${version}/core/document-validation
 [*-v3.4]: /${version}/reference/command/replSetResizeOplog -> ${base}/${version}/reference/command
+[*-v3.0]: /${version}/reference/method/db.collection.createIndexes -> ${base}/{$version}/reference/method/db.collection.createIndex
 
 # 2.8 compatibility
 [*]: /${version}/release-notes/2.8-downgrade -> ${base}/${version}/release-notes

--- a/source/includes/apiargs-method-db.collection.createIndex-options-param.yaml
+++ b/source/includes/apiargs-method-db.collection.createIndex-options-param.yaml
@@ -1,8 +1,10 @@
 arg_name: param
 description: |
-  Builds the index in the background so that building an index does
+  Builds the {{indexPhrase}} in the background so the operation does
   *not* block other database activities. Specify ``true`` to build in
   the background. The default value is ``false``.
+replacement:
+  indexPhrase: "index"
 interface: method
 name: background
 operation: db.collection.createIndex
@@ -13,8 +15,10 @@ type: boolean
 arg_name: param
 description: |
   Creates a unique index so that the collection will not accept
-  insertion of documents where the index key or keys match an existing
-  value in the index. Specify ``true`` to create a unique index. The
+  insertion or update of documents where the index key value matches an existing
+  value in the index.
+post: |
+  Specify ``true`` to create a unique index. The
   default value is ``false``.
 
   The option is *unavailable* for :doc:`hashed </core/index-hashed>`
@@ -45,7 +49,7 @@ arg_name: param
 description: |
   If specified, the index only references documents that match the
   filter expression. See :doc:`/core/index-partial` for more information.
-
+post: |
   A filter expression can include:
 
   .. include:: /includes/fact-partial-filter-expression-operators.rst
@@ -63,8 +67,8 @@ type: document
 ---
 arg_name: param
 description: |
-  If ``true``, the index only references documents with the specified
-  field. These indexes use less space but behave differently in some
+  If ``true``, the {{indexPhrase}} with the specified
+  {{field}}. These indexes use less space but behave differently in some
   situations (particularly sorts). The default value is ``false``.
   See :doc:`/core/index-sparse` for more information.
 
@@ -87,6 +91,9 @@ description: |
      :doc:`2d </core/2d>`, :doc:`geoHaystack </core/geohaystack>`, and
      :doc:`text </core/index-text>` indexes behave similarly to the
      :doc:`2dsphere </core/2dsphere>` indexes.
+replacement:
+  indexPhrase: "index only references documents"
+  field: "field"
 interface: method
 name: sparse
 operation: db.collection.createIndex
@@ -107,15 +114,16 @@ type: integer
 ---
 arg_name: param
 description: |
-  Allows users to specify configuration to the storage engine on a
-  per-index basis when creating an index. The value of the
-  ``storageEngine`` option should take the following form:
+  Allows users to configure the storage engine on a
+  per-index basis when creating an index. 
+post: |
+  The ``storageEngine`` option should take the following form:
 
   .. code-block:: javascript
 
-     { <storage-engine-name>: <options> }
+     storageEngine: { <storage-engine-name>: <options> }
 
-  Storage engine configuration specified when creating indexes are
+  Storage engine configuration options specified when creating indexes are
   validated and logged to the :term:`oplog` during replication to
   support replica sets with members that use different storage
   engines.

--- a/source/includes/apiargs-method-db.collection.createIndexes-option-collation.yaml
+++ b/source/includes/apiargs-method-db.collection.createIndexes-option-collation.yaml
@@ -1,0 +1,7 @@
+arg_name: param
+name: collation
+source:
+  file: apiargs-method-db.collection.createIndex-option-collation.yaml
+  ref: collation
+operation: db.collection.createIndexes
+...

--- a/source/includes/apiargs-method-db.collection.createIndexes-options-2d.yaml
+++ b/source/includes/apiargs-method-db.collection.createIndexes-options-2d.yaml
@@ -1,0 +1,21 @@
+arg_name: param
+name: bits
+source:
+  file: apiargs-method-db.collection.createIndex-options-2d.yaml
+  ref: bits
+operation: db.collection.createIndexes
+---
+arg_name: param
+name: min
+source:
+  file: apiargs-method-db.collection.createIndex-options-2d.yaml
+  ref: min
+operation: db.collection.createIndexes
+---
+arg_name: param
+name: max
+source:
+  file: apiargs-method-db.collection.createIndex-options-2d.yaml
+  ref: max
+operation: db.collection.createIndexes
+...

--- a/source/includes/apiargs-method-db.collection.createIndexes-options-2dsphere.yaml
+++ b/source/includes/apiargs-method-db.collection.createIndexes-options-2dsphere.yaml
@@ -1,0 +1,7 @@
+arg_name: param
+name: 2dsphereIndexVersion
+source:
+  file: apiargs-method-db.collection.createIndex-options-2dsphere.yaml
+  ref: 2dsphereIndexVersion
+operation: db.collection.createIndexes
+...

--- a/source/includes/apiargs-method-db.collection.createIndexes-options-geohaystack.yaml
+++ b/source/includes/apiargs-method-db.collection.createIndexes-options-geohaystack.yaml
@@ -1,0 +1,7 @@
+arg_name: param
+name: bucketSize
+source:
+  file: apiargs-method-db.collection.createIndex-options-geohaystack.yaml
+  ref: bucketSize
+operation: db.collection.createIndexes
+...

--- a/source/includes/apiargs-method-db.collection.createIndexes-options-param.yaml
+++ b/source/includes/apiargs-method-db.collection.createIndexes-options-param.yaml
@@ -1,0 +1,70 @@
+arg_name: param
+operation: db.collection.createIndexes
+source:
+  file: apiargs-method-db.collection.createIndex-options-param.yaml
+  ref: background
+replacement:
+  indexPhrase: "indexes"
+---
+arg_name: param
+source:
+  file: apiargs-method-db.collection.createIndex-options-param.yaml
+  ref: unique
+description: |
+  Specifies that each index specified in the ``keyPatterns`` array
+  is a :doc:`unique index </core/index-unique>`. Unique indexes will not
+  accept insertion or update of documents where the index key value matches an
+  existing value in the index.
+operation: db.collection.createIndexes
+---
+arg_name: param
+source:
+  file: apiargs-method-db.collection.createIndex-options-param.yaml
+  ref: name
+name: name
+operation: db.collection.createIndexes
+post: |
+  Options specified to {{role}} apply to **all** of the index
+  specifications included in the key pattern array. Since index names
+  must be unique, you may
+  only specify {{argname}} if you are creating a single index using
+  {{role}}.
+---
+arg_name: param
+source:
+  file: apiargs-method-db.collection.createIndex-options-param.yaml
+  ref: partialFilterExpression
+description: |
+  If specified, the indexes only reference documents that match the
+  filter expression. See :doc:`/core/index-partial` for more
+  information.
+name: partialFilterExpression
+operation: db.collection.createIndexes
+---
+arg_name: param
+name: sparse
+source:
+  file: apiargs-method-db.collection.createIndex-options-param.yaml
+  ref: sparse
+replacement:
+  indexPhrase: "indexes only reference documents"
+  field: "fields"
+operation: db.collection.createIndexes
+---
+arg_name: param
+name: expireAfterSeconds
+source:
+  file: apiargs-method-db.collection.createIndex-options-param.yaml
+  ref: expireAfterSeconds
+operation: db.collection.createIndexes
+---
+arg_name: param
+name: storageEngine
+source:
+  file: apiargs-method-db.collection.createIndex-options-param.yaml
+  ref: storageEngine
+operation: db.collection.createIndexes
+description: |
+  Allows users to configure the storage engine for the created
+  indexes.
+...

--- a/source/includes/apiargs-method-db.collection.createIndexes-options-text.yaml
+++ b/source/includes/apiargs-method-db.collection.createIndexes-options-text.yaml
@@ -1,0 +1,28 @@
+arg_name: param
+name: weights
+source:
+  file: apiargs-method-db.collection.createIndex-options-text.yaml
+  ref: weights
+operation: db.collection.createIndex
+---
+arg_name: param
+name: default_language
+source:
+  file: apiargs-method-db.collection.createIndex-options-text.yaml
+  ref: default_language
+operation: db.collection.createIndex
+---
+arg_name: param
+name: language_override
+source:
+  file: apiargs-method-db.collection.createIndex-options-text.yaml
+  ref: language_override
+operation: db.collection.createIndex
+---
+arg_name: param
+name: textIndexVersion
+source:
+  file: apiargs-method-db.collection.createIndex-options-text.yaml
+  ref: textIndexVersion
+operation: db.collection.createIndex
+...

--- a/source/includes/apiargs-method-db.collection.createIndexes-param.yaml
+++ b/source/includes/apiargs-method-db.collection.createIndexes-param.yaml
@@ -1,0 +1,31 @@
+arg_name: param
+description: |
+  An array containing index specification documents. Each document
+  contains field and value pairs where the field is
+  the index key and the value describes the type of index for that
+  field. For an ascending index on a field, specify a value of ``1``; for
+  descending index, specify a value of ``-1``.
+
+  MongoDB supports several different index types including
+  :ref:`text <index-feature-text>`, :doc:`geospatial
+  </applications/geospatial-indexes>`, and :ref:`hashed
+  <index-type-hashed>` indexes. See :ref:`index types <index-types>`
+  for more information.
+interface: method
+name: keyPatterns
+operation: db.collection.createIndexes
+optional: false
+position: 1
+type: document
+---
+arg_name: param
+description: |
+  A document that contains a set of options that controls the creation
+  of the indexes. See :ref:`createIndexes-options` for details.
+interface: method
+name: options
+operation: db.collection.createIndexes
+optional: true
+position: 2
+type: document
+...

--- a/source/includes/extracts-collation.yaml
+++ b/source/includes/extracts-collation.yaml
@@ -90,7 +90,7 @@ content: |-
    If you have specified a collation at the collection level, then:
 
    - If you do not specify a collation when creating the index, MongoDB
-     creates the index with that collation.
+     creates the index with the collection's default collation.
 
    - If you do specify a collation when creating the index, MongoDB
      creates the index with the specified collation.

--- a/source/includes/extracts-createIndex-behavior.yaml
+++ b/source/includes/extracts-createIndex-behavior.yaml
@@ -1,0 +1,36 @@
+ref: _behavior
+content: |
+   - .. versionchanged:: 3.4 
+   
+     To add or change index options other than
+     collation, you must drop the index using the
+     :method:`~db.collection.dropIndex()` method and issue another
+     {{method}} operation with the new options.
+
+   - If you create an index with one set of options, and then issue the
+     {{method}} method with the same index
+     fields and different options (not including collation) without first
+     dropping the index, {{method}} will *not*
+     rebuild the existing index with the new options.
+
+   - .. include:: /includes/extracts/collation-index-options.rst
+
+   - If you call {{method}} multiple times concurrently
+     with the same index specification, only
+     the first operation will succeed. All other operations will have
+     no effect.
+---
+ref: createIndex-behavior
+inherit:
+  file: extracts-createIndex-behavior.yaml
+  ref: _behavior
+replacement:
+  method: ":method:`db.collection.createIndex()`"
+---
+ref: createIndexes-behavior
+inherit:
+  file: extracts-createIndex-behavior.yaml
+  ref: _behavior
+replacement:
+  method: ":method:`db.collection.createIndexes()`"
+...  

--- a/source/includes/fact-index-key-length-operation-behaviors.rst
+++ b/source/includes/fact-index-key-length-operation-behaviors.rst
@@ -1,7 +1,7 @@
 .. index-field-limit-ensureIndex
 
-MongoDB will **not** :method:`create an index
-<db.collection.createIndex()>` on a collection if the index entry for
+MongoDB will **not** create an index 
+on a collection if the index entry for
 an existing document exceeds the |limit|. Previous versions of MongoDB
 would create the index but not index such documents.
 

--- a/source/includes/ref-toc-method-collection.yaml
+++ b/source/includes/ref-toc-method-collection.yaml
@@ -18,6 +18,10 @@ name: ":method:`db.collection.createIndex()`"
 file: /reference/method/db.collection.createIndex
 description: "Builds an index on a collection."
 ---
+name: ":method:`db.collection.createIndexes()`"
+file: /reference/method/db.collection.createIndexes
+description: "Builds one or more indexes on a collection."
+---
 name: ":method:`db.collection.dataSize()`"
 file: /reference/method/db.collection.dataSize
 description: "Returns the size of the collection. Wraps the :data:`~collStats.size` field in the output of the :dbcommand:`collStats`."

--- a/source/reference/method/db.collection.createIndex.txt
+++ b/source/reference/method/db.collection.createIndex.txt
@@ -119,33 +119,13 @@ described here.
 
    Foreground index builds block all other operations on the database.
 
-- .. versionchanged:: 3.4
+.. include:: /includes/extracts/createIndex-behavior.rst
 
-  To add or change index options, other than collation, you must drop
-  the index using the :method:`~db.collection.dropIndex()` method and
-  issue another :method:`~db.collection.createIndex()` operation with
-  the new options.
-
-  If you create an index with one set of options, and then issue the
-  :method:`~db.collection.createIndex()` method with the same index
-  fields and different options (not including collation) without first
-  dropping the index, :method:`~db.collection.createIndex()` will *not*
-  rebuild the existing index with the new options.
-
-  .. include:: /includes/extracts/collation-index-options.rst
-
-- If you call multiple :method:`~db.collection.createIndex()`
-  methods with the same index specification at the same time, only
-  the first operation will succeed, all other operations will have
-  no effect.
-
--  .. include:: /includes/fact-index-key-length-operation-behaviors.rst
+- .. include:: /includes/fact-index-key-length-operation-behaviors.rst
       :start-after: index-field-limit-ensureIndex
       :end-before: .. index-field-limit-reIndex
 
-   .. versionchanged:: 2.6
-
-   .. |limit| replace:: :limit:`Maximum Index Key Length <Index Key>`
+  .. |limit| replace:: :limit:`Maximum Index Key Length <Index Key>`
 
 Examples
 --------
@@ -218,9 +198,6 @@ rules, MongoDB can use the index. For details, see :ref:`createIndex-collation-i
 
 Additional Information
 ----------------------
-
-- Use :method:`db.collection.createIndex()` rather than
-  :method:`db.collection.ensureIndex()` to create indexes.
 
 - The :doc:`/indexes` section of this manual for full
   documentation of indexes and indexing in MongoDB.

--- a/source/reference/method/db.collection.createIndexes.txt
+++ b/source/reference/method/db.collection.createIndexes.txt
@@ -1,0 +1,193 @@
+=============================
+db.collection.createIndexes()
+=============================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. method:: db.collection.createIndexes( [ keyPatterns ], options )
+
+   .. versionadded:: 3.2
+
+   Creates one or more indexes on a collection.
+
+   .. include:: /includes/apiargs/method-db.collection.createIndexes-param.rst
+
+.. _createIndexes-options:
+
+Options
+-------
+
+The ``options`` document contains a set of options that control the
+creation of the indexes. Different index types can have additional
+options specific for that type.
+
+.. important::
+   When you specify options to
+   :method:`db.collection.createIndexes()`, the options apply to
+   *all* of the specified indexes. For example, if you specify a
+   collation option, all of the created indexes will include that
+   collation.
+   
+   :method:`db.collection.createIndexes()` will return an error if you
+   attempt to create indexes with incompatible options. Refer to the
+   options descriptions for more information.
+
+.. versionchanged:: 3.4
+
+   Added support for :ref:`collation
+   <create-indexes-collation>`.
+
+Options for All Index Types
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following options are available for all index types unless
+otherwise specified:
+
+.. include:: /includes/fact-remove-dropDups-option.rst
+
+.. include:: /includes/apiargs/method-db.collection.createIndexes-options-param.rst
+
+.. _create-indexes-collation:
+
+Option for Collation
+~~~~~~~~~~~~~~~~~~~~
+
+The :ref:`collation <collation>` option is available for all index
+types except for :doc:`text indexes </core/index-text>`. If you wish to specify the collation
+option, you cannot include a text index specification in the
+:method:`db.collection.createIndexes()` key patterns.
+
+.. include:: /includes/apiargs/method-db.collection.createIndexes-option-collation.rst
+
+Collation and Index Use
+```````````````````````
+
+.. include:: /includes/extracts/collation-index.rst
+
+Options for ``text`` Indexes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following options are available for :doc:`text </core/index-text>`
+indexes only:
+
+.. include:: /includes/apiargs/method-db.collection.createIndexes-options-text.rst
+
+Options for ``2dsphere`` Indexes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following option is available for :doc:`2dsphere </core/2dsphere>`
+indexes only:
+
+.. include:: /includes/apiargs/method-db.collection.createIndexes-options-2dsphere.rst
+
+Options for ``2d`` Indexes
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following options are available for :doc:`2d </core/2d>` indexes
+only:
+
+.. include:: /includes/apiargs/method-db.collection.createIndexes-options-2d.rst
+
+Options for ``geoHaystack`` Indexes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following option is available for :doc:`geoHaystack </core/geohaystack>`
+indexes only:
+
+.. include:: /includes/apiargs/method-db.collection.createIndexes-options-geohaystack.rst
+
+Behaviors
+---------
+
+The :method:`~db.collection.createIndexes()` method has the following
+behaviors.
+
+.. warning::
+
+   Foreground index builds block all other operations on the database.
+
+.. include:: /includes/extracts/createIndexes-behavior.rst
+
+-  .. include:: /includes/fact-index-key-length-operation-behaviors.rst
+      :start-after: index-field-limit-ensureIndex
+      :end-before: .. index-field-limit-reIndex
+
+   .. |limit| replace:: :limit:`Maximum Index Key Length <Index Key>`
+
+Example
+-------
+
+.. seealso:: :method:`db.collection.createIndex()` for examples of
+   various index specifications.
+
+Create Indexes Without Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Consider a ``restaurants`` collection containing documents that
+resemble the following:
+
+.. code-block:: javascript
+
+   {
+      location: {
+         type: "Point",
+         coordinates: [-73.856077, 40.848447]
+      },
+      name: "Morris Park Bake Shop",
+      cuisine: "Cafe",
+      borough: "Bronx",
+   }
+
+The following example creates two indexes on the ``restaurants``
+collection: an ascending index on the ``borough`` field and a
+:doc:`2dsphere </core/2dsphere>` index on the ``location`` field.
+
+.. code-block:: sh
+
+   db.restaurants.createIndexes([{"borough": 1}, {"location": "2dsphere"}])
+
+Create Indexes with Collation Specified
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following example creates two indexes on the ``products``
+collection: an ascending index on the ``manufacturer`` field and an
+ascending index on the ``category`` field. Both indexes use a :ref:`collation
+<create-index-collation>` that specifies the locale ``fr`` and
+comparison strength ``2``:
+
+.. code-block:: javascript
+
+   db.products.createIndexes( [ { "manufacturer": 1}, { "category": 1 } ],
+      { collation: { locale: "fr", strength: 2 } })
+
+For queries or sort operations on the indexed keys that uses the same collation
+rules, MongoDB can use the index. For details, see :ref:`createIndex-collation-index-use`.
+
+
+Additional Information
+----------------------
+
+For additional information about indexes, refer to:
+
+- The :doc:`/indexes` section of this manual for full
+  documentation of indexes and indexing in MongoDB.
+
+- :method:`db.collection.getIndexes()` to view the specifications of
+  existing indexes for a collection.
+
+- :doc:`/core/index-text` for details on creating ``text``
+  indexes.
+
+- :ref:`index-feature-geospatial` and
+  :ref:`index-geohaystack-index` for geospatial queries.
+
+- :ref:`index-feature-ttl` for expiration of data.


### PR DESCRIPTION
For v3.2, v3.4, and master -- sorry! It should merge nicely, though, I think.

First time doing new format of redirects, so please double-check that I've not messed that up 😁 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3090)
<!-- Reviewable:end -->
