### PR TITLE
(DOCS-9990, -10826): Updated flushRouterConfig.

### DIFF
--- a/source/reference/command/flushRouterConfig.txt
+++ b/source/reference/command/flushRouterConfig.txt
@@ -13,18 +13,25 @@ flushRouterConfig
 .. dbcommand:: flushRouterConfig
 
    :dbcommand:`flushRouterConfig` clears the cached routing table in a
-   :binary:`~bin.mongos` instance. Subsequent :binary:`~bin.mongos`
-   commands update the routing table as routes are needed.
+   :binary:`~bin.mongos` instance. Subsequent commands against that 
+   :binary:`~bin.mongos` will repopulate the routing table cache from 
+   the :term:`config server` as they execute.
 
-   When this command is called, it forces an update when the
-   configuration database holds data that is more recent than the data
-   cached in the :binary:`~bin.mongos` process.
+   Use this command to force the routing table cache to be refreshed 
+   from the :term:`config server` if it contains more recent data. In 
+   most cases, this happens automatically. You should need to run 
+   :dbcommand:`flushRouterConfig` only after :dbcommand:`movePrimary` 
+   has been run.
+
+   .. seealso::
+
+      For when and why :dbcommand:`flushRouterConfig` is run, see 
+      **Considerations** on the :dbcommand:`movePrimary` page.
 
    .. warning::
 
-      Do not modify the config data, except as explicitly
-      documented. A config database cannot typically tolerate manual
-      manipulation.
+      Do not modify the routing table data except when it is 
+      explicitly documented.
 
    :dbcommand:`flushRouterConfig` is an administrative command that is
    only available for :binary:`~bin.mongos` instances.

--- a/source/reference/command/flushRouterConfig.txt
+++ b/source/reference/command/flushRouterConfig.txt
@@ -12,13 +12,13 @@ flushRouterConfig
 
 .. dbcommand:: flushRouterConfig
 
-   :dbcommand:`flushRouterConfig` clears the current cluster
-   information cached by a :binary:`~bin.mongos` instance and reloads all
-   :term:`sharded cluster` metadata from the :term:`config database`.
+   :dbcommand:`flushRouterConfig` clears the cached routing table in a
+   :binary:`~bin.mongos` instance. Subsequent :binary:`~bin.mongos`
+   commands update the routing table as routes are needed.
 
-   This forces an update when the configuration database holds data
-   that is newer than the data cached in the :binary:`~bin.mongos`
-   process.
+   When this command is called, it forces an update when the
+   configuration database holds data that is more recent than the data
+   cached in the :binary:`~bin.mongos` process.
 
    .. warning::
 
@@ -28,5 +28,13 @@ flushRouterConfig
 
    :dbcommand:`flushRouterConfig` is an administrative command that is
    only available for :binary:`~bin.mongos` instances.
+
+   Call this command using the following form:
+   
+   .. example::
+
+      .. code-block:: javascript
+
+         db.adminCommand("flushRouterConfig")
 
    .. versionadded:: 1.8.2


### PR DESCRIPTION
@steveren , @kaloianm : This PR adds the invocation example and changes the explanation as to how the cache is cleared and rebuilt. [Staged](https://docs-mongodbcom-staging.corp.mongodb.com/anthonysansone/DOCS-10826/reference/command/flushRouterConfig.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3262)
<!-- Reviewable:end -->
