### PR TITLE
corrected 2 instances of dropIndexes(), previously getIndexes()

### DIFF
--- a/source/reference/method/db.collection.dropIndexes.txt
+++ b/source/reference/method/db.collection.dropIndexes.txt
@@ -70,7 +70,7 @@ Definition
         To get the names of the indexes, use the
         :method:`db.collection.getIndexes()` method.
 
-   The :method:`db.collection.getIndexes()` method takes the following
+   The :method:`db.collection.dropIndexes()` method takes the following
    optional parameter:
 
    .. list-table::
@@ -102,7 +102,7 @@ Definition
           **To drop multiple indexes** (Available starting in MongoDB
           4.2), specify an array of the index names.
 
-   The :method:`db.collection.getIndexes()` is a wrapper around the
+   The :method:`db.collection.dropIndexes()` is a wrapper around the
    :dbcommand:`dropIndexes` command.
    
 Behavior


### PR DESCRIPTION
Corrected two instances of getIndexes() --> dropIndexes()