### PR TITLE
DOCS-11140: bitwise query operations can't use indexes

### DIFF
--- a/source/includes/extracts-fact-query-bitwise.yaml
+++ b/source/includes/extracts-fact-query-bitwise.yaml
@@ -96,7 +96,7 @@ ref: _fact-query-bitwise-floating-point
 content: |
   :query:`{{op}}` will not match numerical values that cannot be represented as
   a signed 64-bit integer. This can be the case if a value is either too large
-  or small to fit in a signed 64-bit integer, or if it has a fractional
+  or too small to fit in a signed 64-bit integer, or if it has a fractional
   component.
 ---
 ref: fact-query-bitsallset-floating-point
@@ -129,7 +129,7 @@ inherit:
 ---
 ref: _fact-query-bitwise-sign-extension
 content: |
-  Numbers are sign extended. For example, {{op}} considers bit position ``200``
+  Numbers are sign extended. For example, :query:`{{op}}` considers bit position ``200``
   to be set for the negative number ``-5``, but bit position ``200`` to be clear
   for the positive number ``+5``.
 
@@ -140,7 +140,7 @@ content: |
 
      db.collection.save({ x: BinData(0, "ww=="), binaryValueofA: "11000011" })
 
-  {{op}} will consider all bits outside of ``x`` to be clear.
+  :query:`{{op}}` will consider all bits outside of ``x`` to be clear.
 ---
 ref: fact-query-bitsallset-sign-extension
 replacement:
@@ -180,4 +180,38 @@ content: |
      db.collection.save({ _id: 2, a: 20, binaryValueofA: "00010100" })
      db.collection.save({ _id: 3, a: 20.0, binaryValueofA: "00010100" })
      db.collection.save({ _id: 4, a: BinData(0, "Zg=="), binaryValueofA: "01100110" })
+---
+ref: _fact-query-bitwise-indexes
+content: |
+  Queries cannot use indexes for the :query:`{{op}}` portion of a
+  query, although the other portions of a query can use indexes, if
+  applicable.
+---
+ref: fact-query-bitwise-indexes-bitsAnySet
+replacement:
+  op: "$bitsAnySet"
+inherit:
+  ref: _fact-query-bitwise-indexes
+  file: extracts-fact-query-bitwise.yaml
+---
+ref: fact-query-bitwise-indexes-bitsAnyClear
+replacement:
+  op: "$bitsAnyClear"
+inherit:
+  ref: _fact-query-bitwise-indexes
+  file: extracts-fact-query-bitwise.yaml
+---
+ref: fact-query-bitwise-indexes-bitsAllSet
+replacement:
+  op: "$bitsAllSet"
+inherit:
+  ref: _fact-query-bitwise-indexes
+  file: extracts-fact-query-bitwise.yaml
+---
+ref: fact-query-bitwise-indexes-bitsAllClear
+replacement:
+  op: "$bitsAllClear"
+inherit:
+  ref: _fact-query-bitwise-indexes
+  file: extracts-fact-query-bitwise.yaml  
 ...

--- a/source/reference/operator/query/bitsAllClear.txt
+++ b/source/reference/operator/query/bitsAllClear.txt
@@ -22,6 +22,11 @@ $bitsAllClear
 Behavior
 --------
 
+Indexes
+~~~~~~~
+
+.. include:: /includes/extracts/fact-query-bitwise-indexes-bitsAllClear.rst
+
 Floating Point Values
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -30,7 +35,7 @@ Floating Point Values
 Sign Extension
 ~~~~~~~~~~~~~~
 
-.. include:: /includes/extracts/fact-query-bitsallset-sign-extension.rst
+.. include:: /includes/extracts/fact-query-bitsallclear-sign-extension.rst
 
 Examples
 --------

--- a/source/reference/operator/query/bitsAllSet.txt
+++ b/source/reference/operator/query/bitsAllSet.txt
@@ -22,6 +22,11 @@ $bitsAllSet
 Behavior
 --------
 
+Indexes
+~~~~~~~
+
+.. include:: /includes/extracts/fact-query-bitwise-indexes-bitsAllSet.rst
+
 Floating Point Values
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/reference/operator/query/bitsAnyClear.txt
+++ b/source/reference/operator/query/bitsAnyClear.txt
@@ -22,6 +22,11 @@ $bitsAnyClear
 Behavior
 --------
 
+Indexes
+~~~~~~~
+
+.. include:: /includes/extracts/fact-query-bitwise-indexes-bitsAnyClear.rst
+
 Floating Point Values
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -30,7 +35,7 @@ Floating Point Values
 Sign Extension
 ~~~~~~~~~~~~~~
 
-.. include:: /includes/extracts/fact-query-bitsallset-sign-extension.rst
+.. include:: /includes/extracts/fact-query-bitsanyclear-sign-extension.rst
 
 Examples
 --------

--- a/source/reference/operator/query/bitsAnySet.txt
+++ b/source/reference/operator/query/bitsAnySet.txt
@@ -22,6 +22,11 @@ $bitsAnySet
 Behavior
 --------
 
+Indexes
+~~~~~~~
+
+.. include:: /includes/extracts/fact-query-bitwise-indexes-bitsAnySet.rst
+
 Floating Point Values
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -30,7 +35,7 @@ Floating Point Values
 Sign Extension
 ~~~~~~~~~~~~~~
 
-.. include:: /includes/extracts/fact-query-bitsallset-sign-extension.rst
+.. include:: /includes/extracts/fact-query-bitsanyset-sign-extension.rst
 
 Examples
 --------


### PR DESCRIPTION
Also some copy fixes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3183)
<!-- Reviewable:end -->
