### PR TITLE
Update projection syntax to 3.0

### DIFF
--- a/source/reference/method/db.collection.find.txt
+++ b/source/reference/method/db.collection.find.txt
@@ -41,7 +41,7 @@ of the following form:
 
 .. code-block:: javascript
 
-   { field1: <value>, field2: <value> ... }
+   { projection: { field1: <value>, field2: <value> ... } }
 
 The ``<value>`` can be any of the following:
 

--- a/source/reference/method/db.collection.findOne.txt
+++ b/source/reference/method/db.collection.findOne.txt
@@ -29,7 +29,7 @@ Definition
 
    .. code-block:: javascript
 
-      { field1: <boolean>, field2: <boolean> ... }
+      { projection: { field1: <boolean>, field2: <boolean> ... } }
 
    The ``<boolean>`` can be one of the following include or exclude values:
 

--- a/source/reference/method/db.collection.findOneAndDelete.txt
+++ b/source/reference/method/db.collection.findOneAndDelete.txt
@@ -61,7 +61,7 @@ The ``projection`` parameter takes a document in the following form:
 
 .. code-block:: javascript
 
-   { field1 : < boolean >, field2 : < boolean> ... }
+   { projection: { field1: <boolean>, field2: <boolean> ... } }
    
 The ``<boolean>`` value can be any of the following:
 

--- a/source/reference/method/db.collection.findOneAndReplace.txt
+++ b/source/reference/method/db.collection.findOneAndReplace.txt
@@ -65,7 +65,7 @@ The ``projection`` parameter takes a document in the following form:
 
 .. code-block:: javascript
 
-   { field1 : < boolean >, field2 : < boolean> ... }
+   { projection: { field1: <boolean>, field2: <boolean> ... } }
    
 The ``<boolean>`` value can be any of the following:
 

--- a/source/reference/method/db.collection.findOneAndUpdate.txt
+++ b/source/reference/method/db.collection.findOneAndUpdate.txt
@@ -66,7 +66,7 @@ The ``projection`` parameter takes a document in the following form:
 
 .. code-block:: javascript
 
-   { field1 : < boolean >, field2 : < boolean> ... }
+   { projection: { field1: <boolean>, field2: <boolean> ... } }
 
 The ``<boolean>`` value can be any of the following:
 


### PR DESCRIPTION
The projection examples in the documentation use 2.0 syntax which no longer works. See:

https://github.com/mongodb/node-mongodb-native/blob/master/CHANGES_3.0.0.md#find

I have updated find, findOne, findOneAndDelete, findOneAndReplace, and findOneAndUpdate to use the new 3.0 syntax.