### PR TITLE
DOCS-12171: Clarify that only data-bearing members vote, hidden and d…

### DIFF
--- a/source/core/replica-set-delayed-member.txt
+++ b/source/core/replica-set-delayed-member.txt
@@ -56,6 +56,18 @@ When choosing the amount of delay, consider that the amount of delay:
 - must be *smaller* than the capacity of the oplog. For more
   information on oplog size, see :ref:`replica-set-oplog-sizing`.
 
+Write Concern
+~~~~~~~~~~~~~
+
+Delayed replica set members can acknowledge write operations issued
+with :ref:`write-concern`. Delayed members can also acknowledge
+write operations with ``majority`` write concern *if* they are also
+voting members. Non-voting replica set members cannot contribute to 
+acknowledging write operations with ``majority`` write concern.
+
+Delayed secondaries can return write acknowledgment no earlier than the 
+configured :rsconf:`~members[n].slaveDelay`.
+
 Sharding
 ~~~~~~~~
 

--- a/source/core/replica-set-hidden-member.txt
+++ b/source/core/replica-set-hidden-member.txt
@@ -50,11 +50,20 @@ Voting
 
 Hidden members *may* vote in replica set elections. If you stop a
 voting hidden member, ensure that the set has an active majority or the
-:term:`primary` will step down.
+:term:`primary` will step down. 
 
 For the purposes of backups,
 
 - .. include:: /includes/extracts/wt-fsync-lock-compatibility.rst
+
+Write Concern
+~~~~~~~~~~~~~
+
+Hidden replica set members can acknowledge write operations issued
+with :ref:`write-concern`. Hidden members can also acknowledge
+write operations with ``majority`` write concern *if* they are also
+voting members. Non-voting replica set members cannot contribute to 
+acknowledging write operations with ``majority`` write concern.
 
 Further Reading
 ---------------

--- a/source/core/replica-set-priority-0-member.txt
+++ b/source/core/replica-set-priority-0-member.txt
@@ -14,7 +14,12 @@ Priority 0 Replica Set Members
 
 A :rsconf:`priority 0 <members[n].priority>` member is a member that
 **cannot** become :term:`primary` and **cannot** trigger
-:term:`elections <election>`.
+:term:`elections <election>`. Priority 0 members can acknowledge write 
+operations issued with :ref:`write-concern` of ``w : <number>``.
+Priority 0 members can also acknowledge write operations with 
+``majority`` write concern *if* they are also
+voting members. Non-voting replica set members cannot contribute to 
+acknowledging write operations with ``majority`` write concern.
 
 Other than the aforementioned restrictions, secondaries that have
 :rsconf:`priority 0 <members[n].priority>` function as normal

--- a/source/core/replica-set-write-concern.txt
+++ b/source/core/replica-set-write-concern.txt
@@ -10,39 +10,83 @@ Write Concern for Replica Sets
    :depth: 1
    :class: singlecol
 
-Write concern describes the level of acknowledgement requested from
-MongoDB for write operations.
+You can use :ref:`write concern <write-concern>` to set the minimum 
+number of data-bearing replica set members that must acknowledge 
+receiving and applying a write operation before returning success. 
+
+For replica sets, the default write concern of ``w: 1`` requires
+that only the primary receive and acknowledge the write. Write 
+operations with write concern ``w`` greater than ``1`` require 
+acknowledgment from the primary and as many data-bearing 
+:doc:`secondaries </core/replica-set-secondary>` as required to meet 
+the requested write concern. Write operations with write concern
+``w : majority`` apply an additional criteria where only voting
+secondaries can acknowledge the write. For complete documentation on 
+member acknowledgment behavior, see 
+:ref:`Replica Set Acknowledgment Behavior <wc-replica-ack-behavior>`.
+
+The following diagram illustrates a write operation issued with a
+write concern of ``w: 2``. The operation blocks until the primary
+and at least one secondary acknowledge the write operation. Secondaries 
+can return write acknowledgment no earlier than after the primary 
+receives, applies, and replicates that write.
+
+.. include:: /images/crud-write-concern-w2.rst
+
+The more data-bearing members that acknowledge a write as successful, 
+the less likely that data will be rolled back if the
+:ref:`primary fails <replication-auto-failover>`. However, the write 
+operation must wait until it receives the requested level of 
+acknowledgment. With higher values of write concern, users trade
+a more reliable promise of data durability for write speed. With
+lower values of write concern, users trade fast writes for the promise
+of data durability.
+
+Selecting the ideal write concern for any given write operation depends
+on your application's performance goals and data durability 
+requirements.
 
 Verify Write Operations to Replica Sets
 ---------------------------------------
 
