### PR TITLE
DOCS-5696 Clarify PIDfile permissions and usage, with note

### DIFF
--- a/source/includes/options-mongod.yaml
+++ b/source/includes/options-mongod.yaml
@@ -447,11 +447,30 @@ name: pidfilepath
 args: <path>
 directive: option
 description: |
-  {{intro}} file location to hold the process ID of the {{program}}
-  process where {{program}} will write its PID. This is useful for
-  tracking the {{program}} process in combination with
-  {{option}}. Without a specified {{role}} option, the
-  process creates no PID file.
+  {{intro}} file location to store the process ID (PID) of the {{program}}
+  process . The user running the the ``mongod`` or ``mongos``
+  process must be able to write to this path. If the {{role}} option is not
+  specified, the process does not create a PID file. This option is generally
+  only useful in combination with the {{option}}.
+
+  .. admonition:: Linux
+     :class: note
+  
+     On Linux, PID file management is generally the responsibility of
+     your distro's init system: usually a service file in the ``/etc/init.d``
+     directory, or a systemd unit file registered with ``systemctl``. Only
+     use the {{role}} option if you are not using one of these init
+     systems. For more information, please see the respective
+     :doc:`Installation Guide </installation>` for your operating system.
+
+  .. admonition:: macOS
+     :class: note
+
+     On macOS, PID file management is generally handled by ``brew``. Only use
+     the {{role}} option if you are not using ``brew`` on your macOS system. 
+     For more information, please see the respective
+     :doc:`Installation Guide </installation>` for your operating system.
+
 optional: true
 replacement:
   intro: "Specifies a"


### PR DESCRIPTION
Expanded pidFilePath option explanation to highlight the more common use of a system's init system to handle PID and PID files, with additional clarification around matching pidFilePath with fork.