### PR TITLE
Add -d <database name> option in mongorestore because it's required as of mongo 3.0 or above

### DIFF
--- a/source/tutorial/backup-and-restore-tools.txt
+++ b/source/tutorial/backup-and-restore-tools.txt
@@ -177,7 +177,7 @@ To use :binary:`~bin.mongorestore` to connect to an active
 
 .. code-block:: sh
 
-   mongorestore --port <port number> <path to the backup>
+   mongorestore -d <database name> --port <port number> <path to the backup>
 
 
 Consider the following example:


### PR DESCRIPTION
note: your documentation guideline is not found