### PR TITLE
(DOCSP-2738): Updated MMAP caution and stable packages table.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -105,7 +105,8 @@ extlinks = {
     'csharp-api': ('https://api.mongodb.com/csharp/current/html/%s.htm', ''),
     'csharp-docs': ('https://mongodb.github.io/mongo-csharp-driver/2.4/reference/%s', ''),
     'java-async-docs': ('http://mongodb.github.io/mongo-java-driver-reactivestreams/1.6/%s', ''),
-    'java-async-api': ('http://mongodb.github.io/mongo-java-driver-reactivestreams/1.6/javadoc/%s', '')
+    'java-async-api': ('http://mongodb.github.io/mongo-java-driver-reactivestreams/1.6/javadoc/%s', ''),
+    'bic': ('https://docs.mongodb.com/bi-connector/current%s','')
 }
 
 ## add `extlinks` for each published version.

--- a/source/includes/fact-mmapv1-big-endian.rst
+++ b/source/includes/fact-mmapv1-big-endian.rst
@@ -1,6 +1,6 @@
 .. important::
 
-   :doc:`MMAPv1 </core/mmapv1>` is unsupported on all big-endian
-   architectures like the IBM z/Architecture (``s390x``) and the
-   PowerPC (``ppc64le``) architecture. MongoDB returns an error when starting a :binary:`~bin.mongod` using MMAPv1 on an unsupported architecture.
-
+   :doc:`MMAPv1 </core/mmapv1>` is supported on 64-bit Intel
+   architectures (``x86_64``) only. MongoDB returns an error when
+   starting a :binary:`~bin.mongod` using MMAPv1 on an unsupported
+   architecture.

--- a/source/includes/fact-mmapv1-big-endian.rst
+++ b/source/includes/fact-mmapv1-big-endian.rst
@@ -1,7 +1,6 @@
 .. important::
 
-   MMAPv1 is unsupported on big-endian and certain bi-endian
-   architectures. This includes the IBM z/Architecture (``s390x``) and
-   PowerPC (``ppc64le``) platforms. MongoDB returns an error if you
-   set MMAPv1 as the storage engine on ``s390x`` and ``ppc64le``
-   platforms.
+   :doc:`MMAPv1 </core/mmapv1>` is unsupported on all big-endian
+   architectures like the IBM z/Architecture (``s390x``) and the
+   PowerPC (``ppc64le``) architecture. MongoDB returns an error when starting a :binary:`~bin.mongod` using MMAPv1 on an unsupported architecture.
+

--- a/source/includes/fact-mmapv1-big-endian.rst
+++ b/source/includes/fact-mmapv1-big-endian.rst
@@ -1,5 +1,7 @@
 .. important::
 
-   MMAPv1 is not supported on big-endian architectures such as s390x.
-   MongoDB returns an error if you set MMAPv1 as the
-   storage engine on a big-endian system.
+   MMAPv1 is unsupported on big-endian and certain bi-endian
+   architectures. This includes the IBM z/Architecture (``s390x``) and
+   PowerPC (``ppc64le``) platforms. MongoDB returns an error if you
+   set MMAPv1 as the storage engine on ``s390x`` and ``ppc64le``
+   platforms.

--- a/source/includes/list-table-products-supported-architecture.rst
+++ b/source/includes/list-table-products-supported-architecture.rst
@@ -4,27 +4,35 @@ version of MongoDB products:
 
 .. list-table::
    :header-rows: 1
+   :widths: 40 15 15 15 15
    
    * - Product
-     - x86_64/amd64
+     - x86_64
+     - ppc64le
      - s390x
-     - POWER8 (little endian)
      - ARMv8-A
 
-   * - MongoDB 3.4
+   * - MongoDB Community (3.4+)
      - |checkmark|
-     - MongoDB Enterprise only
-     - MongoDB Enterprise only
+     - 
+     - 
      - |checkmark|
 
 
-   * - `BI Connector <https://docs.mongodb.com/bi-connector/v2.0/>`__
+   * - MongoDB Enterprise (3.4+)
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
+
+   * - :bic:`BI Connector </installation/>`
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - 
 
-   * - `Compass <https://docs.mongodb.com/compass/current/>`__
+   * - `Compass <https://docs.mongodb.com/compass/current/install/>`__
      - |checkmark|
      -
      -
@@ -36,26 +44,26 @@ version of MongoDB products:
      -
      -
 
-   * - `Ops Manager <https://docs.opsmanager.mongodb.com/current/>`__
+   * - :opsmgr:`Ops Manager </core/requirements/index.html#hardware-compatibility-matrix-for-onprem-hosts>`
      - |checkmark|
-     -
+     - |checkmark|
      -
      -
 
-   * - Automation Agent
+   * - :opsmgr:`Automation Agent </core/requirements/index.html#compatibility-matrix-for-onprem-hosts>`
+     - |checkmark|
      - |checkmark|
      -
-     - |checkmark|
-     -
-
-   * - Monitoring Agent
-     - |checkmark|
-     -
-     - |checkmark|
      -
 
-   * - Backup Agent
+   * - :opsmgr:`Monitoring Agent </core/requirements/index.html#compatibility-matrix-for-onprem-hosts>`
+     - |checkmark|
      - |checkmark|
      -
+     -
+
+   * - :opsmgr:`Backup Agent </core/requirements/index.html#compatibility-matrix-for-onprem-hosts>`
      - |checkmark|
+     - |checkmark|
+     -
      -


### PR DESCRIPTION
@rkumar-mongo : This updates the warning at the bottom of [this section](https://docs-mongodbcom-staging.corp.mongodb.com/anthonysansone/DOCSP-2738/administration/production-notes.html#supported-platforms) and updates the table in [this section](https://docs-mongodbcom-staging.corp.mongodb.com/anthonysansone/DOCSP-2738/administration/production-notes.html#use-the-latest-stable-packages).  Links have been checked.