### PR TITLE
Typo on configure-a-non-voting-replica-set-member.txt

### DIFF
--- a/source/tutorial/configure-a-non-voting-replica-set-member.txt
+++ b/source/tutorial/configure-a-non-voting-replica-set-member.txt
@@ -38,7 +38,7 @@ set members to be non-voting members.
 
       cfg = rs.conf();
 
-   The returned document contains a ``members`` field which contains an
+   The returned document contains a ``members`` field which contains a
    zero-indexed array of member configuration documents, one document for each
    member of the replica set.
 


### PR DESCRIPTION
The use of letter 'an' is not grammatically correct here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3112)
<!-- Reviewable:end -->
