### PR TITLE
(DOCS-11010): Update mongorestore grants.

### DIFF
--- a/source/includes/access-mongorestore-collections.rst
+++ b/source/includes/access-mongorestore-collections.rst
@@ -5,13 +5,14 @@ access to restore any database if the backup data does not include
 
 .. include:: /includes/fact-restore-role-system.profile.rst
 
-If running :binary:`~bin.mongorestore` with :option:`--oplogReplay <mongorestore --oplogReplay>`, the
-:authrole:`restore` role is insufficient to replay the oplog. To replay
-the oplog, create a :ref:`user-defined role <create-user-defined-role>`
-that has :authaction:`anyAction` on :ref:`resource-anyresource` and
-grant only to users who must run :binary:`~bin.mongorestore` with
+As of MongoDB 3.2.11, you can run :binary:`~bin.mongorestore` with 
+:option:`--oplogReplay <mongorestore --oplogReplay>` if you have the
+:authrole:`restore` role. To replay the oplog on versions of MongoDB 
+3.2.10 and earlier, you must create a 
+:ref:`user-defined role <create-user-defined-role>` that has 
+:authaction:`anyAction` on :ref:`resource-anyresource` and grant only 
+to users who must run :binary:`~bin.mongorestore` with 
 :option:`--oplogReplay <mongorestore --oplogReplay>`.
-
 
 .. COMMENT per the following commit, choosing the anyAction/anyResource
    over the __system role.


### PR DESCRIPTION
@rob-mongodb : This is a small update to the permission grants needed to run `mongorestore`. [Staged.](https://docs-mongodbcom-staging.corp.mongodb.com/anthonysansone/DOCS-11010/tutorial/backup-and-restore-tools.html#access-control)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs/3332)
<!-- Reviewable:end -->
