### PR TITLE
DOCS-10676: isMaster returns logicalSessionTimeoutMinutes

### DIFF
--- a/source/reference/command/isMaster.txt
+++ b/source/reference/command/isMaster.txt
@@ -105,6 +105,16 @@ roles:
    Returns the local server time in UTC. This value is an
    :term:`ISO date <ISODate>`.
 
+.. data:: isMaster.logicalSessionTimeoutMinutes
+
+   .. versionadded:: 3.6
+
+   The number of minutes that a :ref:`session <sessions>` lasts without
+   receiving a new read or write operation from the client.
+   :program:`mongod` or :program:`mongos` terminates sessions that
+   exceeds this threshold. Any state associated with a terminated
+   session will be lost.
+
 .. data:: isMaster.minWireVersion
 
    .. versionadded:: 2.6


### PR DESCRIPTION
[Code Review](https://mongodbcr.appspot.com/171660001/)
[Staged Version](https://docs-mongodbcom-staging.corp.mongodb.com/nick/DOCS-10676/reference/command/isMaster.html#isMaster.logicalSessionTimeoutMinutes)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3107)
<!-- Reviewable:end -->
