### PR TITLE
DOCS-10999: Typo in windows installation tutorial

### DIFF
--- a/source/includes/steps-run-mongodb-on-windows.yaml
+++ b/source/includes/steps-run-mongodb-on-windows.yaml
@@ -64,7 +64,7 @@ action:
     copyable: true
     language: powershell
     code: |
-      "C:\Program Files\MongoDB\Server\3.6\bin\mongo.exe
+      "C:\Program Files\MongoDB\Server\3.6\bin\mongo.exe"
 post: |
    If you want to develop applications using .NET, see the documentation
    of :ecosystem:`C# and MongoDB </drivers/csharp>` for more information.


### PR DESCRIPTION
Small typo fix, but this exists as far back as 3.2. Might be worth backporting

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3092)
<!-- Reviewable:end -->
