### PR TITLE
DOCS-9807: adds docs for sh.enableAutoSplit and sh.disableAutoSplit

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1350,6 +1350,8 @@ raw: /master/release-notes/3.0-general-improvements -> ${base}/release-notes/3.0
 [v3.6-*]: /${version}/core/document-validation -> ${base}/${version}/core/schema-validation
 [*-v3.4]: /${version}/core/schema-validation -> ${base}/${version}/core/document-validation
 [v3.6-*]: /${version}/reference/method/sh.getBalancerLockDetails -> ${base}/${version}/reference/method/js-sharding
+[v3.4-*]: /${version}/reference/method/sh.disableAutoSplit -> ${base}/${version}/reference/program/mongos
+[v3.4-*]: /${version}/reference/method/sh.enableAutoSplit -> ${base}/${version}/reference/program/mongos
 
 [v3.6-*]: /${version}/core/data-modeling-json-schema -> ${base}/${version}/core/schema-validation
 [v3.6-*]: /${version}/core/distributed-write-operations -> ${base}/${version}/core/distributed-queries

--- a/source/includes/ref-toc-method-sh.yaml
+++ b/source/includes/ref-toc-method-sh.yaml
@@ -22,6 +22,14 @@ name: ":method:`sh.enableBalancing()`"
 file: /reference/method/sh.enableBalancing
 description: "Activates the sharded collection balancer process if previously disabled using :method:`sh.disableBalancing()`."
 ---
+name: ":method:`sh.disableAutoSplit()`"  
+file: /reference/method/sh.disableAutoSplit
+description: "Disables auto-splitting for the sharded cluster."
+---
+name: ":method:`sh.enableAutoSplit()`"
+file: /reference/method/sh.enableAutoSplit
+description: "Enables auto-splitting for the sharded cluster."
+---
 name: ":method:`sh.enableSharding()`"
 file: /reference/method/sh.enableSharding
 description: "Enables sharding on a specific database."

--- a/source/reference/method/sh.disableAutoSplit.txt
+++ b/source/reference/method/sh.disableAutoSplit.txt
@@ -1,0 +1,37 @@
+===================
+sh.disableAutoSplit
+===================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Description
+-----------
+
+.. method:: sh.disableAutoSplit()
+
+   .. versionadded:: 3.4
+
+   Disables the autosplit flag in the :data:`config.settings`
+   collection. When auto-splitting is enabled for a sharded cluster,
+   MongoDB automatically splits chunks based on the shard key values
+   the chunk represents to keep the chunks from growing too large.
+   
+   Auto-splitting is enabled by default. For more
+   information on chunk splits, see :ref:`sharding-chunk-splits`.
+
+   .. important::
+
+      You can only run :method:`sh.enableAutoSplit()` from a
+      :binary:`~bin.mongo` shell connected to a :binary:`~bin.mongos`
+      instance. :method:`sh.enableAutoSplit()` errors if run on a
+      :binary:`~bin.mongod` instance.
+
+   .. seealso::
+      - :doc:`/tutorial/manage-sharded-cluster-balancer`
+      - :ref:`sharding-balancing`.

--- a/source/reference/method/sh.enableAutoSplit.txt
+++ b/source/reference/method/sh.enableAutoSplit.txt
@@ -1,0 +1,37 @@
+==================
+sh.enableAutoSplit
+==================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Description
+-----------
+
+.. method:: sh.enableAutoSplit()
+
+   .. versionadded:: 3.4
+
+   Enables auto-splitting for the sharded cluster.
+   :method:`sh.enableAutoSplit()` enables the autosplit flag in the
+   :data:`config.settings` collection.
+   
+   Auto-splitting is enabled by default.
+
+   .. important::
+
+      You can only run :method:`sh.enableAutoSplit()` from a
+      :binary:`~bin.mongo` shell connected to a :binary:`~bin.mongos`
+      instance. :method:`sh.enableBalancing()` errors if run on a
+      :binary:`~bin.mongod` instance.
+
+   For more information on chunk splits, see
+   :ref:`sharding-chunk-splits`. For more information about how MongoDB
+   balances chunks among shards, see:
+   :doc:`/tutorial/manage-sharded-cluster-balancer` and
+   :ref:`sharding-balancing`.


### PR DESCRIPTION
`99aebf6` should please be back-ported to v3.4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3243)
<!-- Reviewable:end -->
