### PR TITLE
Fixup to Mongo shell download center links

### DIFF
--- a/source/includes/fact-download-mongo-shell.rst
+++ b/source/includes/fact-download-mongo-shell.rst
@@ -1,0 +1,18 @@
+The :binary:`~bin.mongo` shell is included as part of the :doc:`MongoDB Server
+</installation>` installation. MongoDB also provides the :binary:`~bin.mongo`
+shell as a standalone package. To download the standalone :binary:`~bin.mongo`
+shell package:
+
+1. Open the `Download Center 
+   <https://www.mongodb.com/download-center/community?jmp=docs>`__. For the
+   :binary:`~bin.mongo` Enterprise Shell, select the
+   :guilabel:`MongoDB Enterprise Server` tab.
+   
+2. Select your preferred :guilabel:`Version` and :guilabel:`OS` from the 
+   dropdowns.
+
+3. Select ``Shell`` from the :guilabel:`Package` dropdown and click 
+   :guilabel:`Download` to start downloading the package.
+
+   If the ``Shell`` option is unavailable for the selected :guilabel:`OS` and
+   :guilabel:`Version`, contact MongoDB :ref:`technical-support` for assistance.

--- a/source/mongo.txt
+++ b/source/mongo.txt
@@ -14,23 +14,7 @@ The :binary:`~bin.mongo` shell is an interactive JavaScript interface to
 MongoDB. You can use the :binary:`~bin.mongo` shell to query and update
 data as well as perform administrative operations.
 
-The :binary:`~bin.mongo` shell is included as part of the :doc:`MongoDB Server
-</installation>` installation. For host machines that do not require or allow
-the installation of the MongoDB Server, MongoDB provides the
-:binary:`~bin.mongo` shell as a standalone package. To download the standalone
-:binary:`~bin.mongo` shell package:
-
-1. Open the `Download Center 
-   <https://www.mongodb.com/download-center?jmp=docs#community>`__, 
-   
-2. Select your preferred :guilabel:`Version` and :guilabel:`OS` from the 
-   dropdowns.
-
-3. Select ``Shell`` from the :guilabel:`Package` dropdown and click 
-   :guilabel:`Download` to start downloading the package.
-
-   If the ``Shell`` option is unavailable for the selected package, contact 
-   MongoDB :ref:`technical-support` for assistance.
+.. include:: /includes/fact-download-mongo-shell.rst
 
 Once you have :doc:`installed and have started MongoDB </installation>`, connect
 the :binary:`~bin.mongo` shell to your running MongoDB instance.

--- a/source/reference/program/mongo.txt
+++ b/source/reference/program/mongo.txt
@@ -32,8 +32,8 @@ MongoDB, which provides a powerful interface for system
 administrators as well as a way for developers to test queries and
 operations directly with the database. :binary:`~bin.mongo` also provides
 a fully functional JavaScript environment for use with a MongoDB.
-The :binary:`~bin.mongo` shell is part of the `MongoDB distributions
-<https://www.mongodb.com/download-center?jmp=docs#production>`_.
+
+.. include:: /includes/fact-download-mongo-shell.rst
 
 .. note::
 


### PR DESCRIPTION
@kay-kim requesting a quick headcheck in case I've missed something. Just fixed the URL, and added the text to the `mongo` ref doc. 