### PR TITLE
Delete duplicate paragraph about $abs and null/NaN

### DIFF
--- a/source/reference/operator/aggregation/abs.txt
+++ b/source/reference/operator/aggregation/abs.txt
@@ -34,10 +34,6 @@ Behavior
 
 .. include:: /includes/extracts/agg-expression-null-operand-abs.rst
 
-If the argument resolves to a value of ``null`` or refers to a field
-that is missing, :expression:`$abs` returns ``null``. If the
-argument resolves to ``NaN``, :expression:`$abs` returns ``NaN``.
-
 .. list-table::
    :header-rows: 1
    :widths: 85 15


### PR DESCRIPTION
Hi Docs Team!

The `$abs` page has a duplicate paragraph that discusses the result if the input is `null` or `NaN`, one of which comes from the extract and one of which is verbatim in the text. This pull request proposes deleting the text in the `$abs` page and keeps the extract.

Hope you're all well!
Kyle