### PR TITLE
DOCS-10847: Initial sync gracefully handles renameCollection operatio…

### DIFF
--- a/source/core/replica-set-sync.txt
+++ b/source/core/replica-set-sync.txt
@@ -72,27 +72,6 @@ has built-in retry logic.
    intermittent failures on the network.
 
 
-Initial Sync and ``renameCollection``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. versionchanged:: 3.2.12
-
-If a collection is renamed on the sync source while an initial sync is
-running, the initial sync for the target member fails and restarts to
-avoid data corruption (See :issue:`SERVER-26117`). Operations that
-rename collections include:
-
-- :dbcommand:`renameCollection` command and
-  :method:`db.collection.renameCollection()` method.
-
-- Aggregation (:method:`db.collection.aggregate()` method or
-  :dbcommand:`aggregate` command) with the :pipeline:`$out` stage.
-
-- Map-reduce (:method:`db.collection.mapReduce()` method or
-  :dbcommand:`mapReduce` command) with the ``out`` option.
-
-- :dbcommand:`convertToCapped` command.
-
 .. _replica-set-replication:
 
 Replication

--- a/source/release-notes/3.6.txt
+++ b/source/release-notes/3.6.txt
@@ -461,6 +461,17 @@ Replica Sets
   specify how long a secondary must wait if the ``afterClusterTime`` is
   greater than the last applied time from the oplog.
 
+- Added support for running the following during a replica set member's
+  :term:`initial sync`:
+
+  - :dbcommand:`renameCollection`
+
+  - :dbcommand:`convertToCapped`
+
+  - :pipeline:`$out` stages in aggregation pipelines
+  
+  - :term:`Map-reduce <map-reduce>` jobs that output to a new collection
+
 Sharded Clusters
 ----------------
 


### PR DESCRIPTION
…ns on the sync source.

[Code Review](https://mongodbcr.appspot.com/169600001/)
[Staged Release Notes](https://docs-mongodbcom-staging.corp.mongodb.com/nick/DOCS-10847/release-notes/3.6.html#replica-sets)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3106)
<!-- Reviewable:end -->
