### PR TITLE
added pre v4.0 redirects to atomocity page to avoid 404s

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1486,6 +1486,8 @@ raw: /master/release-notes/3.0-general-improvements -> ${base}/release-notes/3.0
 [*-v3.6]: /${version}/reference/read-concern-snapshot -> ${base}/${version}/reference/read-concern
 [*-v3.6]: /${version}/core/transactions -> ${base}/${version}/core/write-operations-atomicity
 [*-v3.6]: /${version}/core/transactions-operation -> ${base}/${version}/core/write-operations-atomicity
+[*-v3.6]: /${version}/core/transactions-operations -> ${base}/${version}/core/write-operations-atomicity
+[*-v3.6]: /${version}/core/transactions-production-consideration -> ${base}/${version}/core/write-operations-atomicity
 [*-v3.6]: /${version}/reference/method/Session.abortTransaction -> ${base}/${version}/core/write-operations-atomicity
 [*-v3.6]: /${version}/reference/method/Session.commitTransaction -> ${base}/${version}/core/write-operations-atomicity
 [*-v3.6]: /${version}/reference/method/Session.startTransaction -> ${base}/${version}/core/write-operations-atomicity


### PR DESCRIPTION
Added pre-4.0 redirects to atomicity page for non-existent pages.

Will require backports to 3.6, 3.4, and 3.2.