### PR TITLE
Docs 12969 mma pv1 deprecation command parameters

### DIFF
--- a/source/includes/steps-change-replica-set-wiredtiger.yaml
+++ b/source/includes/steps-change-replica-set-wiredtiger.yaml
@@ -20,6 +20,12 @@ pre: |
   ``mongod`` with WiredTiger will not start with data files created with
   a different storage engine.
 ---
+title: "Update configuration for WiredTiger."
+ref: change-wt-repl-remove-mmapv1-config
+content: |
+  Remove any :ref:`4.2-mmapv1-conf-options` from the :binary:`~bin.mongod`
+  instance configuration.
+---
 title: "Start ``mongod`` with WiredTiger."
 ref: change-wt-repl-sync-start-mongod-w-wiredtiger
 content: |
@@ -28,8 +34,7 @@ content: |
    WiredTiger as the :option:`--dbpath <mongod --dbpath>`.
 
    Specify additional options as appropriate, such as
-   :option:`--bind_ip <mongod --bind_ip>`, and remove any
-   :ref:`4.2-mmapv1-conf-options`.
+   :option:`--bind_ip <mongod --bind_ip>`.
 
    .. include:: /includes/warning-bind-ip-security-considerations.rst
     

--- a/source/includes/steps-change-standalone-wiredtiger.yaml
+++ b/source/includes/steps-change-standalone-wiredtiger.yaml
@@ -24,6 +24,12 @@ content: |
   ``mongod`` with WiredTiger will not start with data files created with
   a different storage engine.
 ---
+title: "Update configuration for WiredTiger."
+ref: change-wt-standalone-remove-mmapv1-config
+content: |
+  Remove any :ref:`4.2-mmapv1-conf-options` from the :binary:`~bin.mongod`
+  instance configuration.
+---
 title: "Start ``mongod`` with WiredTiger."
 ref: change-wt-standalone-start-mongod-w-wiredtiger
 pre: |
