### PR TITLE
DOCSP-3622: $jsonSchema `type` keyword does not support "integer", us…

### DIFF
--- a/source/includes/fact-json-schema-validation-keywords.rst
+++ b/source/includes/fact-json-schema-validation-keywords.rst
@@ -1,5 +1,6 @@
 .. list-table::
    :header-rows: 1
+   :widths: 15 15 20 50
 
    * - Keyword
      - Type
@@ -22,6 +23,10 @@
      - string or array of unique strings
      - Enumerates the possible JSON types of the field. Available types are 
        "object", "array", "number", "boolean", "string", and "null".
+       
+       MongoBD's implementation of the JSON Schema does not support the
+       "integer" type. Use the ``bsonType`` keyword and the
+       "int" or "long" types instead.
 
    * - allOf
      - all types

--- a/source/reference/operator/query/jsonSchema.txt
+++ b/source/reference/operator/query/jsonSchema.txt
@@ -53,6 +53,11 @@ aggregation stage.
 Available Keywords
 ~~~~~~~~~~~~~~~~~~
 
+.. note:: 
+
+   MongoDB implements a subset of keywords available in JSON Schema.
+   For a complete list of omissions, see :ref:`json-schema-omission`.
+
 .. include:: /includes/fact-json-schema-validation-keywords.rst
 
 Extensions
@@ -62,6 +67,8 @@ MongoDB's implementation of JSON Schema includes the addition of the ``bsonType`
 keyword, which allows you to use all :term:`BSON` types in the
 :query:`$jsonSchema` operator. ``bsonType`` accepts the same string aliases used
 for the :query:`$type` operator.
+
+.. _json-schema-omission:
 
 Omissions
 ---------


### PR DESCRIPTION
…e `bsonType` with "int" or "long" instead