### PR TITLE
DOCSP-1604 - Documenting autocomplete for Compass query bar

### DIFF
--- a/source/tutorial/query-documents.txt
+++ b/source/tutorial/query-documents.txt
@@ -110,6 +110,17 @@ This operation corresponds to the following SQL statement:
 
    SELECT * FROM inventory WHERE status = "D"
 
+.. tabs-drivers::
+
+   tabs:
+     - id: compass
+       content: |
+         .. note::
+
+            The |compass| query bar autocompletes the current query
+            based on the keys in your collection's documents, including
+            keys in embedded sub-documents.
+
 Specify Conditions Using Query Operators
 ----------------------------------------
 


### PR DESCRIPTION
Adding a blurb to the Compass tab for Query Documents page stating that Compass autocompletes queries. Will be adding a more detailed example to the Compass docs.

Code review: https://mongodbcr.appspot.com/178390001/

Staging: https://docs-mongodbcom-staging.corp.mongodb.com/jeffreyallen/DOCSP-1604/tutorial/query-documents.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3193)
<!-- Reviewable:end -->
