### PR TITLE
Include CA Private key in test-ca.pem

### DIFF
--- a/source/appendix/security/appendixA-openssl-ca.txt
+++ b/source/appendix/security/appendixA-openssl-ca.txt
@@ -159,7 +159,7 @@ B. Generate the Test CA PEM File
 
    .. code-block:: sh
 
-      cat mongodb-test-ca.crt mongodb-test-ia.crt  > test-ca.pem
+      cat mongodb-test-ca.key mongodb-test-ca.crt mongodb-test-ia.crt  > test-ca.pem
 
 You can use the :red:`test` PEM file when configuring :binary:`~bin.mongod`,
 :binary:`~bin.mongos`, or :binary:`~bin.mongo` for TLS/SSL :red:`testing`.


### PR DESCRIPTION
Following these instructions exactly with the latest version of Mongo yields an error on mongod restart.  The error would be with the test-ca.pem file stating "error:no start line".  OpenSSL is expecting a private key at the beginning of the file.  Adding the private key as the first element to concatenate to the test-ca.pem file resolves the issue.