### PR TITLE
DOCSP-5677 Add write concern URI + operator examples

### DIFF
--- a/source/reference/connection-string.txt
+++ b/source/reference/connection-string.txt
@@ -724,16 +724,20 @@ supported by the:
 
 - :binary:`~bin.mongorestore`
 
-For more information on write
-concerns, see :doc:`/reference/write-concern`.
+You can specify the write concern both in the connection string and
+as a parameter to methods like ``insert`` or ``update``. If the
+write concern is specified in both places, the method parameter
+overrides the connection-string setting.
 
+For example:
 
-.. note::
+- The following connection string to a replica set specifies
+  :writeconcern:`"majority"` write concern and a 5 second
+  timeout using the :urioption:`wtimeoutMS` write concern parameter:
 
-   You can specify the write concern both in the connection string and
-   as a parameter to method calls like ``insert`` or ``update``. If the
-   write concern is specified in both places, the method parameter
-   overrides the connection-string setting.
+  .. code-block:: none
+
+     mongodb://db0.example.com,db1.example.com,db2.example.com/?replicaSet=myRepl&w=majority&wtimeoutMS=5000
 
 .. list-table::
    :header-rows: 1
@@ -778,6 +782,8 @@ concerns, see :doc:`/reference/write-concern`.
        :binary:`~bin.mongod` does not have journaling enabled, as with
        :setting:`storage.journal.enabled`, then MongoDB will error.
 
+For more information, see :doc:`/reference/write-concern`.
+
 ``readConcern`` Options
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -796,7 +802,6 @@ The following connection string to a replica set specifies
 
    mongodb://db0.example.com,db1.example.com,db2.example.com/?replicaSet=myRepl&readConcernLevel=majority
 
-
 .. list-table::
    :header-rows: 1
    :widths: 30 70
@@ -813,14 +818,14 @@ The following connection string to a replica set specifies
        - :readconcern:`linearizable <"linearizable">`
        - :readconcern:`available <"available">`
 
-       For details, see :doc:`/reference/read-concern`.
-
        This connection string option is not available for the
        :binary:`~bin.mongo` shell. Specify the read concern as an
        :ref:`option to the specific operation
        <read-concern-operations>`.
 
 .. _connections-read-preference:
+
+For more information, see :doc:`/reference/read-concern`.
 
 Read Preference Options
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -934,6 +939,8 @@ For details, see :ref:`read-preference-tag-order-matching`.
        This connection string option is not available for the
        :binary:`mongo` shell. See :method:`cursor.readPref()` and
        :method:`Mongo.setReadPref()` instead.
+
+For more information, see :doc:`Read preferences </core/read-preference>`.
 
 Authentication Options
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -1287,9 +1294,9 @@ distributes reads to the :term:`secondaries <secondary>`:
 Replica Set with a High Level of Write Concern
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following connects to a replica set with write concern configured to wait for
-replication to succeed on at least two members, with a two-second
-timeout.
+The following connects to a replica set with write concern configured to wait
+for replication to succeed across a majority of the data-bearing voting
+members, with a two-second timeout.
 
 .. note::
 
@@ -1297,7 +1304,7 @@ timeout.
 
 .. code-block:: none
 
-   mongodb://example1.com,example2.com,example3.com/?replicaSet=test&w=2&wtimeoutMS=2000
+   mongodb://example1.com,example2.com,example3.com/?replicaSet=test&w=majority&wtimeoutMS=2000
 
 Sharded Cluster
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
Included prominent write concern URI connection string example, and changed extant write concern w:2 example to majority per recommended usage guidance.