### PR TITLE
DOCS-11265: clarify default for mapReduce verbose option

### DIFF
--- a/source/includes/apiargs-command-mapReduce-field.yaml
+++ b/source/includes/apiargs-command-mapReduce-field.yaml
@@ -115,7 +115,9 @@ arg_name: field
 description: |
   Specifies whether to convert intermediate data into BSON
   format between the execution of the ``map`` and ``reduce``
-  functions. Defaults to ``false``.
+  functions.
+
+  Defaults to ``false``.
 
   If ``false``:
 
@@ -140,7 +142,6 @@ description: |
     500,000 distinct ``key`` arguments to the mapper's ``emit()``
     function.
 
-  The ``jsMode`` defaults to false.
 interface: command
 name: jsMode
 operation: mapReduce
@@ -151,8 +152,11 @@ type: boolean
 arg_name: field
 description: |
   Specifies whether to include the ``timing`` information in the
-  result information. The ``verbose`` defaults to ``true`` to include
+  result information. Set ``verbose`` to ``true`` to include
   the ``timing`` information.
+
+  Defaults to ``false``.
+
 interface: command
 name: verbose
 operation: mapReduce


### PR DESCRIPTION
If you were feeling generous, you could plop this into 3.4 as well :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3245)
<!-- Reviewable:end -->
