### PR TITLE
Add readPreference as unsupported option with --uri

### DIFF
--- a/source/includes/options-shared.yaml
+++ b/source/includes/options-shared.yaml
@@ -489,6 +489,7 @@ description: |
        :doc:`URI </reference/connection-string/>` connection string)
      - ``--authenticationDatabase``
      - ``--authenticationMechanism``
+     - ``--readPreference``
 ---
 program: _shared
 name: json


### PR DESCRIPTION
When passing --uri if you attempt to pass --readPreference it states its incompatible.  But the document did not reflect that.