@@ -34,8 +40,7 @@ pre: |
    <mongod --dbpath>`.
 
    Specify additional options as appropriate, such as
-   :option:`--bind_ip <mongod --bind_ip>`, and remove any
-   :ref:`4.2-mmapv1-conf-options`.
+   :option:`--bind_ip <mongod --bind_ip>`.
 
    .. include:: /includes/warning-bind-ip-security-considerations.rst
 

--- a/source/release-notes/4.2-compatibility.txt
+++ b/source/release-notes/4.2-compatibility.txt
@@ -31,39 +31,13 @@ MMAPv1 Specific Configuration Options
 MongoDB removes the following MMAPv1 specific configuration
 options:
 
-.. list-table::
-   :header-rows: 1
-   :widths: 70 45
+.. include:: /includes/removed-mmapv1-options.rst
 
-   * - Configuration File Setting
-     - Command-line Option
+.. note::
 
-   * - ``storage.mmapv1.journal.commitIntervalMs``
-     -
-
-   * - ``storage.mmapv1.journal.debugFlags``
-     - ``mongod --journalOptions``
-
-   * - ``storage.mmapv1.nsSize``
-     - ``mongod --nssize``
-
-   * - ``storage.mmapv1.preallocDataFiles``
-     - ``mongod --noprealloc``
-
-   * - ``storage.mmapv1.quota.enforced``
-     - ``mongod --quota``
-
-   * - ``storage.mmapv1.quota.maxFilesPerDB``
-     - ``mongod --quotaFiles``
-
-   * - ``storage.mmapv1.smallFiles``
-     - ``mongod --smallfiles``
-
-   * - ``storage.repairPath``
-     - ``mongod --repairpath``
-
-   * - ``replication.secondaryIndexPrefetch``
-     - ``mongod --replIndexPrefetch``
+   Starting in version 4.2, MongoDB processes will not start with
+   these options. Remove any MMAPv1 specific configuration
+   options if using a WiredTiger deployment.
 
 MMAPv1 Specific Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -87,9 +61,8 @@ MongoDB removes the MMAPv1 specific options:
 
 - ``verbose`` for :dbcommand:`collStats`
 
-
 - ``flags`` for :dbcommand:`create`
- 
+
 - ``paddingFactor``, ``paddingBytes``, ``preservePadding`` for
   :method:`db.createCollection()`.
 

--- a/source/release-notes/4.2-upgrade-replica-set.txt
+++ b/source/release-notes/4.2-upgrade-replica-set.txt
@@ -77,8 +77,17 @@ MMAPv1 to WiredTiger Storage Engine
 MongoDB 4.2 removes support for the deprecated MMAPv1 storage engine.
 
 If your 4.0 deployment uses MMAPv1, you must change the 4.0 deployment
-to :doc:`/core/wiredtiger` before upgrading to MongoDB 4.2. For
-details, see :doc:`/tutorial/change-replica-set-wiredtiger`.
+to :doc:`/core/wiredtiger` before upgrading to MongoDB 4.2. For details,
+see :doc:`/tutorial/change-replica-set-wiredtiger`.
+
+Review Current Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+With MongoDB 4.2, the :binary:`mongod <bin.mongod>` and
+:binary:`mongos <bin.mongos>` processes will not start with
+:ref:`4.2-mmapv1-conf-options`. Previous versions of MongoDB running
+WiredTiger ignored MMAPv1 configurations options if they were specified.
+With MongoDB 4.2, you must remove these from your WiredTiger deployment.
 
 Feature Compatibility Version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/release-notes/4.2-upgrade-replica-set.txt
+++ b/source/release-notes/4.2-upgrade-replica-set.txt
@@ -87,7 +87,7 @@ With MongoDB 4.2, the :binary:`mongod <bin.mongod>` and
 :binary:`mongos <bin.mongos>` processes will not start with
 :ref:`4.2-mmapv1-conf-options`. Previous versions of MongoDB running
 WiredTiger ignored MMAPv1 configurations options if they were specified.
-With MongoDB 4.2, you must remove these from your WiredTiger deployment.
+With MongoDB 4.2, you must remove these from your configuration.
 
 Feature Compatibility Version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/release-notes/4.2-upgrade-sharded-cluster.txt
+++ b/source/release-notes/4.2-upgrade-sharded-cluster.txt
@@ -75,8 +75,17 @@ MMAPv1 to WiredTiger Storage Engine
 MongoDB 4.2 removes support for the deprecated MMAPv1 storage engine.
 
 If your 4.0 deployment uses MMAPv1, you must change the 4.0 deployment
-to :doc:`/core/wiredtiger` before upgrading to MongoDB 4.2. For
-details, see :doc:`/tutorial/change-sharded-cluster-wiredtiger`.
+to :doc:`/core/wiredtiger` before upgrading to MongoDB 4.2. For details,
+see :doc:`/tutorial/change-sharded-cluster-wiredtiger`.
+
+Review Current Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+With MongoDB 4.2, the :binary:`mongod <bin.mongod>` and
+:binary:`mongos <bin.mongos>` processes will not start with
+:ref:`4.2-mmapv1-conf-options`. Previous versions of MongoDB running
+WiredTiger ignored MMAPv1 configurations options if they were specified.
+With MongoDB 4.2, you must remove these from your WiredTiger deployment.
 
 Feature Compatibility Version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -135,7 +144,7 @@ that the hashed value for the floating point value 2\ :sup:`63` on
 PowerPC is consistent with other platforms. 
 
 Although :doc:`hashed indexes </core/index-hashed>` on a field that may
-contain floating point values greater than 2\ :sup:`53` is an
+contain floating point values greater than 2\ :sup:`63` is an
 unsupported configuration, clients may still insert documents where the
 indexed field has the value 2\ :sup:`63`.
 

--- a/source/release-notes/4.2-upgrade-sharded-cluster.txt
+++ b/source/release-notes/4.2-upgrade-sharded-cluster.txt
@@ -85,7 +85,7 @@ With MongoDB 4.2, the :binary:`mongod <bin.mongod>` and
 :binary:`mongos <bin.mongos>` processes will not start with
 :ref:`4.2-mmapv1-conf-options`. Previous versions of MongoDB running
 WiredTiger ignored MMAPv1 configurations options if they were specified.
-With MongoDB 4.2, you must remove these from your WiredTiger deployment.
+With MongoDB 4.2, you must remove these from your configuration.
 
 Feature Compatibility Version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/release-notes/4.2-upgrade-standalone.txt
+++ b/source/release-notes/4.2-upgrade-standalone.txt
@@ -31,8 +31,17 @@ MMAPv1 to WiredTiger Storage Engine
 MongoDB 4.2 removes support for the deprecated MMAPv1 storage engine.
 
 If your 4.0 deployment uses MMAPv1, you must change the 4.0 deployment
-to :doc:`/core/wiredtiger` before upgrading to MongoDB 4.2. For
-details, see :doc:`/tutorial/change-standalone-wiredtiger`.
+to :doc:`/core/wiredtiger` before upgrading to MongoDB 4.2. For details,
+see :doc:`/tutorial/change-standalone-wiredtiger`.
+
+Review Current Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+With MongoDB 4.2, the :binary:`mongod <bin.mongod>` and
+:binary:`mongos <bin.mongos>` processes will not start with
+:ref:`4.2-mmapv1-conf-options`. Previous versions of MongoDB running
+WiredTiger ignored MMAPv1 configurations options if they were specified.
+With MongoDB 4.2, you must remove these from your configuration.
 
 Feature Compatibility Version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/release-notes/4.2.txt
+++ b/source/release-notes/4.2.txt
@@ -91,6 +91,11 @@ options:
 
 .. include:: /includes/removed-mmapv1-options.rst
 
+.. note::
+
+   Starting in version 4.2, MongoDB processes will not start with
+   these options. Remove any MMAPv1 specific configuration
+   options if using a WiredTiger deployment.
 
 MMAPv1 Specific Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/tutorial/change-standalone-wiredtiger.txt
+++ b/source/tutorial/change-standalone-wiredtiger.txt
@@ -25,8 +25,8 @@ Considerations
    :binary:`~bin.mongorestore` utilities to export and import data.
 
    - Ensure that these MongoDB package components are installed and
-     updated on your system. 
-  
+     updated on your system.
+
    - Make sure you have sufficient drive space available for the
      :binary:`~bin.mongodump` export file and the data files of your new
      :binary:`~bin.mongod` instance running with WiredTiger.


### PR DESCRIPTION
Provided messaging to advise removing MMAPv1 options from WiredTiger deployments, with prominent warnings that these options prevent WiredTiger deployments on 4.2 from starting.