### PR TITLE
add content on read priority of evaluted script via --eval or loaded script via the command line and .mongorc

### DIFF
--- a/source/tutorial/write-scripts-for-the-mongo-shell.txt
+++ b/source/tutorial/write-scripts-for-the-mongo-shell.txt
@@ -211,7 +211,8 @@ pass the shell a JavaScript fragment, as in the following:
 This returns the output of :method:`db.getCollectionNames()` using the
 :binary:`~bin.mongo` shell connected to the :binary:`~bin.mongod` or
 :binary:`~bin.mongos` instance running on port ``27017`` on the
-``localhost`` interface.
+``localhost`` interface. :binary:`~bin.mongo` runs ``printjson(db.getCollectionNames())`` before running
+:ref:`.mongorc.js <mongo-mongorc-file>`.
 
 .. _mongo-shell-javascript-file:
 
@@ -229,7 +230,8 @@ following example:
 This operation executes the ``myjsfile.js`` script in a
 :binary:`~bin.mongo` shell that connects to the ``test`` :term:`database`
 on the :binary:`~bin.mongod` instance accessible via the ``localhost``
-interface on port ``27017``.
+interface on port ``27017``. :binary:`~bin.mongo` runs ``myjsfile.js`` before reading from
+:ref:`.mongorc.js <mongo-mongorc-file>`
 
 Alternately, you can specify the mongodb connection parameters inside
 of the javascript file using the ``Mongo()`` constructor. See


### PR DESCRIPTION
mongo actually reads the evaluated specified with the  `--eval` option or loaded via the terminal by specifying the file name before reading from `.mongorc.js`