### PR TITLE
DOCSP-6950 corrected typo on 'watchdogPeriodSeconds'

### DIFF
--- a/source/reference/parameters.txt
+++ b/source/reference/parameters.txt
@@ -887,7 +887,7 @@ General Parameters
    * The directory of :option:`--logpath <mongod --logpath>` file
    * The directory of :option:`--auditPath <mongod --auditPath>` file
 
-   Valid values for :parameter:`watchdobgPeriodSeconds` are:
+   Valid values for :parameter:`watchdogPeriodSeconds` are:
 
    - ``-1`` (the default), to disable/pause :ref:`Storage Node Watchdog
      <storage-node-watchdog>`, or


### PR DESCRIPTION
Corrected minor typo on watchdogPeriodSeconds.

(no backporting required)