### PR TITLE
Rename authorization to authentication for --auth command line option to match --noauth and elsewhere

### DIFF
--- a/locale/es/LC_MESSAGES/reference/program/mongod.po
+++ b/locale/es/LC_MESSAGES/reference/program/mongod.po
@@ -1471,7 +1471,7 @@ msgstr ""
 
 #: ../source/includes/option/option-mongod-auth.rst:3
 msgid ""
-"Enables authorization to control user's access to database resources and "
+"Enables authentication to control user's access to database resources and "
 "operations. When authorization is enabled, MongoDB requires all clients to "
 "authenticate themselves first in order to determine the access for the "
 "client."

--- a/locale/es/LC_MESSAGES/reference/program/mongod.po
+++ b/locale/es/LC_MESSAGES/reference/program/mongod.po
@@ -1472,7 +1472,7 @@ msgstr ""
 #: ../source/includes/option/option-mongod-auth.rst:3
 msgid ""
 "Enables authentication to control user's access to database resources and "
-"operations. When authorization is enabled, MongoDB requires all clients to "
+"operations. When authentication is enabled, MongoDB requires all clients to "
 "authenticate themselves first in order to determine the access for the "
 "client."
 msgstr ""

--- a/locale/pot/reference/program/mongod.pot
+++ b/locale/pot/reference/program/mongod.pot
@@ -416,7 +416,7 @@ msgstr ""
 
 #: ../source/includes/option/option-mongod-auth.rst:3
 # 0f37c30ef3a64eecaf924eac9b82e26d
-msgid "Enables authorization to control user's access to database resources and operations. When authorization is enabled, MongoDB requires all clients to authenticate themselves first in order to determine the access for the client."
+msgid "Enables authentication to control user's access to database resources and operations. When authentication is enabled, MongoDB requires all clients to authenticate themselves first in order to determine the access for the client."
 msgstr ""
 
 #: ../source/includes/option/option-mongod-auth.rst:8

--- a/locale/zh/LC_MESSAGES/reference/program/mongod.po
+++ b/locale/zh/LC_MESSAGES/reference/program/mongod.po
@@ -517,8 +517,8 @@ msgstr ""
 # 0f37c30ef3a64eecaf924eac9b82e26d
 #: ../source/includes/option/option-mongod-auth.rst:3
 msgid ""
-"Enables authorization to control user's access to database resources and "
-"operations. When authorization is enabled, MongoDB requires all clients "
+"Enables authentication to control user's access to database resources and "
+"operations. When authentication is enabled, MongoDB requires all clients "
 "to authenticate themselves first in order to determine the access for the"
 " client."
 msgstr ""

--- a/source/includes/options-mongod.yaml
+++ b/source/includes/options-mongod.yaml
@@ -441,8 +441,8 @@ name: auth
 args: null
 directive: option
 description: |
-  Enables authorization to control user's access to database resources
-  and operations. When authorization is enabled, MongoDB requires all
+  Enables authentication to control user's access to database resources
+  and operations. When authentication is enabled, MongoDB requires all
   clients to authenticate themselves first in order to determine the
   access for the client.
 


### PR DESCRIPTION
Compare https://docs.mongodb.com/manual/reference/program/mongod/#cmdoption-mongod-auth

> --auth
> Enables **authorization** to control user’s access to database resources and operations. When **authorization** is enabled, MongoDB requires all clients to authenticate themselves first in order to determine the access for the client.

with https://docs.mongodb.com/manual/reference/program/mongod/#cmdoption-mongod-noauth

> --noauth
> Disables **authentication**. Currently the default. Exists for future compatibility and clarity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3265)
<!-- Reviewable:end -->
