### PR TITLE
Update db.auth.txt w/ needed shell flag

### DIFF
--- a/source/reference/method/db.auth.txt
+++ b/source/reference/method/db.auth.txt
@@ -43,6 +43,7 @@ Definition
 
    Alternatively, you can use :option:`mongo --username`,
    :option:`--password <mongo --password>`, and
+   :option:`--authenticationDatabase <mongo --authenticationDatabase>`, and
    :option:`--authenticationMechanism <mongo --authenticationMechanism>`
    to specify authentication credentials.
 


### PR DESCRIPTION
One cannot authenticate into the MongoDB shell ( at least in version 3.6.0 ) w/o specifying the authentication database. Following the format of the other flags mentioned here, one can use the --authenticationDatabase flag.

My apologies if I am not following procedure (or am simply wrong), but the current version seemed to me particularly misleading, and the change incredibly simple.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3186)
<!-- Reviewable:end -->
