### PR TITLE
CSFLE Json Schema - added missing quote

### DIFF
--- a/source/reference/security-client-side-automatic-json-schema.txt
+++ b/source/reference/security-client-side-automatic-json-schema.txt
@@ -145,7 +145,7 @@ The JSON schema specifies the following encryption behavior:
        .. code-block:: none
           :copyable: false
           
-          UUID("9962b057-3718-4bcf-8988-0bc519738e0)
+          UUID("9962b057-3718-4bcf-8988-0bc519738e0")
 
        The field specifies all required encryption options and
        does not inherit any settings from any parent


### PR DESCRIPTION
UUID equivalent of a base64-encoded id in the JSON Schema was missing closing quote