### PR TITLE
Took out --with-openssl option b/c doesn't exist

### DIFF
--- a/source/includes/steps-install-mongodb-on-osx-with-homebrew.yaml
+++ b/source/includes/steps-install-mongodb-on-osx-with-homebrew.yaml
@@ -25,7 +25,7 @@ action:
     language: sh
     copyable: true
     code: |
-      brew install mongodb --with-openssl
+      brew install mongodb
   - heading: Install the Latest Development Release of MongoDB
     pre: |
       To install the latest development release for use in testing and


### PR DESCRIPTION
There is no available option `--with-openssl` . This is installed by default. Adding this option gives the user a warning during install.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3158)
<!-- Reviewable:end -->
