### PR TITLE
DOCS-12940 add Windows-specific quoting for --eval

### DIFF
--- a/source/reference/program/mongo.txt
+++ b/source/reference/program/mongo.txt
@@ -562,19 +562,28 @@ rather than provided on the command-line, use the following form:
 
 .. seealso:: :method:`isInteractive()`
 
-Use :option:`--eval <mongo --eval>` to Print Query Results as JSON
+Use :option:`--eval <mongo --eval>` to Execute JavaScript Code
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To print return a query as :term:`JSON`, from the system prompt using
-the :option:`--eval <mongo --eval>` option, use the following form:
+You may use the :option:`--eval <mongo --eval>` option to execute
+JavaScript directly from the command line.
+
+For example, the following operation evaluates a JavaScript string
+which queries a collection and prints the results as JSON.
+
+On Linux and macOS, you will need to use single quotes (e.g. ``'``)
+to enclose the JavaScript, using the following form:
 
 .. code-block:: sh
 
    mongo --eval 'db.collection.find().forEach(printjson)'
 
-Use single quotes (e.g. ``'``) to enclose the JavaScript, as well as
-the additional JavaScript required to generate this output.
+On Windows, you will need to use double quotes (e.g. ``"``)
+to enclose the JavaScript, using the following form:
 
+.. code-block:: sh
+
+   mongo --eval "db.collection.find().forEach(printjson)"
 
 .. seealso::
 


### PR DESCRIPTION
Updated examples to include platform-specific quoting instructions, and clarified language otherwise.