### PR TITLE
DOCS-11160 Missing readConcern available in cursor.readConcern() manu…

### DIFF
--- a/source/includes/fact-readConcern-option-description.rst
+++ b/source/includes/fact-readConcern-option-description.rst
@@ -2,6 +2,10 @@ Possible read concern levels are:
 
 - :readconcern:`"local"`. This is the default read concern level.
 
+- :readconcern:`"available"`. This is the default for reads against 
+  secondaries when :ref:`afterClusterTime` and `"level"` are unspecified.  The 
+  query returns the the instance's most recent data.
+
 - :readconcern:`"majority"`. Available for replica sets that use
   :ref:`WiredTiger storage engine <storage-wiredtiger>`.
 


### PR DESCRIPTION
…al page

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3185)
<!-- Reviewable:end -->
