### PR TITLE
DOCSP-3338: Clarify Auditing Availability in Enterprise + Atlas

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -95,6 +95,7 @@ extlinks = {
     'mms-docs': ('https://docs.cloudmanager.mongodb.com%s', ''),
     'mms-home': ('https://www.mongodb.com/cloud/cloud-manager%s', ''),
     'opsmgr': ('https://docs.opsmanager.mongodb.com/current%s', ''),
+    'atlas': ('https://docs.atlas.mongodb.com%s',''),
     'products': ('https://www.mongodb.com/products%s', ''),
     'wtdocs': ('http://source.wiredtiger.com/mongodb-3.4%s', ''),
     'perl-api': ('https://metacpan.org/pod/MongoDB::%s', ''),

--- a/source/core/auditing.txt
+++ b/source/core/auditing.txt
@@ -13,6 +13,7 @@ Auditing
    :class: singlecol
 
 .. note::
+
    If your database is hosted on MongoDB Atlas, auditing is included natively.
    Atlas makes it easy for administrators to select the actions that they want
    to audit, as well as the MongoDB users, Atlas roles, and LDAP groups whose

--- a/source/includes/note-audit-in-enterprise-only.rst
+++ b/source/includes/note-audit-in-enterprise-only.rst
@@ -1,3 +1,4 @@
 .. note::
-   Available only in `MongoDB Enterprise
-   <http://www.mongodb.com/products/mongodb-enterprise?jmp=docs>`_.
+   
+   Available only in `MongoDB Enterprise <http://www.mongodb.com/products/mongodb-enterprise?jmp=docs>`_
+   and `MongoDB Atlas <https://cloud.mongodb.com/user#/atlas/login>`_.

--- a/source/reference/audit-message.txt
+++ b/source/reference/audit-message.txt
@@ -19,7 +19,7 @@ Audit Message
 
 The :doc:`event auditing feature </core/auditing>` can record events in
 JSON format. To configure auditing output, see
-:doc:`/tutorial/configure-auditing`
+:doc:`/tutorial/configure-auditing`.
 
 The recorded JSON messages have the following syntax:
 

--- a/source/tutorial/configure-audit-filters.txt
+++ b/source/tutorial/configure-audit-filters.txt
@@ -12,6 +12,18 @@ Configure Audit Filters
    :depth: 1
    :class: singlecol
 
+.. admonition:: Auditing in MongoDB Atlas
+   :class: note
+
+   MongoDB Atlas supports auditing for all ``M10`` and larger
+   clusters. Atlas supports specifying a JSON-formatted audit
+   filter as documented below and using the Atlas audit filter
+   builder for simplified auditing configuration. To learn more, see 
+   the Atlas documentation for
+   :atlas:`Set Up Database Auditing </database-auditing>`
+   and
+   :atlas:`Configure a Custom Auditing Filter </tutorial/auditing-custom-filter>`.
+
 :products:`MongoDB Enterprise </mongodb-enterprise-advanced?jmp=docs>`
 supports :ref:`auditing <auditing>` of various operations. When
 :doc:`enabled </tutorial/configure-auditing>`, the audit facility, by

--- a/source/tutorial/configure-auditing.txt
+++ b/source/tutorial/configure-auditing.txt
@@ -10,6 +10,18 @@ Configure Auditing
    :depth: 1
    :class: singlecol
 
+.. admonition:: Auditing in MongoDB Atlas
+   :class: note
+
+   MongoDB Atlas supports auditing for all ``M10`` and larger
+   clusters. Atlas supports specifying a JSON-formatted audit
+   filter as documented in :doc:`/tutorial/configure-audit-filters` 
+   and using the Atlas audit filter builder for simplified auditing 
+   configuration. To learn more, see the Atlas documentation for 
+   :atlas:`Set Up Database Auditing </database-auditing>`
+   and
+   :atlas:`Configure a Custom Auditing Filter </tutorial/auditing-custom-filter>`.
+
 .. versionadded:: 2.6
  
 :products:`MongoDB Enterprise </mongodb-enterprise-advanced?jmp=docs>`


### PR DESCRIPTION
Staged:

https://docs-mongodbcom-staging.corp.mongodb.com/rkumar/DOCSP-3338/core/auditing.html

Goals: Clarify that Auditing is available on both MongoDB Atlas and in MongoDB Enterprise

Non-Goals: Updating pages for other security features in both Enterprise and Atlas.