### PR TITLE
Typo fix and link to the dot notation

### DIFF
--- a/source/meta/aggregation-quick-reference.txt
+++ b/source/meta/aggregation-quick-reference.txt
@@ -77,10 +77,10 @@ Field Path and System Variables
 
 Aggregation expressions use :term:`field path` to access fields in the
 input documents. To specify a field path, use a string that prefixes
-with a dollar sign ``$`` the field name or the dotted field name, if
-the field is in embedded document. For example, ``"$user"`` to specify
-the field path for the ``user`` field or ``"$user.name"`` to specify
-the field path to ``"user.name"`` field.
+with a dollar sign ``$`` the field name or the :ref:`dotted field name
+<document-dot-notation>`, if the field is in the embedded document. For
+example, ``"$user"`` to specify the field path for the ``user`` field
+or ``"$user.name"`` to specify the field path to ``"user.name"`` field.
 
 ``"$<field>"`` is equivalent to ``"$$CURRENT.<field>"`` where the
 :variable:`CURRENT` is a system variable that defaults to the root of


### PR DESCRIPTION
Hope I haven't screwed up the link format (.rst is much weirder to me than Markdown :). Wanted to link to https://docs.mongodb.com/manual/core/document/#document-dot-notation. And sorry for [the big diff, all subsequent lines are due only to my trying to preserve wrapping](https://softwareengineering.stackexchange.com/questions/351549/style-line-length-and-wrapping-of-comments-in-javascript).