### PR TITLE
DOCS-9714 Clarify operation of compact command with WiredTiger

### DIFF
--- a/source/reference/command/compact.txt
+++ b/source/reference/command/compact.txt
@@ -153,10 +153,15 @@ To see how the storage space changes for the collection, run the
 WiredTiger
 ``````````
 
-On :ref:`WiredTiger <storage-wiredtiger>`, :dbcommand:`compact` will rewrite
-the collection and indexes to minimize disk space by releasing unused disk space
-to the system. This is useful if you have removed a large amount of data
-from the collection, and do not plan to replace it.
+On :ref:`WiredTiger <storage-wiredtiger>`, :dbcommand:`compact` attempts to
+reduce the required storage space for data and indexes in a collection, releasing
+unneeded disk space to the operating system. The effectiveness of this operation
+is workload dependent and no disk space may be recovered. This command is useful
+if you have removed a large amount of data from the collection, and do not plan
+to replace it.
+
+:dbcommand:`compact` does not require any additional disk space to run
+on WiredTiger databases.
 
 MMAPv1
 ``````


### PR DESCRIPTION
Note: also fixes the `compact` part of DOCS-9267: WiredTiger Space Requirements & Behavior during repair and compact

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3143)
<!-- Reviewable:end -->
