### PR TITLE
Update db.auth.txt w/ needed shell flag

### DIFF
--- a/source/reference/method/db.auth.txt
+++ b/source/reference/method/db.auth.txt
@@ -42,7 +42,8 @@ Definition
    .. include:: /includes/apiargs/method-db.auth-param.rst
 
    Alternatively, you can use :option:`mongo --username`,
-   :option:`--password <mongo --password>`, and
+   :option:`--password <mongo --password>`,
+   :option:`--authenticationDatabase <mongo --authenticationDatabase>`, and
    :option:`--authenticationMechanism <mongo --authenticationMechanism>`
    to specify authentication credentials.
 


### PR DESCRIPTION
One cannot authenticate into the MongoDB shell ( at least in version 3.6.0 ) w/o specifying the authentication database. Following the format of the other flags mentioned here, one can use the --authenticationDatabase flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3187)
<!-- Reviewable:end -->
