### PR TITLE
DOCS-11415: Use TLS to mitigate cleartext passwords

### DIFF
--- a/source/includes/fact-auth-restrictions-array-contents.rst
+++ b/source/includes/fact-auth-restrictions-array-contents.rst
@@ -1,7 +1,8 @@
 .. versionadded:: 3.6
 
-The ``authenticationRestrictions`` document can contain the
-following fields:
+The ``authenticationRestrictions`` document can contain *only* the
+following fields. The server throws an error if the 
+``authenticationRestrictions`` document contains an unrecognized field:
 
 .. list-table::
    :header-rows: 1
@@ -29,13 +30,6 @@ following fields:
        server does not authenticate the user.
 
 .. important::
-
-   These are the only fields recognized by the server in the
-   ``authenticationRestrictions`` document. When creating a user,
-   if the server does not recognize a field contained within the
-   ``authenticationRestrictions`` document, it throws an error.
-
-.. warning::
 
    If a user inherits multiple roles with incompatible authentication
    restrictions, that user becomes unusable.

--- a/source/includes/fact-cleartext-passwords-tls.rst
+++ b/source/includes/fact-cleartext-passwords-tls.rst
@@ -1,0 +1,12 @@
+.. warning::
+
+   By default, |command| sends all specified data to the MongoDB 
+   instance in cleartext. Use TLS transport encryption to protect
+   communications between clients and the server, 
+   including the password sent by |command|. For 
+   instructions on enabling TLS transport encryption, see 
+   :doc:`/tutorial/configure-ssl`. 
+
+   MongoDB does not store the password in cleartext. The password
+   is only vulnerable in transit between the client and the 
+   server, and only if TLS transport encryption is not enabled.

--- a/source/reference/command/createUser.txt
+++ b/source/reference/command/createUser.txt
@@ -58,9 +58,9 @@ Behavior
 Encryption
 ~~~~~~~~~~
 
-:dbcommand:`createUser` sends password to the MongoDB instance in
-cleartext. To encrypt the password in transit, use :doc:`TLS/SSL
-</tutorial/configure-ssl>`.
+.. |command| replace:: :dbcommand:`createUser`
+
+.. include:: /includes/fact-cleartext-passwords-tls.rst
 
 External Credentials
 ~~~~~~~~~~~~~~~~~~~~

--- a/source/reference/command/updateUser.txt
+++ b/source/reference/command/updateUser.txt
@@ -64,9 +64,9 @@ Authentication Restrictions
 Behavior
 --------
 
-:dbcommand:`updateUser` sends the password to the MongoDB instance in
-cleartext. To encrypt the password in transit, use :doc:`TLS/SSL
-</tutorial/configure-ssl>`.
+.. |command| replace:: :dbcommand:`updateUser`
+
+.. include:: /includes/fact-cleartext-passwords-tls.rst
 
 Required Access
 ---------------

--- a/source/reference/method/db.changeUserPassword.txt
+++ b/source/reference/method/db.changeUserPassword.txt
@@ -26,6 +26,13 @@ Required Access
 
 .. include:: /includes/access-change-password.rst
 
+Behavior
+--------
+
+.. |command| replace:: :method:`db.changeUserPassword()`
+
+.. include:: /includes/fact-cleartext-passwords-tls.rst
+
 Example
 -------
 

--- a/source/reference/method/db.createUser.txt
+++ b/source/reference/method/db.createUser.txt
@@ -68,9 +68,9 @@ Behavior
 Encryption
 ~~~~~~~~~~
 
-:method:`db.createUser()` sends password to the MongoDB instance
-*without* encryption. To encrypt the password during transmission,
-use :doc:`TLS/SSL </tutorial/configure-ssl>`.
+.. |command| replace:: :method:`db.createUser()`
+
+.. include:: /includes/fact-cleartext-passwords-tls.rst
 
 External Credentials
 ~~~~~~~~~~~~~~~~~~~~

--- a/source/reference/method/db.updateUser.txt
+++ b/source/reference/method/db.updateUser.txt
@@ -79,9 +79,9 @@ command.
 Behavior
 --------
 
-:method:`db.updateUser()` sends password to the MongoDB instance
-*without* encryption. To encrypt the password during transmission,
-use :doc:`TLS/SSL </tutorial/configure-ssl>`.
+.. |command| replace:: :method:`db.updateUser()`
+
+.. include:: /includes/fact-cleartext-passwords-tls.rst
 
 Required Access
 ---------------


### PR DESCRIPTION
@kay-kim RFM into master. Would need to remove the chunk on authrestrictions if we want to backport to 3.2/3.4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3258)
<!-- Reviewable:end -->
