### PR TITLE
Fix reference to textIndexVersion

### DIFF
--- a/source/core/index-text.txt
+++ b/source/core/index-text.txt
@@ -48,7 +48,7 @@ Versions
        MongoDB 2.4 can only support version ``1``.
 
 To override the default version and specify a different version,
-include the option ``{ "2dsphereIndexVersion": <version> }`` when
+include the option ``{ "textIndexVersion": <version> }`` when
 creating the index.
 
 .. _create-text-index:


### PR DESCRIPTION
The old values appears to be copypasta from the geospatial index section.