### PR TITLE
DOCS-10992 capped commands take DB_X locks

### DIFF
--- a/source/core/capped-collections.txt
+++ b/source/core/capped-collections.txt
@@ -186,7 +186,7 @@ the :dbcommand:`convertToCapped` command:
 The ``size`` parameter specifies the size of the capped collection in
 bytes.
 
-.. include:: /includes/warning-blocking-global.rst
+.. include:: /includes/fact-database-lock.rst
 
 Automatically Remove Data After a Specified Period of Time
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/faq/concurrency.txt
+++ b/source/faq/concurrency.txt
@@ -184,6 +184,8 @@ lock at the database level for extended periods:
 - :method:`db.collection.validate()`, and
 - :method:`db.copyDatabase()`. This operation may lock all
   databases. See :ref:`faq-concurrency-lock-multiple-dbs`.
+- :dbcommand:`convertToCapped`
+- :dbcommand:`cloneCollectionAsCapped`
 
 The following administrative commands lock the database but only hold
 the lock for a very short time:

--- a/source/includes/fact-database-lock.rst
+++ b/source/includes/fact-database-lock.rst
@@ -1,0 +1,4 @@
+This holds a database exclusive lock for the duration of the operation.
+Other operations which lock the same database will be blocked until the
+operation completes. See :ref:`faq-concurrency-operations-locks` for
+operations that lock the database.

--- a/source/reference/command/cloneCollectionAsCapped.txt
+++ b/source/reference/command/cloneCollectionAsCapped.txt
@@ -55,7 +55,7 @@ Definition
           distinct and cannot be the same as that of the original existing
           collection.
 
-      * - size
+      * - ``size``
         - number
         - Maximum size of the capped collection.
 
@@ -92,3 +92,5 @@ Behavior
 If the ``capped size`` is less than the size of the source collection,
 then not all documents in the source collection will exist in the destination
 capped collection.
+
+.. include:: /includes/fact-database-lock.rst

--- a/source/reference/command/convertToCapped.txt
+++ b/source/reference/command/convertToCapped.txt
@@ -84,6 +84,8 @@ command exhibits the following behavior:
   - :dbcommand:`renameCollection` renames the new capped collection
     to the name of the original collection.
 
+  - .. include:: /includes/fact-database-lock.rst
+
 .. note::
 
    MongoDB does not support the :dbcommand:`convertToCapped`


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3102)
<!-- Reviewable:end -->
