### PR TITLE
(Typo fix) $ne (aggregation) refering lte comparison

### DIFF
--- a/source/reference/operator/aggregation/ne.txt
+++ b/source/reference/operator/aggregation/ne.txt
@@ -21,7 +21,7 @@ Definition
 
    - ``false`` when the values are equivalent.
 
-   .. include:: /includes/extracts/fact-agg-comparison-expression-lte.rst
+   .. include:: /includes/extracts/fact-agg-comparison-expression-ne.rst
 
    :expression:`$ne` has the following syntax:
 


### PR DESCRIPTION
$ne (aggregation) is refering to /includes/extracts/fact-agg-comparison-expression-lte.rst
instead of fact-agg-comparison-expression-ne.rst