### PR TITLE
 (DOCS-12966): Updating behavior for countDocuments on empty collections 

### DIFF
--- a/source/reference/method/db.collection.countDocuments.txt
+++ b/source/reference/method/db.collection.countDocuments.txt
@@ -94,8 +94,15 @@ aggregation operation and returns just the value of ``n``:
       { $group: { _id: null, n: { $sum: 1 } } }
    ])
 
-:method:`db.collection.countDocuments()` errors on an empty or
+Empty or Non-Existing Collections and Views
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Starting in version 4.2.1 (and 4.0-series in 4.0.13),
+:method:`db.collection.countDocuments()` returns ``0`` on an empty or
 non-existing collection or view.
+
+In earlier versions of MongoDB, :method:`db.collection.countDocuments()`
+errors on an empty or non-existing collection or view.
 
 .. _countDocuments-restrictions:
 

--- a/source/reference/method/db.collection.countDocuments.txt
+++ b/source/reference/method/db.collection.countDocuments.txt
@@ -97,9 +97,8 @@ aggregation operation and returns just the value of ``n``:
 Empty or Non-Existing Collections and Views
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Starting in version 4.2.1 (and 4.0-series in 4.0.13),
-:method:`db.collection.countDocuments()` returns ``0`` on an empty or
-non-existing collection or view.
+Starting in version 4.0.13, :method:`db.collection.countDocuments()`
+returns ``0`` on an empty or non-existing collection or view.
 
 In earlier versions of MongoDB, :method:`db.collection.countDocuments()`
 errors on an empty or non-existing collection or view.


### PR DESCRIPTION
This is the same as #3681, except with a second commit to remove the reference to the 4.2 series. This is for the 4.0.13 branch.

Code review: https://mongodbcr.appspot.com/507280007/

Staged: https://docs-mongodbcom-staging.corp.mongodb.com/jeffreyallen/v4.0.13/reference/method/db.collection.countDocuments.html#empty-or-non-existing-collections-and-views