### PR TITLE
Remove password from command line

### DIFF
--- a/source/includes/steps-create-admin-then-enable-authentication.yaml
+++ b/source/includes/steps-create-admin-then-enable-authentication.yaml
@@ -92,7 +92,7 @@ action:
          
     language: sh
     code: |
-      mongo --port 27017 -u "myUserAdmin" -p "abc123" --authenticationDatabase "admin"
+      mongo --port 27017 -u "myUserAdmin" -p --authenticationDatabase "admin"
 
   - heading:  To authenticate after connecting
     pre: |


### PR DESCRIPTION
Passwords should not be typed out on the command line; this is a security issue. By simply using "-p" in the command with no password, the user will then be able to type their password without it showing up on the command line.