### PR TITLE
Corrected expresion $$REMOVE

### DIFF
--- a/source/reference/operator/aggregation/project.txt
+++ b/source/reference/operator/aggregation/project.txt
@@ -56,7 +56,7 @@ Definition
           .. versionchanged:: 3.6
 
              MongoDB 3.6 adds the variable :variable:`REMOVE`. If the
-             the expression evaluates to ``$$REMOVE``, the field is
+             the expression evaluates to ``$REMOVE``, the field is
              excluded in the output. For details, see :ref:`remove-var`.
 
       * - ``<field>:<0 or false>``
@@ -373,7 +373,7 @@ variable to excludes the ``author.middle`` field only if it equals ``""``:
             "author.middle": {
                $cond: {
                   if: { $eq: [ "", "$author.middle" ] }, 
-                  then: "$$REMOVE",
+                  then: "$REMOVE",
                   else: "$author.middle"
                } 
             }


### PR DESCRIPTION
Corrected expresion $$REMOVE to $REMOVE.

Error mesage is: 

> E QUERY    [thread1] Error: command failed: {
> 	"ok" : 0,
> 	"errmsg" : "Use of undefined variable: REMOVE",
> 	"code" : 17276,
> 	"codeName" : "Location17276"
> }

when executing:

> db.prueba.aggregate( [    {       $project: {          title: 1,          "author.first": 1,          "author.last" : 1,          "author.middle": {             $cond: {                if: { $eq: [ "", "$author.middle" ] },                then: "**$$REMOVE**",                else: "$author.middle"             }          }       }    } ] )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3227)
<!-- Reviewable:end -->
