### PR TITLE
DOCSP-6837 Refactor drivers table to lean on ecosystem

### DIFF
--- a/source/reference/database-references.txt
+++ b/source/reference/database-references.txt
@@ -194,75 +194,84 @@ Driver Support for DBRefs
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
-   :widths: 20 80
+   :header-rows: 1
+   :widths: 20 25 80
+
+   * - Driver
+     - DBRef Support
+     - Notes
 
    * - **C**
 
-     - The C driver contains no support for DBRefs. You can traverse references
-       manually.
+     - Not Supported
+
+     - You can traverse references manually.
 
    * - **C++**
 
-     - The C++ driver contains no support for DBRefs. You can traverse
-       references manually.
+     - Not Supported
+
+     - You can traverse references manually.
 
    * - **C#**
 
-     - The C# driver supports DBRefs using the :api:`MongoDBRef
-       <csharp/current/html/T_MongoDB_Driver_MongoDBRef.htm>` class and
-       ``FetchDBRef`` and ``FetchDBRefAs`` methods.
+     - Supported
+
+     - Please see the :ecosystem:`C# driver page </drivers/csharp/>`
+       for more information.
 
    * - **Haskell**
 
-     - The Haskell driver contains no support for DBRefs. You can traverse
-       references manually.
+     - Not Supported
+
+     - You can traverse references manually.
 
    * - **Java**
 
-     - The :api:`DBRef <java/current/com/mongodb/DBRef.html>` class provides
-       support for DBRefs from Java.
+     - Supported
 
-   * - **JavaScript**
-
-     - The :binary:`~bin.mongo` shell's :doc:`JavaScript </reference/method>`
-       interface provides a DBRef.
+     - Please see the :ecosystem:`Java driver page </drivers/java/>`
+       for more information.
 
    * - **Node.js**
 
-     - The Node.js driver supports DBRefs using the `DBRef
-       <http://mongodb.github.io/node-mongodb-native/api-bson-generated/db_ref.h
-       tml>`_ class and the `dereference
-       <http://mongodb.github.io/node-mongodb-native/api-generated/db.html#deref
-       erence>`_ method.
+     - Supported
+
+     - Please see the :ecosystem:`Node.js driver page </drivers/node/>`
+       for more information.
 
    * - **Perl**
 
-     - The Perl driver supports DBRefs using the `MongoDB::DBRef
-       <https://metacpan.org/pod/MongoDB::DBRef>`_ class. You can traverse
-       references manually.
+     - Supported
+
+     - Please see the :ecosystem:`Perl driver page </drivers/perl/>`
+       for more information.
 
    * - **PHP**
 
-     - The PHP driver contains no support for DBRefs. You can traverse
-       references manually.
+     - Not Supported
+
+     - You can traverse references manually.
 
    * - **Python**
 
-     - The Python driver supports DBRefs using the :api:`DBRef
-       <python/current/api/bson/dbref.html>` class and the :api:`dereference
-       <python/current/api/pymongo/database.html#pymongo.database.Database.deref
-       eren ce>` method.
+     - Supported
+
+     - Please see the :ecosystem:`PyMongo driver page </drivers/pymongo/>`
+       for more information.
 
    * - **Ruby**
 
-     - The Ruby driver supports DBRefs using the :api:`DBRef
-       <ruby/current/BSON/DBRef.html>` class and the :api:`dereference
-       <ruby/current/Mongo/DB.html#dereference-instance_method>` method.
+     - Supported
+
+     - Please see the `Ruby driver page <https://docs.mongodb.com/ruby-driver/current/>`__
+       for more information.
 
    * - **Scala**
 
-     - The Scala driver contains no support for DBRefs. You can traverse
-       references manually.
+     - Not Supported
+
+     - You can traverse references manually.
 
 Use
 ~~~


### PR DESCRIPTION
Clarify supported / not supported in separate column, and provide links directly to ecosystem for driver options that do support DBRefs