### PR TITLE
adjust return-limits func to properly check pids

### DIFF
--- a/source/reference/ulimit.txt
+++ b/source/reference/ulimit.txt
@@ -276,9 +276,9 @@ object for a process or processes with a given name:
    return-limits(){
 
         for process in $@; do
-             process_pids=`ps -C $process -o pid --no-headers | cut -d " " -f 2`
+             process_pids=`ps -C $process -o pid --no-headers | egrep -o '[0-9]{1,}`
 
-             if [ -z $@ ]; then
+             if [ -z "$process_pids" ]; then
                 echo "[no $process running]"
              else
                 for pid in $process_pids; do


### PR DESCRIPTION
Using cut doesn't guarantee that the pid is returned and the first conditional was check for as a empty string $@ which would never be true as it entered the for loop and by not including the double quotes around it breaks the conditional interpreter