### PR TITLE
Remove statement from $and operator document

### DIFF
--- a/source/reference/operator/query/and.txt
+++ b/source/reference/operator/query/and.txt
@@ -75,9 +75,6 @@ This query will select all documents where:
 - the ``sale`` field value is equal to ``true`` **or** the ``qty``
   field value is less than ``20``.
 
-This query cannot be constructed using an implicit ``AND`` operation,
-because it uses the :query:`$or` operator more than once.
-
 .. seealso::
 
    :method:`~db.collection.find()`, :method:`~db.collection.update()`,


### PR DESCRIPTION
This query can be constructed without the help of explicit `and` using `$in` operator which is encourage to be used at any place possible instead of the `$or`. It discourages learners from trying out different methods and potentially adopting $in operator. An equivalent query could be as follows. 

```js
db.inventory.find({
	price: { $in: [ 0.99, 1.99 ] },
	$or: [ { sale: true }, { qty: { $lt: 20 } } ]
});
```

We can instead add the above mentioned query here or a helpful statement. Not adding anything for now.