### PR TITLE
adding commas to the code-block containing the example documents

### DIFF
--- a/source/core/index-unique.txt
+++ b/source/core/index-unique.txt
@@ -120,8 +120,8 @@ For example, consider a collection with the following documents:
 
 .. code-block:: javascript
 
-   { _id: 1, a: [ { loc: "A", qty: 5 }, { qty: 10 } ] }
-   { _id: 2, a: [ { loc: "A" }, { qty: 5 } ] }
+   { _id: 1, a: [ { loc: "A", qty: 5 }, { qty: 10 } ] },
+   { _id: 2, a: [ { loc: "A" }, { qty: 5 } ] },
    { _id: 3, a: [ { loc: "A", qty: 10 } ] }
 
 Create a unique compound multikey index on ``a.loc`` and ``a.qty``:


### PR DESCRIPTION
missing commas on this code block cause insert to fail.

as is:
```
> db.test.insert({ _id: 1, a: [ { loc: "A", qty: 5 }, { qty: 10 } ] }
... { _id: 2, a: [ { loc: "A" }, { qty: 5 } ] }
... { _id: 3, a: [ { loc: "A", qty: 10 } ] })
2018-03-24T08:26:45.803-0400 E QUERY    [thread1] SyntaxError: missing ) after argument list @(shell):2:0
```
with commas added:
```
> db.test.insert({ _id: 1, a: [ { loc: "A", qty: 5 }, { qty: 10 } ] },
... { _id: 2, a: [ { loc: "A" }, { qty: 5 } ] },
... { _id: 3, a: [ { loc: "A", qty: 10 } ] })
WriteResult({ "nInserted" : 1 })
> 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3267)
<!-- Reviewable:end -->
