### PR TITLE
DOCS-11101: add killAnyCursor privilege, clarify coAuthz behaviour

### DIFF
--- a/source/reference/built-in-roles.txt
+++ b/source/reference/built-in-roles.txt
@@ -418,7 +418,7 @@ Cluster Administration Roles
    - :authaction:`flushRouterConfig`
    - :authaction:`fsync`
    - :authaction:`invalidateUserCache`
-
+   - :authaction:`killAnyCursor` (New in version 4.0)
    - :authaction:`killAnySession` (New in version 3.6)
 
    - :authaction:`killop`

--- a/source/reference/command/killCursors.txt
+++ b/source/reference/command/killCursors.txt
@@ -41,6 +41,21 @@ Definition
 
    .. include:: /includes/apiargs/dbcommand-killCursors-field.rst
 
+Required Access
+---------------
+
+.. versionchanged:: 3.6.3
+
+To successfully execute a :dbcommand:`killCursors` command, all cursors
+that you wish to kill must be associated with a currently authenticated
+user. MongoDB associates cursors with the users that were authenticated when
+the cursor was created. If the operation is not successful due to
+permission issues, the command returns an error message.
+
+Alternatively, if a user possesses the :authaction:`killAnyCursor`
+privilege, that user may kill any cursor regardless of what users the
+cursor is associated with.
+
 Example
 -------
 

--- a/source/reference/privilege-actions.txt
+++ b/source/reference/privilege-actions.txt
@@ -47,7 +47,8 @@ Query and Write Actions
    - :dbcommand:`getMore`
    - :dbcommand:`getPrevError`
    - :dbcommand:`group`
-   - :dbcommand:`killCursors`
+   - :dbcommand:`killCursors`, provided that the cursor is associated
+     with a currently authenticated user.
    - :dbcommand:`listCollections`
    - :dbcommand:`listIndexes`
    - :dbcommand:`mapReduce` with the ``{out: inline}`` option.
@@ -261,7 +262,16 @@ Database Management Actions
 
 .. authaction:: killCursors
 
-   User can kill cursors on the target collection.
+   User can kill cursors with which they are associated. Cursors are
+   associated with the users that were authenticated when the cursor was
+   created. Apply this action to collection resources.
+
+.. authaction:: killAnyCursor
+
+   .. versionadded:: 3.6.3
+
+   User can kill **any** cursor regardless of their association
+   with the cursor. Apply this action to collection resources.
 
 .. authaction:: revokeRole
 

--- a/source/release-notes/4.0-compatibility.txt
+++ b/source/release-notes/4.0-compatibility.txt
@@ -181,6 +181,17 @@ General
   other date parts to calculate the date. In previous versions, values
   that exceed the range result in an error.
 
+- Changed behavior of the :authaction:`killCursors` privilege action.
+  Prior to MongoDB 4.0, a user could kill any cursor if they knew that
+  cursor's ID. As of MongoDB 4.0, the :authaction:`killCursors`
+  privilege grants the user the ability to kill any cursor associated
+  with a currently authenticated user. If the user does not have
+  permission to kill a cursor, :dbcommand:`killCursors` returns an error.
+
+- MongoDB 4.0 adds a :authaction:`killAnyCursor` privilege action that
+  grants the user permission to kill any cursor for the specified
+  collection.
+ 
 ``cursor.min()`` and ``cursor.max()``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
I'm not sure if the added privilege action item belongs in the compatibility notes or the main release notes, but I figured I'd put it in compatibility for now?



This change was backported to 3.6; making a separate PR for that patch.