### PR TITLE
Update read-concern.txt

### DIFF
--- a/source/reference/read-concern.txt
+++ b/source/reference/read-concern.txt
@@ -136,16 +136,16 @@ The following read concern levels are available:
 
 .. versionadded:: 3.6
 
-MongoDB introduces the ``afterClusterTime`` option that can be set by
-the drivers.
+MongoDB 3.6 introduces the ``afterClusterTime`` option that can be set by
+the drivers. To satisfy a read request with an ``afterClusterTime`` value of ``T`` a mongod must perform the request after its opLog reaches time ``T``. If its opLog has not reached time ``T`` the mongod must wait to service the request.
 
 Read operations with a specified ``afterClusterTime``
 return data that meet both the :ref:`read concern level <read-concern-levels>` 
-requirement and the specified  ``afterClusterTime`` requirement.
+requirement and the specified ``afterClusterTime`` requirement.
 
 .. important::
 
-   Do not manually set the ``afterClusterTime``. MongoDB drivers set
+   Do not manually set ``afterClusterTime``. MongoDB drivers set
    this value automatically for operations associated with
    causally consistent sessions.
 
@@ -160,8 +160,8 @@ and :readconcern:`"majority"` read concern levels:
    readConcern: { level: <"majority"|"local"> , afterClusterTime: <Timestamp> }
 
 For read operations not associated with causally consistent sessions,
-i.e. where the ``afterClusterTime`` is unset, reads against secondary members
-have the default read concern level: :readconcern:`"available"`.
+i.e. where ``afterClusterTime`` is unset, reads against secondary members
+have the default read concern level: :readconcern:`"available"`, meaning that queries will return the instance’s most recent data. :readconcern:`"available"` provides no guarantee that data has been written to a majority of the replica set members. It might be rolled back.
 
 .. _read-concern-storage-engine-drivers:
 


### PR DESCRIPTION
Our discussion of afterClusterTime here:
https://docs.mongodb.com/manual/reference/read-concern/#afterclustertime
does not currently explain exactly what effect afterClusterTime has on the way an instance handles operations. 

In addition, we don't explain readConcern: available which leaves the reader at a bit of a cliff hanger.

Finally, there are several grammatical mistakes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3266)
<!-- Reviewable:end -->
