### PR TITLE
DOCS-11025: added a timestamp to plan cache entries

### DIFF
--- a/source/includes/ref-toc-method-plan-cache.yaml
+++ b/source/includes/ref-toc-method-plan-cache.yaml
@@ -2,7 +2,7 @@ name: ":method:`db.collection.getPlanCache()`"
 file: /reference/method/db.collection.getPlanCache
 description: |
     Returns an interface to access the query plan cache object and
-    associated PlanCache methods for a collection."
+    associated PlanCache methods for a collection.
 ---
 name: ":method:`PlanCache.clear()`"
 file: /reference/method/PlanCache.clear

--- a/source/reference/command/planCacheListPlans.txt
+++ b/source/reference/command/planCacheListPlans.txt
@@ -48,6 +48,11 @@ Definition
    To see the query shapes for which cached query plans exist, use the
    :dbcommand:`planCacheListQueryShapes` command.
 
+   .. versionadded:: 3.6
+
+      The :dbcommand:`planCacheListPlans` database command returns the
+      same output as the :method:`PlanCache.getPlansByQuery()` method.
+
 Required Access
 ---------------
 

--- a/source/reference/method/PlanCache.getPlansByQuery.txt
+++ b/source/reference/method/PlanCache.getPlansByQuery.txt
@@ -37,6 +37,11 @@ Definition
    To see the query shapes for which cached query plans exist, use the
    :method:`PlanCache.listQueryShapes()` method.
 
+   .. versionadded:: 3.6
+
+      The :method:`PlanCache.getPlansByQuery()` method returns the same
+      output as the :dbcommand:`planCacheListPlans` database command.
+
 Required Access
 ---------------
 

--- a/source/release-notes/3.6.txt
+++ b/source/release-notes/3.6.txt
@@ -592,6 +592,11 @@ MongoDB 3.6 includes the following enhancements:
   of a database, which indicates the maximum number of write operations
   permitted in a write batch, raises from ``1,000`` to ``100,000``.
 
+- The :dbcommand:`planCacheListPlans` database command produces the same
+  output as the :method:`PlanCache.getPlansByQuery()` shell method. The
+  output from both operations now includes a timestamp for when
+  the plans were generated.
+
 Changes Affecting Compatibility
 -------------------------------
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3128)
<!-- Reviewable:end -->
