### PR TITLE
DOCSP-2294: correct param name for cursor.tailable method

### DIFF
--- a/source/includes/apiargs-method-cursor.tailable-param.yaml
+++ b/source/includes/apiargs-method-cursor.tailable-param.yaml
@@ -5,7 +5,7 @@ description: |
   ``awaitData`` is ``false`` by default.
   
 interface: method
-name: isAwaitData
+name: awaitData
 operation: cursor.tailable
 optional: true
 position: 1

--- a/source/reference/method/cursor.tailable.txt
+++ b/source/reference/method/cursor.tailable.txt
@@ -27,7 +27,7 @@ Definition
    
    .. code-block:: javascript
    
-      cursor.tailable( { isAwaitData : <boolean> } )
+      cursor.tailable( { awaitData : <boolean> } )
       
    :method:`~cursor.tailable()` has the following parameter:
    


### PR DESCRIPTION
Backport to 3.6 (and 3.4 if one is feeling charitable) would be lovely :D

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3303)
<!-- Reviewable:end -->
