### PR TITLE
Clarify that any constant can be used to group as a whole

### DIFF
--- a/source/reference/operator/aggregation/group.txt
+++ b/source/reference/operator/aggregation/group.txt
@@ -30,8 +30,8 @@ Definition
       { $group: { _id: <expression>, <field1>: { <accumulator1> : <expression1> }, ... } }
 
    The ``_id`` field is *mandatory*; however, you can specify an
-   ``_id`` value of null to calculate accumulated values for all the
-   input documents as a whole.
+   ``_id`` value of null (or any constant value) to calculate
+   accumulated values for all the input documents as a whole.
 
    The remaining computed fields are *optional* and computed using the
    ``<accumulator>`` operators.


### PR DESCRIPTION
Related to a discussion earlier in drivers Slack. I've left the example section further down in the document, which uses `null`, as-is; however, it'd be good to clarify that there is nothing special about `null` here and it is rather the use of a constant value that allows `$group` to utilize a single accumulation bucket. 