### PR TITLE
Update 'Active Indexing Operations' examples

### DIFF
--- a/source/includes/example-filter-current-op.rst
+++ b/source/includes/example-filter-current-op.rst
@@ -61,7 +61,7 @@ The following example returns information on index creation operations:
        {
          $or: [
            { op: "command", "query.createIndexes": { $exists: true } },
-           { op: "none", ns: /\.system\.indexes\b/ }
+           { op: "insert", ns: /\.system\.indexes\b/ }
          ]
        }
    )

--- a/source/reference/command/currentOp.txt
+++ b/source/reference/command/currentOp.txt
@@ -188,7 +188,7 @@ The following example returns information on index creation operations:
          currentOp: true,
          $or: [
            { op: "command", "query.createIndexes": { $exists: true } },
-           { op: "none", ns: /\.system\.indexes\b/ }
+           { op: "insert", ns: /\.system\.indexes\b/ }
          ]
        }
    )


### PR DESCRIPTION
It looks like `op: "none"` in the query examples for 'Active Indexing Operations' should actually be `op: "insert"` as evidenced by this example result:

```javascript
{
	"inprog" : [
		{
			"desc" : "conn7",
			"threadId" : "140517429856000",
			"connectionId" : 7,
			"client" : "172.18.0.1:43528",
			"active" : true,
			"opid" : 5996,
			"secs_running" : 34,
			"microsecs_running" : NumberLong(34822182),
			"op" : "insert", // This is "insert", instead of "none"
			"ns" : "bc-local-main.system.indexes",
			"query" : {
				"insert" : "system.indexes",
				"documents" : [
					{
						"ns" : "bc-local-main.BidderGroups",
						"key" : {
							"companyId" : 1,
							"projectId" : 1
						},
						"name" : "companyId_1_projectId_1",
						"background" : true,
						"unique" : false
					}
				],
				"ordered" : true
			},
			"msg" : "Index Build (background) Index Build (background): 2279799/38746293 5%",
			"progress" : {
				"done" : 2279799,
				"total" : 38746293
			},
			"numYields" : 18271,
			"locks" : {
				"Global" : "w",
				"Database" : "w",
				"Collection" : "w"
			},
			"waitingForLock" : false,
			"lockStats" : {
				"Global" : {
					"acquireCount" : {
						"r" : NumberLong(18272),
						"w" : NumberLong(18272)
					}
				},
				"Database" : {
					"acquireCount" : {
						"w" : NumberLong(18272),
						"W" : NumberLong(1)
					}
				},
				"Collection" : {
					"acquireCount" : {
						"w" : NumberLong(18272)
					}
				}
			}
		}
	],
	"ok" : 1
}
```