### PR TITLE
DOCS-11128: rephrase afterClusterTime reference in read concern docs

### DIFF
--- a/source/reference/read-concern.txt
+++ b/source/reference/read-concern.txt
@@ -134,18 +134,20 @@ The following read concern levels are available:
 .. versionadded:: 3.6
 
 MongoDB introduces the ``afterClusterTime`` option that can be set by
-the drivers. Read operations with a specified ``afterClusterTime``
-return data that meets the level requirement and the specified after
-cluster time requirement.
+the drivers.
+
+Read operations with a specified ``afterClusterTime``
+return data that meet both the :ref:`read concern level <read-concern-levels>` 
+requirement and the specified  ``afterClusterTime`` requirement.
 
 .. important::
 
    Do not manually set the ``afterClusterTime``. MongoDB drivers set
    this value automatically for operations associated with
-   :ref:`causally consistent sessions <causal-consistency>`.
+   causally consistent sessions.
 
-:ref:`Causally consistent sessions<causal-consistency>` use
-``afterClusterTime`` to provide :ref:`causal consistency <causal-consistency>`.
+Causally consistent sessions use the ``afterClusterTime`` value to
+provide causal consistency.
 
 ``afterClusterTime`` is available for :readconcern:`"local"` (default)
 and :readconcern:`"majority"` read concern levels:
@@ -155,8 +157,8 @@ and :readconcern:`"majority"` read concern levels:
    readConcern: { level: <"majority"|"local"> , afterClusterTime: <Timestamp> }
 
 For read operations not associated with causally consistent sessions,
-i.e. the ``afterClusterTime`` is unset, reads against secondary members
-have the default read concern level :readconcern:`"available"`.
+i.e. where the ``afterClusterTime`` is unset, reads against secondary members
+have the default read concern level: :readconcern:`"available"`.
 
 .. _read-concern-storage-engine-drivers:
 


### PR DESCRIPTION
That sentence still makes me sad, but we shall persevere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3180)
<!-- Reviewable:end -->
