### PR TITLE
DOCS-10018: CLI auth in OpenLDAP Tutorial

### DIFF
--- a/source/includes/steps-configure-ldap-mongodb.yaml
+++ b/source/includes/steps-configure-ldap-mongodb.yaml
@@ -75,8 +75,18 @@ title: Authenticate the user in the ``mongo`` shell.
 stepnum: 3
 ref: ldap-sasl-authenticate
 pre: |
-  To perform the authentication in the :program:`mongo` shell, use the
-  :method:`db.auth()` method in the ``$external`` database.
+  To authenticate when connecting with the ``mongo`` shell, run
+  :program:`mongo` with the following options, substituting ``<host>``
+  and ``<user>``, and enter your password when prompted:
+
+  .. class:: copyable-code
+  .. code-block:: shell
+
+     mongo --host <host> --authenticationMechanism PLAIN --authenticationDatabase '$external' -u <user> -p
+
+  Alternatively, connect without supplying credentials and call the
+  :method:`db.auth()` method on the ``$external`` database.
+
 action:
   pre: |
     Specify the value ``"PLAIN"`` in the ``mechanism`` field, the user and


### PR DESCRIPTION
Small change to add a CLI Auth example to this tutorial. Functionality tested and confirmed.

[Jira Ticket](https://jira.mongodb.org/browse/DOCS-10018)
[Staged Changes](https://docs-mongodbcom-staging.corp.mongodb.com/nick/DOCS-11018/tutorial/configure-ldap-sasl-openldap.html#authenticate-the-user-in-the-mongo-shell)
[Code Review](https://mongodbcr.appspot.com/170900002/)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3155)
<!-- Reviewable:end -->
