### PR TITLE
Triage Updates

### DIFF
--- a/source/includes/apiargs-method-db.collection.explain-param.yaml
+++ b/source/includes/apiargs-method-db.collection.explain-param.yaml
@@ -11,9 +11,6 @@ description: |
   :method:`cursor.explain()`, MongoDB interprets ``true`` as
   ``"allPlansExecution"`` and ``false`` as ``"queryPlanner"``.
   
-  :method:`aggregate() <db.collection.aggregate()>` ignores the verbosity
-  parameter and executes in ``queryPlanner`` mode.
-  
   For more information on the modes, see
   :ref:`explain-method-verbosity`.
 interface: method

--- a/source/includes/extracts-wired-tiger.yaml
+++ b/source/includes/extracts-wired-tiger.yaml
@@ -175,6 +175,12 @@ content: |
    - 50% of (RAM - 1 GB), or
 
    - 256 MB.
+
+   For example, on a system with a total of 4GB of RAM the WiredTiger
+   cache will use 1.5GB of RAM (``0.5 * (4 GB - 1 GB) = 1.5 GB``).
+   Conversely, a system with a total of 1.25 GB of RAM will allocate 256
+   MB to the WiredTiger cache because that is more than half of the
+   total RAM minus one gigabyte (``0.5 * (1.25 GB - 1 GB) = 128 MB < 256 MB``).
 ---
 ref: wt-filesystem-cache
 content: |

--- a/source/reference/method/db.collection.explain.txt
+++ b/source/reference/method/db.collection.explain.txt
@@ -64,9 +64,6 @@ Verbosity Modes
 The behavior of :method:`db.collection.explain()` and the amount of
 information returned depend on the ``verbosity`` mode.
 
-:method:`~db.collection.aggregate()` ignores the verbosity 
-parameter and executes in ``queryPlanner`` mode.
-
 .. |explain| replace:: :method:`db.collection.explain()`
 .. |operation| replace:: method
 


### PR DESCRIPTION
Quick fixes from docs triage

([staged changes](https://docs-mongodbcom-staging.corp.mongodb.com/nick/triage/reference/configuration-options.html#storage.wiredTiger.engineConfig.cacheSizeGB)) [DOCS-11776: Provide example(s) of WiredTiger cacheSizeGB default calculation](https://jira.mongodb.org/browse/DOCS-11776)

([staged changes](https://docs-mongodbcom-staging.corp.mongodb.com/nick/triage/reference/method/db.collection.explain.html#db.collection.explain)) [DOCS-11777: db.collection.explain("verbosity") now supported for aggregation](https://jira.mongodb.org/browse/DOCS-11777)

_**Please backport DOCS-11777 to 3.6**_