### PR TITLE
Missing examples label in "On this page" section

### DIFF
--- a/source/reference/method/db.collection.findOneAndUpdate.txt
+++ b/source/reference/method/db.collection.findOneAndUpdate.txt
@@ -94,7 +94,7 @@ If the operation results in an upsert, the collection must already exist.
 .. _findOneAndUpdate-examples:
 
 Examples
-~~~~~~~~
+----------
 
 .. _findOneAndUpdate-example-replace-document:
 


### PR DESCRIPTION
Changing header level of "Examples", to be visible in On this page section