### PR TITLE
Update macOS bug warning

### DIFF
--- a/source/includes/extracts-4.0-errata.yaml
+++ b/source/includes/extracts-4.0-errata.yaml
@@ -15,7 +15,7 @@ content: |
 ref: 4.0-errata-wt-4018
 content: |
 
-   MongoDB 4.0 may lose data during unclean shutdowns on macOS 10.13+.
+   MongoDB 4.0 may lose data during unclean shutdowns on macOS 10.12.x and 10.13.x.
 ---
 ref: 4.0-errata-server-35657
 content: |


### PR DESCRIPTION
The bug was fixed in 10.14.1, so I changed "10.13+" to specify just the 10.12 and 10.13 versions.  10.14.0 is also affected but I think we assume that users must keep up with operating system minor upgrades.