### PR TITLE
(DOCS-11711): Updated downgrade shutdown requirement.

### DIFF
--- a/source/includes/note-clean-shutdown.rst
+++ b/source/includes/note-clean-shutdown.rst
@@ -1,0 +1,9 @@
+.. note::
+
+   If you do not perform a clean shut down, errors result that
+   prevent the :binary:`~bin.mongod` process from starting.
+
+   Invoking ``sudo service mongod stop`` does not guarantee a 
+   clean shutdown. This ``service`` script forceably stops the
+   :binary:`~bin.mongod` process if it takes longer than five
+   minutes to shut down.

--- a/source/includes/note-clean-shutdown.rst
+++ b/source/includes/note-clean-shutdown.rst
@@ -1,7 +1,12 @@
 .. note::
 
-   If you do not perform a clean shut down, errors result that
+   If you do not perform a clean shut down, errors may result that
    prevent the :binary:`~bin.mongod` process from starting.
+
+   Forcibly terminating the :binary:`~bin.mongod` process may cause 
+   inaccurate results for :method:`db.collection.count()` and 
+   :method:`db.stats()` as well as lengthen startup time the next time 
+   that the :binary:`~bin.mongod` process is restarted.
 
    Invoking ``sudo service mongod stop`` does not guarantee a 
    clean shutdown. This ``service`` script forceably stops the

--- a/source/includes/steps-3.6-downgrade-mongod.yaml
+++ b/source/includes/steps-3.6-downgrade-mongod.yaml
@@ -16,4 +16,13 @@ ref: 3.6-downgrade-restart-instance
 content: |
   Shut down your :binary:`~bin.mongod` instance. Replace the existing
   binary with the downloaded :binary:`~bin.mongod` binary and restart.
+
+  a. :ref:`Perform a clean shut down <terminate-mongod-processes>`
+     of the :binary:`~bin.mongod` process.
+
+     .. include:: /includes/note-clean-shutdown.rst
+
+  #. Replace the |newversion| binary with the |oldversion| binary.
+
+  #. Start the |oldversion| :binary:`~bin.mongod` process.
 ...

--- a/source/includes/steps-3.6-downgrade-replica-set.yaml
+++ b/source/includes/steps-3.6-downgrade-replica-set.yaml
@@ -17,13 +17,19 @@ content: |
   Downgrade each :term:`secondary` member of the replica set, one at a
   time:
 
-  a. Shut down the :binary:`~bin.mongod`. See :ref:`terminate-mongod-processes` for instructions on safely terminating :binary:`~bin.mongod` processes.
+  a. :ref:`Perform a clean shut down <terminate-mongod-processes>`
+     of the :binary:`~bin.mongod` process.
 
-  #. Replace the |newversion| binary with the |oldversion| binary and restart.
+     .. include:: /includes/note-clean-shutdown.rst
+
+  #. Replace the |newversion| binary with the |oldversion| binary.
+
+  #. Start the |oldversion| :binary:`~bin.mongod` process.
 
   #. Wait for the member to recover to ``SECONDARY`` state
-     before downgrading the next secondary. To check the member's state,
-     use the :method:`rs.status()` method in the :binary:`~bin.mongo` shell.
+     before downgrading the next secondary. To check the member's 
+     state, use the :method:`rs.status()` method in the 
+     :binary:`~bin.mongo` shell.
 
 ---
 title: Step down the primary.
@@ -46,7 +52,8 @@ level: 4
 ref: downgrade-primary
 content: |
   When :method:`rs.status()` shows that the primary has stepped down
-  and another member has assumed ``PRIMARY`` state, shut down the
+  and another member has assumed ``PRIMARY`` state, 
+  :ref:`perform a clean shut down <terminate-mongod-processes>` of the
   previous primary and replace the :binary:`~bin.mongod` binary with
-  the |oldversion| binary and start the new instance.
+  the |oldversion| binary and start the new process.
 ...

--- a/source/includes/steps-3.6-downgrade-sharded-cluster.yaml
+++ b/source/includes/steps-3.6-downgrade-sharded-cluster.yaml
@@ -29,11 +29,15 @@ content: |
 
    Downgrade the shards one at a time. If the shards are replica sets, for each shard:
 
-   1. Downgrade the :ref:`secondary <replica-set-secondary-members>`
+   a. Downgrade the :ref:`secondary <replica-set-secondary-members>`
       members of the replica set one at a time:
 
-      a. Shut down the :binary:`~bin.mongod` instance and replace the |newversion|
-         binary with the |oldversion| binary.
+      i. :ref:`Perform a clean shut down <terminate-mongod-processes>`
+         of the :binary:`~bin.mongod` process.
+
+         .. include:: /includes/note-clean-shutdown.rst
+
+      #. Replace the |newversion| binary with the |oldversion| binary.
 
       #. Start the |oldversion| binary with the ``--shardsvr`` and
          ``--port`` command line options. Include any other
@@ -42,7 +46,8 @@ content: |
  
          .. code-block:: sh
 
-            mongod --shardsvr --port <port> --dbpath <path> --bind_ip localhost,<ip address>
+            mongod --shardsvr --port <port> --dbpath <path> \
+              --bind_ip localhost,<ip address>
 
          Or if using a :doc:`configuration file
          </reference/configuration-options>`, update the file to
@@ -118,10 +123,10 @@ ref: 3.6-downgrade-config-servers
 content: |-
    If the config servers are replica sets:
       
-   1. Downgrade the :ref:`secondary <replica-set-secondary-members>`
+   a. Downgrade the :ref:`secondary <replica-set-secondary-members>`
       members of the replica set one at a time:
 
-      a. Shut down the secondary :binary:`~bin.mongod` instance and replace
+      i. Shut down the secondary :binary:`~bin.mongod` instance and replace
          the |newversion| binary with the |oldversion| binary.
 
       #. Start the |oldversion| binary with both the ``--configsvr`` and
@@ -160,7 +165,7 @@ content: |-
 
    #. Step down the replica set primary.
 
-      a. Connect a :binary:`~bin.mongo` shell to the primary and use
+      i. Connect a :binary:`~bin.mongo` shell to the primary and use
          :method:`rs.stepDown()` to step down the primary and force an
          election of a new primary:
 


### PR DESCRIPTION
@MongoCaleb : There are a few line wrap issues, but the big thing is the note that I added:

- [Standalone](https://docs-mongodbcom-staging.corp.mongodb.com/anthonysansone/DOCS-11711/release-notes/3.6-downgrade-standalone.html#restart-with-the-latest-oldversion-mongod-instance)
- [Replica Set](https://docs-mongodbcom-staging.corp.mongodb.com/anthonysansone/DOCS-11711/release-notes/3.6-downgrade-replica-set.html#downgrade-secondary-members-of-the-replica-set)
- [Sharded Cluster](https://docs-mongodbcom-staging.corp.mongodb.com/anthonysansone/DOCS-11711/release-notes/3.6-downgrade-sharded-cluster.html#downgrade-each-shard-one-at-a-time)

Staging build is still ongoing. Stage may not reflect code.