### PR TITLE
Typos in some new 3.6 feature pages

### DIFF
--- a/source/includes/fact-json-schema-validation-keywords.rst
+++ b/source/includes/fact-json-schema-validation-keywords.rst
@@ -139,7 +139,7 @@
    * - maxItems
      - arrays
      - integer
-     - Indicates the maximum length of arrayy
+     - Indicates the maximum length of array
    
    * - minItems
      - arrays

--- a/source/tutorial/change-streams-example.txt
+++ b/source/tutorial/change-streams-example.txt
@@ -239,6 +239,8 @@ See :ref:`change-stream-output` for more information on the change stream
 response document format.
 
 
+.. change-stream-resume::
+
 Resume a Change Stream
 ----------------------
 


### PR DESCRIPTION
There's one for JSON Schema and one for change streams.

I noticed the missing change streams link at the bottom of this page: https://docs.mongodb.com/manual/changeStreams/. Someone on the docs team might want to double-check, since my laptop is no longer set up for docs builds and I can't test it :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3150)
<!-- Reviewable:end -->
