### PR TITLE
Update where.txt

### DIFF
--- a/source/reference/operator/query/where.txt
+++ b/source/reference/operator/query/where.txt
@@ -99,7 +99,7 @@ MD5 hash and returns any matching document.
 
 .. code-block:: sh
 
-   db.foo.find( { $where: function() { 
+   db.users.find( { $where: function() { 
       return (hex_md5(this.name) == "9b53e667f30cd329dca1ec9e6a83e994") 
    } } );
 


### PR DESCRIPTION
Correction on the collection name.

The doc said :

> Consider the following documents in the **users** collection

and the command was :

```javascript
db.foo.find( { $where: function() {
   return (hex_md5(this.name) == "9b53e667f30cd329dca1ec9e6a83e994")
} } );
```

This pull request just change the foo of the command to `users` according to the previous sentence
