### PR TITLE
Use plural verb for "none"

### DIFF
--- a/source/reference/method/Session.commitTransaction.txt
+++ b/source/reference/method/Session.commitTransaction.txt
@@ -22,7 +22,7 @@ Definition
    Saves the changes made by the operations in the :doc:`multi-document
    transaction </core/transactions>` and ends the transaction. Until
    the commit, none of the data changes made from within the
-   transaction is visible outside the transaction.
+   transaction are visible outside the transaction.
 
 Behavior
 --------


### PR DESCRIPTION
This is consistent with the language in the [command reference](https://github.com/mongodb/docs/blob/master/source/reference/command/commitTransaction.txt). See also: https://english.stackexchange.com/a/22075