### PR TITLE
DOCS-10721 Document locked memory ulimit

### DIFF
--- a/source/reference/ulimit.txt
+++ b/source/reference/ulimit.txt
@@ -104,7 +104,7 @@ system limits, as in the following example:
    -m: resident set size (kbytes) unlimited
    -u: processes                  192276
    -n: file descriptors           21000
-   -l: locked-in-memory size (kb) 40000
+   -l: locked-in-memory size (kb) unlimited
    -v: address space (kb)         unlimited
    -x: file locks                 unlimited
    -i: pending signals            192276
@@ -158,7 +158,7 @@ process.
 
 Depending on your system's configuration, and default settings, any
 change to system limits made using ``ulimit`` may revert following
-system a system restart. Check your distribution and operating
+a system restart. Check your distribution and operating
 system documentation for more information.
 
 .. include:: /includes/note-suse-ulimit.rst
@@ -175,6 +175,7 @@ the following thresholds and settings are particularly important for
 - ``-f`` (file size): ``unlimited``
 - ``-t`` (cpu time): ``unlimited``
 - ``-v`` (virtual memory): ``unlimited`` [#memory-size]_
+- ``-l`` (locked-in-memory size): ``unlimited``
 - ``-n`` (open files): ``64000``
 - ``-m`` (memory size): ``unlimited`` [#memory-size]_ [#rss-linux]_
 - ``-u`` (processes/threads): ``64000``
@@ -196,11 +197,12 @@ example:
 
 .. code-block:: sh
 
-   limit fsize unlimited unlimited  # (file size)
-   limit cpu unlimited unlimited    # (cpu time)
-   limit as unlimited unlimited     # (virtual memory size)
-   limit nofile 64000 64000         # (open files)
-   limit nproc 64000 64000          # (processes/threads)
+   limit fsize unlimited unlimited    # (file size)
+   limit cpu unlimited unlimited      # (cpu time)
+   limit as unlimited unlimited       # (virtual memory size)
+   limit memlock unlimited unlimited  # (locked-in-memory size)
+   limit nofile 64000 64000           # (open files)
+   limit nproc 64000 64000            # (processes/threads)
 
 Each ``limit`` stanza sets the "soft" limit to the first value specified and the "hard"
 limit to the second.
@@ -236,6 +238,8 @@ example:
    LimitCPU=infinity
    # (virtual memory size)
    LimitAS=infinity
+   # (locked-in-memory size)
+   LimitMEMLOCK=infinity
    # (open files)
    LimitNOFILE=64000
    # (processes/threads)


### PR DESCRIPTION
Backport to 3.2 and 3.4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3251)
<!-- Reviewable:end -->
