### PR TITLE
Improve description of aggregation `$count`

### DIFF
--- a/source/reference/operator/aggregation/count.txt
+++ b/source/reference/operator/aggregation/count.txt
@@ -17,8 +17,8 @@ Definition
 
    .. versionadded:: 3.4
 
-   Returns a document that contains a count of the number of documents
-   input to the stage.
+   Passes a document to the next stage that contains a count of the
+   number of documents input to the stage.
 
    :pipeline:`$count` has the following prototype form:
 


### PR DESCRIPTION
Re: https://github.com/Automattic/mongoose/issues/7114, the current description is misleading because it implies that if `$count` is the last aggregation stage, you should get a single document as output rather than a cursor or array.

Also, it looks like all the links on https://github.com/mongodb/docs/blob/master/CONTRIBUTING.rst are broken, like [this one](https://docs.mongodb.com/manual/meta/style-guide), so my apologies if this doesn't conform to a style guideline or convention.