### PR TITLE
DOCS-12940 eval option for Windows

### DIFF
--- a/source/reference/program/mongo.txt
+++ b/source/reference/program/mongo.txt
@@ -563,6 +563,9 @@ the :option:`--eval <mongo --eval>` option, use the following form:
 Use single quotes (e.g. ``'``) to enclose the JavaScript, as well as
 the additional JavaScript required to generate this output.
 
+Use double quotes (e.g. ``"``) to enclose db command while using eval
+command on windows operating system.
+
 
 .. seealso::
 


### PR DESCRIPTION
Changes made based on DOCS-12940: eval option for mongo shell needs double quotes in Windows