-For a replica set, the default :doc:`write concern
-</reference/write-concern>` requests acknowledgement only from the primary.
-You can, however, override this default write concern, such as to
-confirm write operations on a specified number of the replica set
-members.
+For write operations that support user-specified write concern, set
+the :ref:`write concern <wc-w>` based on the number of data-bearing
+replica set members you want to acknowledge the write before
+returning success. The exact syntax for specifying write concern
+depends on the write operation. Refer to the documentation for that
+write operation for instructions on syntax and use.
 
-.. include:: /images/crud-write-concern-w2.rst
-
-To override the default write concern, specify a write concern with
-each write operation. For example, the following method includes a
-write concern that specifies that the method return only after the
-write propagates to the primary and at least one secondary or the
-method times out after 5 seconds.
+For example, the :method:`db.collection.insert()` method
+supports a ``writeConcern`` document as an option. In the following
+operation, the ``writeConcern`` document specifies ``w : 2``, which 
+corresponds to requiring acknowledgment from the primary and at least 
+one data-bearing secondary. This can include hidden or delayed 
+secondaries:
 
 .. code-block:: javascript
 
    db.products.insert(
       { item: "envelopes", qty : 100, type: "Clasp" },
-      { writeConcern: { w: 2, wtimeout: 5000 } }
+      { writeConcern: { w: 2 } }
    )
 
-You can include a timeout threshold for a write concern. This prevents
-write operations from blocking indefinitely if the write concern is
-unachievable. For example, if the write concern requires
-acknowledgement from 4 members of the replica set and the replica set
-has only available 3 members, the operation blocks until those members
-become available. See :ref:`wc-wtimeout`.
+With the specified write concern, the write operation blocks until the 
+primary and at least one secondary acknowledge the write. You can set
+an additional timeout parameter using :ref:`wc-wtimeout`. The following
+operation times out after 5 seconds, returning a write concern error
+on timeout:
+
+.. code-block:: javascript
+
+   db.products.insert(
+      { item: "envelopes", qty : 100, type: "Clasp" },
+      { writeConcern: { w: 2 , , wtimeout: 5000 } }
+   )
+
+A write operation that times out waiting for the specified write concern 
+does not indicate write failure. It only indicates that the ``w`` 
+number of replica set members did not acknowledge the write 
+operation in the ``wtimeout`` time period.
 
 .. seealso::
    :ref:`write-methods-incompatibility`

--- a/source/reference/replica-configuration.txt
+++ b/source/reference/replica-configuration.txt
@@ -261,6 +261,9 @@ Replica Set Configuration Fields
       read operations (i.e. queries) from ever reaching this host by
       way of secondary :term:`read preference`.
 
+      Hidden members can contribute to acknowledging write operations
+      issued with :ref:`write-concern`. 
+
       .. seealso::
          :ref:`Hidden Replica Set Members <replica-set-hidden-members>`
 
@@ -335,6 +338,11 @@ Replica Set Configuration Fields
       of the data that reflects the state of the data at some time in
       the past.
 
+      Delayed members can contribute to acknowledging write
+      operations issued with :ref:`write-concern`. However,
+      they return write acknowledgment no earlier than the configured
+      delay value.
+
       .. seealso::
          :doc:`/core/replica-set-delayed-member`
 
@@ -364,6 +372,9 @@ Replica Set Configuration Fields
          .. include:: /includes/fact-rs-non-voting-priority-restriction.rst
 
       .. include:: /includes/members-used-to-allow-multiple-votes.rst
+
+      Members with ``0`` votes cannot acknowledge write operations
+      issued with a :ref:`write-concern` of :writeconcern:`majority`.
 
 ``settings``
 ~~~~~~~~~~~~

--- a/source/reference/write-concern.txt
+++ b/source/reference/write-concern.txt
@@ -15,7 +15,7 @@ Write Concern
    :depth: 1
    :class: singlecol
 
-Write concern describes the level of acknowledgement requested from
+Write concern describes the level of acknowledgment requested from
 MongoDB for write operations to a standalone :binary:`~bin.mongod` or
 to :doc:`replica sets </replication>` or to :doc:`sharded clusters
 </sharding>`. In sharded clusters, :binary:`~bin.mongos` instances will
@@ -37,11 +37,11 @@ Write concern can include the following fields:
 
    { w: <value>, j: <boolean>, wtimeout: <number> }
 
-- the :ref:`w <wc-w>` option to request acknowledgement that the write
+- the :ref:`w <wc-w>` option to request acknowledgment that the write
   operation has propagated to a specified number of :binary:`~bin.mongod`
   instances or to :binary:`~bin.mongod` instances with specified tags.
 
