### PR TITLE
docs($addToSet): use a simple example update for `Field is Not an Array`

### DIFF
--- a/source/reference/operator/update/addToSet.txt
+++ b/source/reference/operator/update/addToSet.txt
@@ -83,7 +83,7 @@ The following operation appends the array ``[ "c", "d" ]`` to the
 
    db.test.update(
       { _id: 1 },
-      { $addToSet: {letters: [ "c", "d" ] } }
+      { $addToSet: { letters: "c" } }
    )
 
 The ``letters`` array now includes the ``[ "c", "d" ]`` array

--- a/source/reference/operator/update/addToSet.txt
+++ b/source/reference/operator/update/addToSet.txt
@@ -60,7 +60,7 @@ The following :update:`$addToSet` operation on the non-array field
 
    db.foo.update(
       { _id: 1 },
-      { $addToSet: { colors: [ "c", "d" ] } }
+      { $addToSet: { colors: "c" } }
    )
 
 Value to Add is An Array
@@ -83,7 +83,7 @@ The following operation appends the array ``[ "c", "d" ]`` to the
 
    db.test.update(
       { _id: 1 },
-      { $addToSet: { letters: "c" } }
+      { $addToSet: { letters: [ "c", "d" ] } }
    )
 
 The ``letters`` array now includes the ``[ "c", "d" ]`` array


### PR DESCRIPTION
https://docs.mongodb.com/manual/reference/operator/update/addToSet/#field-is-not-an-array