### PR TITLE
Multiple small fixups:

### DIFF
--- a/source/core/gridfs.txt
+++ b/source/core/gridfs.txt
@@ -205,6 +205,13 @@ following fields:
    ``Date`` type.
 
 .. data:: files.md5
+   
+   **Deprecated**
+
+   The MD5 algorithm is prohibited by FIPS 140-2. MongoDB drivers
+   deprecate MD5 support and will remove MD5 generation in future
+   releases.  Applications that require a file digest should implement
+   it outside of GridFS and store in :data:`files.metadata`.
 
    An MD5 hash of the complete file returned by the :doc:`filemd5
    </reference/command/filemd5>` command. This value has the ``String``
@@ -215,12 +222,23 @@ following fields:
    Optional. A human-readable name for the GridFS file.
 
 .. data:: files.contentType
+   
+   **Deprecated**
 
-   Optional. A valid MIME type for the GridFS file.
+   Optional. A valid MIME type for the GridFS file. For application
+   use only.
+
+   Use :data:`files.metadata` for storing information related to the
+   MIME type of the GridFS file.
 
 .. data:: files.aliases
 
-   Optional. An array of alias strings.
+   **Deprecated**
+
+   Optional. An array of alias strings. For application use only.
+
+   Use :data:`files.metadata` for storing information related to the
+   MIME type of the GridFS file.
 
 .. data:: files.metadata
 

--- a/source/includes/extracts-built-in-roles.yaml
+++ b/source/includes/extracts-built-in-roles.yaml
@@ -105,9 +105,7 @@ content: |
   Prior to 3.4, :authrole:`readAnyDatabase` includes ``local`` and
   ``config`` databases. To provide ``read`` privileges on the
   ``local`` database, create a user in the ``admin`` database with
-  :authrole:`read` role in the ``local`` database. See also
-  :authrole:`clusterManager` and :authrole:`clusterMonitor` role
-  for access to the ``config`` and ``local`` databases.
+  :authrole:`read` role in the ``local`` database.
 ---
 ref: built-in-roles-readWriteAnyDatabase
 content: |
@@ -121,9 +119,7 @@ content: |
   Prior to 3.4, :authrole:`readWriteAnyDatabase` includes ``local``
   and ``config`` databases. To provide ``readWrite`` privileges on
   the ``local`` database, create a user in the ``admin`` database
-  with :authrole:`readWrite` role in the ``local`` database. See
-  also :authrole:`clusterManager` and :authrole:`clusterMonitor`
-  role for access to the ``config`` and ``local`` databases.
+  with :authrole:`readWrite` role in the ``local`` database.
 ---
 ref: built-in-roles-dbAdminAnyDatabase
 content: |
@@ -137,9 +133,7 @@ content: |
   Prior to 3.4, :authrole:`dbAdminAnyDatabase` includes ``local``
   and ``config`` databases. To provide ``dbAdmin`` privileges on
   the ``local`` database, create a user in the ``admin`` database
-  with :authrole:`dbAdmin` role in the ``local`` database. See also
-  :authrole:`clusterManager` and :authrole:`clusterMonitor` role
-  for access to the ``config`` and ``local`` databases.
+  with :authrole:`dbAdmin` role in the ``local`` database.
 ---
 ref: built-in-roles-userAdminAnyDatabase
 content: |

--- a/source/reference/command/setFeatureCompatibilityVersion.txt
+++ b/source/reference/command/setFeatureCompatibilityVersion.txt
@@ -111,6 +111,13 @@ Definition
 Behavior
 --------
 
+Conflicts with Background Operations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Certain background operations, such as index builds, may prevent
+execution of :dbcommand:`setFeatureCompatibilityVersion`. Use 
+:dbcommand:`currentOp` to identify any ongoing operations.
+
 Default Values
 ~~~~~~~~~~~~~~
 

--- a/source/reference/operator/aggregation/cond.txt
+++ b/source/reference/operator/aggregation/cond.txt
@@ -32,6 +32,9 @@ Definition
 
       { $cond: [ <boolean-expression>, <true-case>, <false-case> ] }
 
+   :expression:`$cond` requires all three arguments (``if-then-else``)
+   for either syntax.
+
    If the ``<boolean-expression>`` evaluates to ``true``, then
    :expression:`$cond` evaluates and returns the value of the
    ``<true-case>`` expression. Otherwise, :expression:`$cond` evaluates

--- a/source/reference/operator/query/and.txt
+++ b/source/reference/operator/query/and.txt
@@ -15,7 +15,7 @@ $and
    *Syntax*: ``{ $and: [ { <expression1> }, { <expression2> } , ... , { <expressionN> } ] }``
 
    :query:`$and` performs a logical ``AND`` operation on an array
-   of *two or more* expressions (e.g. ``<expression1>``,
+   of *one or more* expressions (e.g. ``<expression1>``,
    ``<expression2>``, etc.) and selects the documents that satisfy
    *all* the expressions in the array. The :query:`$and` operator
    uses *short-circuit evaluation*. If the first expression


### PR DESCRIPTION
DOCS-12567: Removing duplicate line
DOCSP-4943: $cond requires all arguments
DOCS-12556: Deprecate GridFS contentType, aliases, MD5
DOCS-12543: query $and accepts one expression
DOCSP-4791: Certain background operations can block setFeatureCompatibilityVersion

@kay-kim LMK if I've done something insidious among these minor fixes! No rush. 