### PR TITLE
add example of logComponentVerbosity cmdline

### DIFF
--- a/source/reference/parameters.txt
+++ b/source/reference/parameters.txt
@@ -742,7 +742,11 @@ Logging Parameters
    You can also set parameter :parameter:`logComponentVerbosity` at
    startup time, passing the verbosity level document as a string.
 
-   :binary:`~bin.mongo` shell also provides the :method:`db.setLogLevel()`
+   .. code-block:: sh
+
+      mongod --setParameter "logComponentVerbosity={command: 3}"
+
+   The :binary:`~bin.mongo` shell also provides the :method:`db.setLogLevel()`
    to set the log level for a single component. For various ways to set
    the log verbosity level, see :ref:`log-messages-configure-verbosity`.
 


### PR DESCRIPTION
I often forget the syntax of having a document value for setParameter on the command line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3212)
<!-- Reviewable:end -->
