### PR TITLE
DOCS-10925: --nojournal option is deprecated for WiredTiger nodes in …

### DIFF
--- a/source/includes/extracts-manage-journaling.yaml
+++ b/source/includes/extracts-manage-journaling.yaml
@@ -21,17 +21,6 @@ content: |
   :setting:`~storage.journal.commitIntervalMs` for more information on
   the default.
 ---
-ref: journaling-enable-journaling
-content: |
-  Enable Journaling
-  ~~~~~~~~~~~~~~~~~
-
-  For 64-bit builds of :program:`mongod`, journaling is enabled by
-  default.
-  
-  To enable journaling, start :program:`mongod` with the
-  :option:`--journal <mongod --journal>` command line option.
----
 ref: journaling-disable-journaling
 content: |
   Disable Journaling
@@ -46,6 +35,8 @@ content: |
      running with journaling, then you must recover from an unaffected
      :term:`replica set` member or backup, as described in :doc:`repair
      </tutorial/recover-data-following-unexpected-shutdown>`.
+
+     .. include:: /includes/wiredtiger-node-nojournal.rst
 
   To disable journaling, start :program:`mongod` with the
   :option:`--nojournal <mongod --nojournal>` command line option.

--- a/source/includes/not-available-for-inmemory-storage-engine.rst
+++ b/source/includes/not-available-for-inmemory-storage-engine.rst
@@ -1,2 +1,2 @@
-Not available for :program:`mongod` instances that use the in-memory
-storage engine.
+Not available for :program:`mongod` instances that use the
+:doc:`in-memory storage engine </core/inmemory>`.

--- a/source/includes/options-mongod.yaml
+++ b/source/includes/options-mongod.yaml
@@ -638,10 +638,12 @@ name: nojournal
 args: null
 directive: option
 description: |
-  Disables the durability journaling. The {{program}} instance
-  enables journaling by default in 64-bit versions after v2.0.
+  Disables :doc:`journaling </core/journaling>`. {{program}}
+  enables journaling by default.
 post: |
   .. include:: /includes/not-available-for-inmemory-storage-engine.rst
+
+  .. include:: /includes/wiredtiger-node-nojournal.rst
 optional: true
 ---
 program: mongod

--- a/source/includes/options-shared.yaml
+++ b/source/includes/options-shared.yaml
@@ -429,8 +429,7 @@ directive: option
 description: |
   {{intro}} the durability :term:`journal` to ensure data files remain valid
   and recoverable. This option applies only when you specify the
-  :option:`--dbpath` option. The {{program}} enables journaling by default
-  on 64-bit builds of versions after 2.0.
+  :option:`--dbpath` option. {{program}} enables journaling by default.
 optional: true
 replacement:
   intro: "Enables"

--- a/source/includes/wiredtiger-node-nojournal.rst
+++ b/source/includes/wiredtiger-node-nojournal.rst
@@ -1,0 +1,4 @@
+:doc:`Replica set members </core/replica-set-members/>` which use the
+WiredTiger :doc:`storage engine </core/storage-engines/>` should not
+use the :option:`--nojournal` option. For more information about
+journaling, see :doc:`/tutorial/manage-journaling`.

--- a/source/release-notes/3.6-compatibility.txt
+++ b/source/release-notes/3.6-compatibility.txt
@@ -416,6 +416,11 @@ index keys.
 To delete existing indexes named ``*``, delete the index before
 upgrading. To rename them, delete and recreate the index.
 
+``--nojournal`` Option with WiredTiger
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/wiredtiger-node-nojournal.rst
+
 Platform Support
 ----------------
 

--- a/source/tutorial/manage-journaling.txt
+++ b/source/tutorial/manage-journaling.txt
@@ -15,8 +15,6 @@ Manage Journaling
 Procedures
 ----------
 
-.. include:: /includes/extracts/journaling-enable-journaling.rst
-
 .. include:: /includes/extracts/journaling-disable-journaling.rst
 
 .. include:: /includes/extracts/journaling-get-commit-acknowledgement.rst


### PR DESCRIPTION
…a replica set

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3096)
<!-- Reviewable:end -->
