### PR TITLE
DOCS-11045: adds new isMaster output fields for cluster time

### DIFF
--- a/source/reference/command/isMaster.txt
+++ b/source/reference/command/isMaster.txt
@@ -128,6 +128,34 @@ roles:
    Clients may use :data:`~isMaster.maxWireVersion` to help negotiate
    compatibility with MongoDB.
 
+.. data:: isMaster.readOnly
+
+   .. versionadded:: 3.4
+   
+   A boolean value that, when ``true``, indicates that the
+   :program:`mongod` or :program:`mongos` is running in read-only mode.
+
+.. data:: isMaster.compression
+
+   .. versionadded:: 3.4
+   
+   .. versionchanged:: 3.6 In MongoDB 3.6, :data:`~isMaster.compression`
+      appears by default. Previously, :data:`~isMaster.compression` only
+      appeared if the network connection was compressed.
+   
+   An array listing the compression algorithms used to compress the
+   current connection's network communication between the
+   :program:`mongod` or :program:`mongos` and other members of the
+   deployment or the :program:`mongo` shell.
+
+   For a :program:`mongod` or :program:`mongos` using the ``snappy``
+   compressor , the :data:`~isMaster.compression` field would resemble
+   the following:
+
+   .. code-block:: sh
+   
+      "compression": [ "snappy" ]
+   
 Sharded Instances
 ~~~~~~~~~~~~~~~~~
 
@@ -227,7 +255,7 @@ of a replica set:
 
 .. data:: isMaster.electionId
 
-   .. versionadded:: 3.0.0
+   .. versionadded:: 3.0
 
    A unique identifier for each election. Included only in the output
    of :dbcommand:`isMaster` for the :term:`primary`. Used by clients
@@ -259,3 +287,7 @@ of a replica set:
       A :bsontype:`date <data_date>` object containing the
       time of the last write operation readable by
       :readconcern:`majority <"majority">` reads.
+
+For details on the ``ok`` status field, the ``operationTime`` field,
+and the ``$clusterTime`` field, see `Command Response
+<command-response>`.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3162)
<!-- Reviewable:end -->
