### PR TITLE
Remove redundant 'of' in type conversion operators.

### DIFF
--- a/source/reference/operator/aggregation/toBool.txt
+++ b/source/reference/operator/aggregation/toBool.txt
@@ -23,7 +23,7 @@ Definition
 
    .. versionadded:: 4.0
 
-   Converts a value of to a boolean.
+   Converts a value to a boolean.
 
    :expression:`$toBool` has the following syntax:
 

--- a/source/reference/operator/aggregation/toDate.txt
+++ b/source/reference/operator/aggregation/toDate.txt
@@ -21,7 +21,7 @@ Definition
 
    .. versionadded:: 4.0
 
-   Converts a value of to a date. If the value cannot be converted
+   Converts a value to a date. If the value cannot be converted
    to a date, :expression:`$toDate` errors. If the value is null or
    missing, :expression:`$toDate` returns null.
 

--- a/source/reference/operator/aggregation/toDecimal.txt
+++ b/source/reference/operator/aggregation/toDecimal.txt
@@ -22,7 +22,7 @@ Definition
 
    .. versionadded:: 4.0
 
-   Converts a value of to a decimal. If the value cannot be converted
+   Converts a value to a decimal. If the value cannot be converted
    to a decimal, :expression:`$toDecimal` errors. If the value is null or
    missing, :expression:`$toDecimal` returns null.
 

--- a/source/reference/operator/aggregation/toDouble.txt
+++ b/source/reference/operator/aggregation/toDouble.txt
@@ -21,7 +21,7 @@ Definition
 
    .. versionadded:: 4.0
 
-   Converts a value of to a double. If the value cannot be converted to
+   Converts a value to a double. If the value cannot be converted to
    an double, :expression:`$toDouble` errors. If the value is null or
    missing, :expression:`$toDouble` returns null.
 

--- a/source/reference/operator/aggregation/toInt.txt
+++ b/source/reference/operator/aggregation/toInt.txt
@@ -21,7 +21,7 @@ Definition
 
    .. versionadded:: 4.0
 
-   Converts a value of to an integer. If the value cannot be converted
+   Converts a value to an integer. If the value cannot be converted
    to an integer, :expression:`$toInt` errors. If the value is null or
    missing, :expression:`$toInt` returns null.
 

--- a/source/reference/operator/aggregation/toLong.txt
+++ b/source/reference/operator/aggregation/toLong.txt
@@ -21,7 +21,7 @@ Definition
 
    .. versionadded:: 4.0
 
-   Converts a value of to a long. If the value cannot be converted
+   Converts a value to a long. If the value cannot be converted
    to a long, :expression:`$toLong` errors. If the value is null or
    missing, :expression:`$toLong` returns null.
 

--- a/source/reference/operator/aggregation/toString.txt
+++ b/source/reference/operator/aggregation/toString.txt
@@ -17,7 +17,7 @@ Definition
 
    .. versionadded:: 4.0
 
-   Converts a value of to a string. If the value cannot be converted
+   Converts a value to a string. If the value cannot be converted
    to a string, :expression:`$toString` errors. If the value is null or
    missing, :expression:`$toString` returns null.
 


### PR DESCRIPTION
Remove the redundant 'of' in the description of the other shorthand type conversion operators.