### PR TITLE
This is not working when inserting your example in MongoDB Extended JSON docs.

### DIFF
--- a/source/reference/mongodb-extended-json.txt
+++ b/source/reference/mongodb-extended-json.txt
@@ -473,6 +473,8 @@ NumberDecimal
 
       db.json.insert( { decimalQuoted : NumberDecimal("123.40") } )
       db.json.insert( { decimalUnQuoted : NumberDecimal(123.40) } )
+      
+    This is throwing an error here with mongo 4.0.0 since NumberDecimal is unquoted.
 
    When you retrieve the documents, the value of ``decimalUnQuoted`` has
    changed, while ``decimalQuoted`` retains its specified precision:


### PR DESCRIPTION
I see the following in my running mongo docker image of 4.0.0

```js
db.json.insert( { longUnQuoted : NumberLong(9223372036854775808) } )
2019-02-04T23:39:13.080+0000 E QUERY    [js] Error: number passed to NumberLong must be representable as an int64_t :
@(shell):1:34
```

I put a comment here since I couldn't create an issue.