### PR TITLE
DOCS-10648: Clarify that bypassDocumentValidation does not apply for …

### DIFF
--- a/source/includes/apiargs-command-mapReduce-field.yaml
+++ b/source/includes/apiargs-command-mapReduce-field.yaml
@@ -158,7 +158,7 @@ name: verbose
 operation: mapReduce
 optional: true
 position: 10
-type: Boolean
+type: boolean
 ---
 name: bypassDocumentValidation
 source:
@@ -169,6 +169,16 @@ interface: command
 position: 11
 replacement:
   verb: "insert"
+post: |
+  .. note::
+
+     If the :ref:`output option <mapreduce-out-cmd>` is set to
+     ``inline``, no :doc:`document validation
+     </core/schema-validation/>` occurs. If the output goes to
+     a collection, :dbcommand:`mapReduce` observes any validation 
+     rules which the collection has and does not insert any invalid
+     documents unless the ``bypassDocumentValidation`` parameter is
+     set to true.
 ---
 arg_name: field
 operation: mapReduce

--- a/source/includes/apiargs-dbcommand-insert-field.yaml
+++ b/source/includes/apiargs-dbcommand-insert-field.yaml
@@ -50,7 +50,7 @@ description: |
   Enables {{role}} to bypass document validation
   during the operation. This lets you {{verb}} documents that do not
   meet the validation requirements.
-  
+
   .. versionadded:: 3.2
 interface: dbcommand
 operation: insert


### PR DESCRIPTION
…mapReduce inline mode

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3208)
<!-- Reviewable:end -->
