### PR TITLE
Typo on configure-a-hidden-replica-set-member.txt

### DIFF
--- a/source/tutorial/configure-a-hidden-replica-set-member.txt
+++ b/source/tutorial/configure-a-hidden-replica-set-member.txt
@@ -12,7 +12,7 @@ Configure a Hidden Replica Set Member
 
 Hidden members are part of a :term:`replica set` but cannot become
 :term:`primary` and are invisible to client applications. Hidden members
-may vote in :ref:`elections <replica-set-elections>`. For a
+may vote in :ref:`elections <replica-set-elections>`. For
 more information on hidden members and their uses, see
 :doc:`/core/replica-set-hidden-member`.
 


### PR DESCRIPTION
The use of letter 'a' is not grammatically correct here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3113)
<!-- Reviewable:end -->
