### PR TITLE
Typo in database-references.txt

### DIFF
--- a/source/reference/database-references.txt
+++ b/source/reference/database-references.txt
@@ -33,7 +33,7 @@ or databases.
    :pipeline:`$graphLookup`.
 
 This page outlines alternative procedures that predate the
-:pipeline:`$lookup` and:pipeline:`$graphLookup` pipeline stages.
+:pipeline:`$lookup` and :pipeline:`$graphLookup` pipeline stages.
 
 MongoDB applications use one of two methods for relating documents:
 


### PR DESCRIPTION
The missing space is preventing a proper parsing of the link.