-- the :ref:`j <wc-j>` option to request acknowledgement that the write
+- the :ref:`j <wc-j>` option to request acknowledgment that the write
   operation has been written to the journal, and
 
 - the :ref:`wtimeout <wc-wtimeout>` option to specify a time limit to
@@ -52,7 +52,7 @@ Write concern can include the following fields:
 ``w`` Option
 ~~~~~~~~~~~~
 
-The ``w`` option requests acknowledgement that the write operation has
+The ``w`` option requests acknowledgment that the write operation has
 propagated to a specified number of :binary:`~bin.mongod` instances or to
 :binary:`~bin.mongod` instances with specified tags.
 
@@ -68,41 +68,57 @@ available:
 
    * - .. writeconcern:: <number>
 
-     - Requests acknowledgement that the write operation has propagated
+     - Requests acknowledgment that the write operation has propagated
        to the specified number of :binary:`~bin.mongod` instances. For
        example:
 
        ``w: 1``
-         Requests acknowledgement that the write operation has
+         Requests acknowledgment that the write operation has
          propagated to the standalone :binary:`~bin.mongod` or the primary
          in a replica set. ``w: 1`` is the default write concern for
          MongoDB.
 
        ``w: 0``
-         Requests no acknowledgement of the write operation. However, ``w:
+         Requests no acknowledgment of the write operation. However, ``w:
          0`` may return information about socket exceptions and
          networking errors to the application.
 
          If you specify ``w: 0`` but include :ref:`j: true <wc-j>`, the
-         :ref:`j: true <wc-j>` prevails to request acknowledgement from
+         :ref:`j: true <wc-j>` prevails to request acknowledgment from
          the standalone :binary:`~bin.mongod` or the primary of a replica
          set.
 
-       Numbers greater than 1 are valid only for replica sets to
-       request acknowledgement from specified number of members,
-       including the primary.
+       Numbers greater than 1 request acknowledgment from the specified 
+       number of data-bearing members, including the primary and any 
+       hidden or delayed secondary members. For example, in a 
+       3-member replica set with 1 delayed secondary and 1 hidden
+       member, ``w : 3`` requires acknowledgment from the primary and
+       either secondary.
+
+       .. note:: 
+
+          Delayed secondaries can return write acknowledgment no earlier
+          than the configured :rsconf:`~members[n].slaveDelay`. 
 
        See :ref:`wc-ack-behavior` for when :binary:`~bin.mongod` instances
        acknowledge the write.
 
    * - .. writeconcern:: "majority"
 
-     - Requests acknowledgement that write operations have propagated to
-       the majority of voting nodes, including
-       the primary.
+     - Requests acknowledgment that write operations have propagated to
+       the majority of data-bearing voting members, including
+       the primary and any hidden or delayed secondary members.
+       For example, in a 5 member replica set with 2 non-voting members,
+       :writeconcern:`majority` requires acknowledgment from the primary 
+       and either one of the two voting secondaries.
+
+       .. note:: 
+
+          Delayed secondaries can return write acknowledgment no earlier
+          than the configured :rsconf:`~members[n].slaveDelay`. 
 
        After the write operation returns with a :writeconcern:`w:
-       "majority" <"majority">` acknowledgement to the client, the
+       "majority" <"majority">` acknowledgment to the client, the
        client can read the result of that write with a
        :readconcern:`"majority"` readConcern.
 
@@ -111,7 +127,7 @@ available:
 
    * - .. writeconcern:: <tag set>
 
-     - Requests acknowledgement that the write operations have
+     - Requests acknowledgment that the write operations have
        propagated to a replica set member with the specified :ref:`tag
        <replica-set-configuration-tag-sets>`. See
        :ref:`wc-ack-behavior` for when :binary:`~bin.mongod` instances
@@ -124,7 +140,7 @@ available:
 ``j`` Option
 ~~~~~~~~~~~~
 
-The ``j`` option requests acknowledgement from MongoDB that
+The ``j`` option requests acknowledgment from MongoDB that
 the write operation has been written to the :doc:`journal
 </core/journaling>`.
 
@@ -133,7 +149,7 @@ the write operation has been written to the :doc:`journal
 
    * - .. writeconcern:: j
 
-     - If ``j: true``, requests acknowledgement that the
+     - If ``j: true``, requests acknowledgment that the
        :binary:`~bin.mongod` instances, as specified in the :ref:`w:
        \<value\> <wc-w>`, have written to the on-disk journal. ``j:
        true`` does not by itself guarantee that the write will not be
