### PR TITLE
DOCSP-7092 clarified RHEL/CentOS nprocs override note

### DIFF
--- a/source/includes/note-suse-ulimit.rst
+++ b/source/includes/note-suse-ulimit.rst
@@ -1,10 +1,8 @@
-.. note::
+SUSE Linux Enterprise Server and potentially other SUSE distributions ship
+with virtual memory address space limited to 8 GB by default. You *must*
+adjust this in order to prevent virtual memory allocation failures as the
+database grows.
 
-   SUSE Linux Enterprise Server and potentially other SUSE distributions ship
-   with virtual memory address space limited to 8 GB by default. You *must*
-   adjust this in order to prevent virtual memory allocation failures as the
-   database grows.
-
-   The SLES packages for MongoDB adjust these limits in the default scripts,
-   but you will need to make this change manually if you are using custom
-   scripts and/or the tarball release rather than the SLES packages.
+The SLES packages for MongoDB adjust these limits in the default scripts,
+but you will need to make this change manually if you are using custom
+scripts and/or the tarball release rather than the SLES packages.

--- a/source/reference/ulimit.txt
+++ b/source/reference/ulimit.txt
@@ -17,15 +17,6 @@ basis. These "ulimits" prevent single users from using too many system
 resources. Sometimes, these limits have low default values that can
 cause a number of issues in the course of normal MongoDB operation.
 
-.. note::
-
-   Red Hat Enterprise Linux and CentOS 6 place a max process
-   limitation of 1024 which overrides ``ulimit`` settings. Create a
-   file named ``/etc/security/limits.d/99-mongodb-nproc.conf`` with
-   new ``soft nproc`` and ``hard nproc`` values to increase the
-   process limit. See ``/etc/security/limits.d/90-nproc.conf`` file as
-   an example.
-
 .. _system-resource-utilization:
 
 Resource Utilization
@@ -161,7 +152,38 @@ change to system limits made using ``ulimit`` may revert following
 a system restart. Check your distribution and operating
 system documentation for more information.
 
+SUSE Linux Enterprise Server
+````````````````````````````
+
 .. include:: /includes/note-suse-ulimit.rst
+
+Red Hat Linux Enterprise Server and CentOS
+``````````````````````````````````````````
+
+Red Hat Enterprise Linux and CentOS 6 and 7 enforce a separate max process
+limitation, ``nproc``, which overrides ``ulimit`` settings. This value is
+defined in the following configuration file, depending on version:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 8 60
+
+   * - Version
+     - Value
+     - File
+
+   * - RHEL / CentOS 7
+     - 4096
+     - ``/etc/security/limits.d/20-nproc.conf``
+
+   * - RHEL / CentOS 6
+     - 1024
+     - ``/etc/security/limits.d/90-nproc.conf``
+
+To configure an ``nproc`` value for these versions, create a file named
+``/etc/security/limits.d/99-mongodb-nproc.conf`` with new ``soft nproc`` and
+``hard nproc`` values to increase the process limit. For recommended values,
+see :ref:`recommended-ulimit-settings`.
 
 .. _recommended-ulimit-settings:
 

--- a/source/tutorial/install-mongodb-enterprise-on-suse.txt
+++ b/source/tutorial/install-mongodb-enterprise-on-suse.txt
@@ -43,7 +43,9 @@ Considerations
 
 .. include:: /includes/fact-use-distribution-package.rst
 
-.. include:: /includes/note-suse-ulimit.rst
+.. note::
+
+   .. include:: /includes/note-suse-ulimit.rst
 
 Install MongoDB Enterprise
 --------------------------

--- a/source/tutorial/install-mongodb-on-suse.txt
+++ b/source/tutorial/install-mongodb-on-suse.txt
@@ -33,7 +33,9 @@ Packages
 
 .. include:: /includes/list-mongodb-org-packages.rst
 
-.. include:: /includes/note-suse-ulimit.rst
+.. note::
+
+   .. include:: /includes/note-suse-ulimit.rst
 
 
 Install MongoDB Community Edition


### PR DESCRIPTION
Provided updated nproc conf file for `el7` (changed from `el6`).