### PR TITLE
Update connection-string.txt to fix URI scheme typo

### DIFF
--- a/source/reference/connection-string.txt
+++ b/source/reference/connection-string.txt
@@ -42,7 +42,7 @@ The standard URI connection scheme has the form:
 
 .. code-block:: none
 
-   mongodb://[username:password@]host1[:port1][,...hostN[:portN]]][/[database][?options]]
+   mongodb://[username:password@]host1[:port1][,...hostN[:portN]][/[database][?options]]
 
 Examples
 ````````


### PR DESCRIPTION
Remove a redundant close bracket in standard URI connection scheme