### PR TITLE
DOCS-11357 Remove mention of WiredTiger snapshotting after 2 GB of jo…

### DIFF
--- a/source/includes/extracts-wired-tiger.yaml
+++ b/source/includes/extracts-wired-tiger.yaml
@@ -183,16 +183,18 @@ content: |
 ---
 ref: wt-snapshot-frequency
 content: |
-   MongoDB configures WiredTiger to create checkpoints (i.e. write the
-   snapshot data to disk) at intervals of 60 seconds.
+   .. versionchanged:: 3.6
+      MongoDB configures WiredTiger to create checkpoints (i.e. write the
+      snapshot data to disk) at intervals of 60 seconds.
 ---
 ref: wt-journal-frequency
 content: |
    - .. versionadded:: 3.2
         Every 50 milliseconds.
 
-   - MongoDB sets checkpoints to occur in WiredTiger on user data at an
-     interval of 60 seconds.
+   - .. versionchanged:: 3.6
+        MongoDB sets checkpoints to occur in WiredTiger on user data at an
+        interval of 60 seconds.
 
    - If the write operation includes a write concern of :writeconcern:`j:
      true <j>`, WiredTiger forces a sync of the WiredTiger journal files.

--- a/source/includes/extracts-wired-tiger.yaml
+++ b/source/includes/extracts-wired-tiger.yaml
@@ -168,7 +168,7 @@ content: |
 ---
 ref: wt-cache-default-setting
 content: |
-   
+
    Starting in 3.4, the WiredTiger internal cache, by default, will use
    the larger of either:
 
@@ -184,8 +184,7 @@ content: |
 ref: wt-snapshot-frequency
 content: |
    MongoDB configures WiredTiger to create checkpoints (i.e. write the
-   snapshot data to disk) at intervals of 60 seconds or 2 gigabytes of
-   journal data.
+   snapshot data to disk) at intervals of 60 seconds.
 ---
 ref: wt-journal-frequency
 content: |
@@ -193,8 +192,7 @@ content: |
         Every 50 milliseconds.
 
    - MongoDB sets checkpoints to occur in WiredTiger on user data at an
-     interval of 60 seconds or when 2 GB of journal data has been written,
-     whichever occurs first.
+     interval of 60 seconds.
 
    - If the write operation includes a write concern of :writeconcern:`j:
      true <j>`, WiredTiger forces a sync of the WiredTiger journal files.


### PR DESCRIPTION
…urnal data

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3250)
<!-- Reviewable:end -->
