### PR TITLE
fixes typo; referencing MacDyver in findOneAndUpdate method

### DIFF
--- a/source/reference/method/db.collection.findOneAndUpdate.txt
+++ b/source/reference/method/db.collection.findOneAndUpdate.txt
@@ -147,7 +147,7 @@ The ``grades`` collection contains documents similar to the following:
    { _id: 6322, name : "A. MacDyver", "assignment" : 2, "points" : 14 },
    { _id: 6234, name : "R. Stiles", "assignment" : 1, "points" : 10 }
 
-The following operation updates a document where ``name : "A. MacGyver"``.  The
+The following operation updates a document where ``name : "A. MacDyver"``.  The
 operation sorts the matching documents by ``points`` ascending to update the
 matching document with the least points.
 


### PR DESCRIPTION
I just found a typo in the `findOneAndUpdate` method. 
It's a rather small fix, so hopefully it is okay :-)