### PR TITLE
(DOCS-6329): Updated default NTFS allocation unit size.

### DIFF
--- a/source/administration/production-checklist-operations.txt
+++ b/source/administration/production-checklist-operations.txt
@@ -249,6 +249,8 @@ Windows
 
    - Consider disabling NTFS "last access time"  updates. This is 
      analogous to disabling ``atime`` on Unix-like systems.
+   - Format NTFS disks using the default 
+     :guilabel:`Allocation unit size` of `4096 bytes <https://support.microsoft.com/en-us/help/140365/default-cluster-size-for-ntfs-fat-and-exfat>`__.
 
 Backups
 ~~~~~~~


### PR DESCRIPTION
@kay-kim : This is a short update for the NTFS default allocation unit size. RFM for `master` and `v3.6`.