### PR TITLE
minor: fix typos in oplog resizing tutorial

### DIFF
--- a/source/tutorial/change-oplog-size.txt
+++ b/source/tutorial/change-oplog-size.txt
@@ -20,8 +20,8 @@ with the :term:`secondary` members before proceeding to the
 .. important::
 
    You can only run :dbcommand:`replSetResizeOplog` on
-   replica set member's running with the 
-   :ref:`Wired Tiger storage engine <storage-wiredtiger>`.
+   replica set members running with the
+   :ref:`WiredTiger storage engine <storage-wiredtiger>`.
 
 Perform these steps on each :term:`secondary` replica set member
 *first*. Once you have changed the oplog size for all secondary
@@ -62,8 +62,8 @@ The ``maxSize`` field displays the collection size in bytes.
 C. Change the oplog size of the replica set member
 --------------------------------------------------
 
-To change the size, run the :dbcommand:`replSetResizeOplog` passing
-the desired size in megabytes as the ``size`` parameter. The
+To resize the oplog, run the :dbcommand:`replSetResizeOplog` command,
+passing the desired size in megabytes as the ``size`` parameter. The
 specified size must be greater than ``990``, or 990 megabytes.
 
 The following operation changes the oplog size of the replica set


### PR DESCRIPTION
I realize this page is written in an old style (for example, it doesn't have the fancy numbering system that [this page](https://docs.mongodb.com/manual/tutorial/perform-maintence-on-replica-set-members/) has) but the typos annoyed me.