### PR TITLE
Fix typo

### DIFF
--- a/source/reference/operator/aggregation/replaceRoot.txt
+++ b/source/reference/operator/aggregation/replaceRoot.txt
@@ -56,7 +56,7 @@ documents:
    ])
 
 Then the following :pipeline:`$replaceRoot` operation fails because one
-of the document does not have the ``name`` field:
+of the documents does not have the ``name`` field:
 
 .. code-block:: javascript
 


### PR DESCRIPTION
This bit seems out of place:

> to merge the ``pets`` document into some default document