### PR TITLE
DOCS-11661: Add a warning to discourage people from setting failIndexKeyTooLong

### DIFF
--- a/source/reference/parameters.txt
+++ b/source/reference/parameters.txt
@@ -561,9 +561,10 @@ General Parameters
    .. important::
 
       Setting :parameter:`failIndexKeyTooLong` to ``false`` is
-      intended to be a temporary workaround. Leaving
-      :parameter:`failIndexKeyTooLong` set to ``false`` in a
-      production environment is not recommended.
+      intended to be a temporary workaround, not a permanent
+      solution to the problem of oversized index keys. Leaving
+      indexes in place which contain oversized keys is not
+      recommended, because they may return incomplete results.
 
    :parameter:`failIndexKeyTooLong` defaults to ``true``. When
    ``false``, a 2.6 :binary:`~bin.mongod` instance will provide the 2.4

--- a/source/reference/parameters.txt
+++ b/source/reference/parameters.txt
@@ -558,6 +558,13 @@ General Parameters
    upgrade and then gradually resolve these indexing issues, you can
    use :parameter:`failIndexKeyTooLong` to disable this behavior.
 
+   .. important::
+
+      Setting :parameter:`failIndexKeyTooLong` to ``false`` is
+      intended to be a temporary workaround. Leaving
+      :parameter:`failIndexKeyTooLong` set to ``false`` in a
+      production environment is not recommended.
+
    :parameter:`failIndexKeyTooLong` defaults to ``true``. When
    ``false``, a 2.6 :binary:`~bin.mongod` instance will provide the 2.4
    behavior.

--- a/source/reference/parameters.txt
+++ b/source/reference/parameters.txt
@@ -561,10 +561,10 @@ General Parameters
    .. important::
 
       Setting :parameter:`failIndexKeyTooLong` to ``false`` is
-      intended to be a temporary workaround, not a permanent
-      solution to the problem of oversized index keys. Leaving
+      a temporary workaround, not a permanent solution to the
+      problem of oversized index keys. Leaving
       indexes in place which contain oversized keys is not
-      recommended, because they may return incomplete results.
+      recommended because they may return incomplete results.
 
    :parameter:`failIndexKeyTooLong` defaults to ``true``. When
    ``false``, a 2.6 :binary:`~bin.mongod` instance will provide the 2.4


### PR DESCRIPTION
Staged: https://docs-mongodbcom-staging.corp.mongodb.com/steverenaker/DOCS-11661/reference/parameters.html#param.failIndexKeyTooLong