### PR TITLE
Suggestion for explanation about $in

### DIFF
--- a/source/reference/operator/query/in.txt
+++ b/source/reference/operator/query/in.txt
@@ -23,8 +23,7 @@ $in
       { field: { $in: [<value1>, <value2>, ... <valueN> ] } }
 
    If the ``field`` holds an array, then the :query:`$in` operator
-   selects the documents whose ``field`` holds an array that contains
-   at least one element that matches a value in the specified array
+   selects the documents whose ``field`` has at least one element that matches the value in the specified array
    (e.g. ``<value1>``, ``<value2>``, etc.)
 
    .. versionchanged:: 2.6


### PR DESCRIPTION
About '$in', there is such a description:
 If the ``field`` holds an array, then the :query:`$in` operator
   selects the documents whose ``field`` holds an array that contains
   at least one element that matches a value in the specified array
   (e.g. ``<value1>``, ``<value2>``, etc.)
This method is said to match field is a array,but，it is more powerful.
Even the field is not a array,the method also can selects the documents.
The following is an example：
> db.in.find()
{ "_id" : ObjectId("5acec3d446973fd2133c336c"), "name" : "tom", "hobbies" : [ "read", "play" ] }
{ "_id" : ObjectId("5acec3fb46973fd2133c336d"), "name" : "akke", "hobbies" : [ "read", "play", "write" ] }
{ "_id" : ObjectId("5acec40d46973fd2133c336e"), "name" : "luffy", "hobbies" : "read" }

> db.in.find({'hobbies':{'$in':['read']}},{})
{ "_id" : ObjectId("5acec3d446973fd2133c336c"), "name" : "tom", "hobbies" : [ "read", "play" ] }
{ "_id" : ObjectId("5acec3fb46973fd2133c336d"), "name" : "akke", "hobbies" : [ "read", "play", "write" ] }
{ "_id" : ObjectId("5acec40d46973fd2133c336e"), "name" : "luffy", "hobbies" : "read" }

So, I made some changes to the description of the original text, please advise, thank you