@@ -177,8 +193,8 @@ concern without the ``wtimeout`` option.
 
 .. _wc-ack-behavior:
 
-Acknowledgement Behavior
-------------------------
+Acknowledgment Behavior
+-----------------------
 
 The :ref:`w <wc-w>` option and the :ref:`j <wc-j>` option determine
 when :binary:`~bin.mongod` instances acknowledge write operations. 
@@ -188,7 +204,7 @@ Standalone
 
 A standalone :binary:`~bin.mongod` acknowledges a write operation either
 after applying the write in memory or after writing to the on-disk
-journal. The following table lists the acknowledgement behavior for a
+journal. The following table lists the acknowledgment behavior for a
 standalone and the relevant write concerns:
 
 .. list-table::
@@ -214,55 +230,65 @@ standalone and the relevant write concerns:
 
    .. include:: /includes/extracts/no-journaling-rollback.rst
 
+.. _wc-replica-ack-behavior:
+
 Replica Sets
 ~~~~~~~~~~~~
 
-.. versionchanged:: 3.4
+The value specified to :ref:`w <wc-w>` determines the criteria
+for whether a replica set member can contribute to write acknowledgment.
+For each eligible replica set member, the :ref:`j <wc-j>` option
+determines whether the member acknowledges writes after applying
+the write operation in memory or after writing to the on-disk journal.
 
-A replica set acknowledges a write operation either after the specified
-number of members apply the write in memory or after they write to the
-on-disk journal. The number of members is specified by the :ref:`w:
-\<value\> <wc-w>` setting. The following table lists the
-acknowledgement behavior for these members and the relevant write
-concerns [#3.2-behavior]_:
+``w: "majority"``
+  Any data-bearing voting member of the replica set can contribute
+  to write acknowledgment of :writeconcern:`majority` write operations, 
+  such as the primary and all secondaries. This includes any hidden or 
+  delayed secondaries. 
 
-.. list-table::
-   :header-rows: 1
-   :widths: 22 50 22 20
+  The following table lists when the member can acknowledge
+  the write based on the :ref:`j <wc-j>` value:
 
-   * -
-     - ``j`` is unspecified
-     - ``j:true``
-     - ``j:false``
+  .. list-table::
+     :stub-columns: 1
+     :widths: 30 70
 
-   * - ``w: "majority"``
+     * - ``j`` is unspecified
+       - Acknowledgment depends on the value of
+         :rsconf:`writeConcernMajorityJournalDefault`:
 
-     - Depends on the value of
-       :rsconf:`writeConcernMajorityJournalDefault`.
+         - If ``true``, acknowledgment requires writing operation to on-disk journal
+         - If ``false``, acknowledgment requires writing operation in memory
 
-       - If true, On-disk journal.
+     * - ``j: true``
+       - Acknowledgment requires writing operation to on-disk journal
 
-       - If false, In memory.
+     * - ``j: false``
+       - Acknowledgment requires writing operation in memory.
 
-       .. versionchanged:: 3.4
-          
-     - On-disk journal
+  .. note::
 
-     - In memory
+     .. include:: /includes/extracts/no-journaling-rollback.rst
 
-   * - ``w: <number>``
+``w: <number>``
+  Any data-bearing member of the replica set can contribute
+  to write acknowledgment of :ref:`w: \<number\> <wc-w>` write
+  operations, such as the primary and all secondaries. This includes 
+  any hidden or delayed secondaries.
+       
+  The following table lists when the member can acknowledge
+  the write based on the :ref:`j <wc-j>` value:
 
-     - In memory
+  .. list-table::
+     :stub-columns: 1
+     :widths: 30 70
 
-     - On-disk journal
+     * - ``j`` is unspecified
+       - Acknowledgment requires writing operation in memory
 
-     - In memory
+     * - ``j: true``
+       - Acknowledgment requires writing operation to on-disk journal
 
-.. note::
-
-   .. include:: /includes/extracts/no-journaling-rollback.rst
-
-.. [#3.2-behavior]
-
-   For the behavior in version 3.2, refer to the :v3.2:`3.2 manual
-   </reference/write-concern>`.
+     * - ``j: false``
+       - Acknowledgment requires writing operation in memory.


### PR DESCRIPTION
…elayed secondaries eligible. Stretch to clean up replica set write concern documentation

Summary:

Delayed and Hidden secondaries are eligible to contribute to write concern acknowledgment. There are also some caveats, e.g. with Majority write concern, only *voting* secondaries can contribute. 

Goals:

* Clarified eligibility of member types in contributing to write concern
* Improved copy and flow on replication write concern page
