### PR TITLE
Require replica connection in read preference

### DIFF
--- a/source/core/read-preference.txt
+++ b/source/core/read-preference.txt
@@ -110,6 +110,14 @@ Read Preference Modes
    [#edge-cases-2-primaries]_ Ensure that your application can tolerate
    stale data if you choose to use a non-:readmode:`primary` mode.
 
+.. note::
+
+   For a read preference mode to apply, you must use a replica set
+   connection instead of a direct connection. For example: 
+   `mongodb://localhost:5432` is a direct connection and 
+   `mongodb://localhost:5432/?replicaSet=foo` is a replica set 
+   connection.
+
 MongoDB :ecosystem:`drivers </drivers>` support five
 read preference modes.
 


### PR DESCRIPTION
My team and I were severely blocked due to a misunderstanding of the read preference modes. Basically we were using a direct connection to our database while trying to specify a read preference mode of `secondary`.  During our tests, our queries did not fail when there was only a primary replica available as we were expecting.

We spent a while trying to work out why our read preferences where not being applied. It was only when we saw this [ticket](https://jira.mongodb.org/browse/SERVER-22289?focusedCommentId=1158605&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1158605) with the comment:

> The mongo shell respects read preference, but you need to use a replica set connection instead of a direct connection

That we were able to get our tests working.

So in order to help people who may be experiencing a similar misunderstanding I want to add a note to the documentation.