### PR TITLE
DOCSP-1910: fixed typo in java example

### DIFF
--- a/source/tutorial/change-streams-example.txt
+++ b/source/tutorial/change-streams-example.txt
@@ -359,7 +359,6 @@ more of the following pipeline stages when configuring the change stream:
 - :pipeline:`$redact`
 
 .. tabs-drivers::
-
    tabs:
      - id: java-sync
        content: |
@@ -371,7 +370,7 @@ more of the following pipeline stages when configuring the change stream:
 
             MongoDatabase db = mongoClient.getDatabase("myTargetDatabase");
 
-            MongoCollection<Document> collection = database.getCollection("myTargetCollection");
+            MongoCollection<Document> collection = db.getCollection("myTargetCollection");
 
             // Create $match pipeline stage.
             List<Bson> pipeline = singletonList(Aggregates.match(Filters.or(


### PR DESCRIPTION
var name change -- was incorrect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3242)
<!-- Reviewable:end -->
