### PR TITLE
minor: fix featureCompatibilityVersion typo

### DIFF
--- a/source/includes/list-table-featureCompatibilityVersion-defaults.rst
+++ b/source/includes/list-table-featureCompatibilityVersion-defaults.rst
@@ -10,7 +10,7 @@
 
    * - For deployments :ref:`upgraded from 3.6 <4.0-upgrade>`
 
-     - `A`"3.6"`` until you :dbcommand:`setFeatureCompatibilityVersion` to ``"4.0"``.
+     - ``"3.6"`` until you :dbcommand:`setFeatureCompatibilityVersion` to ``"4.0"``.
 
    * - For new 3.6 deployments
      - ``"3.6"``


### PR DESCRIPTION
Saw it on [this page](https://docs.mongodb.com/manual/reference/command/setFeatureCompatibilityVersion/).