### PR TITLE
DOCS-11421 Internal auth is used by mongos

### DIFF
--- a/source/core/security-internal-authentication.txt
+++ b/source/core/security-internal-authentication.txt
@@ -18,6 +18,12 @@ You can authenticate members of :term:`replica sets <replica set>` and
 the members, MongoDB can use either keyfiles or :ref:`x.509 <security-auth-x509>`
 certificates.
 
+The selected method is used for all internal communication. For example, when a
+client authenticates to a :binary:`~bin.mongos` using one of the supported
+:ref:`authentication mechanisms <security-authentication-mechanisms>`,
+the ``mongos`` then uses the configured internal authentication method to
+connect to the required :binary:`~bin.mongod` processes.
+
 .. note::
 
    Enabling internal authentication also enables :doc:`client


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3256)
<!-- Reviewable:end -->
