### PR TITLE
(DOCSP-7259): Standardizing amazon enterprise install page

### DIFF
--- a/config/sphinx_local.yaml
+++ b/config/sphinx_local.yaml
@@ -106,6 +106,7 @@ theme:
     - /tutorial/install-mongodb-on-debian
     - /tutorial/install-mongodb-on-suse
     - /tutorial/install-mongodb-on-amazon
+    - /tutorial/install-mongodb-enterprise-on-amazon
     - /tutorial/install-mongodb-enterprise-on-windows
     - /tutorial/install-mongodb-on-os-x
 

--- a/source/tutorial/install-mongodb-enterprise-on-amazon-tarball.txt
+++ b/source/tutorial/install-mongodb-enterprise-on-amazon-tarball.txt
@@ -1,0 +1,48 @@
+.. _install-amazon-from-tarball:
+
+==============================================
+Install Using ``.tgz`` Tarball on Amazon Linux
+==============================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Overview
+--------
+
+The following tutorial downloads the ``.tgz`` file directly to install
+MongoDB Enterprise on Amazon Linux. To install using ``brew``, see
+:doc:`/tutorial/install-mongodb-enterprise-on-amazon` instead.
+
+Prerequisites
+-------------
+
+.. include:: /includes/fact-tarball-dependencies.rst
+
+.. include:: /includes/extracts/install-mongodb-enterprise-manually-redhat-6.rst
+
+Procedure
+---------
+
+.. include:: /includes/steps/install-mongodb-enterprise-on-linux.rst
+
+Additional Considerations
+-------------------------
+
+Security
+~~~~~~~~
+
+Starting with MongoDB 3.6, MongoDB binaries, :binary:`mongod
+<bin.mongod>` and :binary:`mongos <bin.mongos>`, bind to
+``localhost`` by default.
+
+When bound only to the localhost, these binaries can only accept
+connections from clients that are running on the same machine. Remote
+clients cannot connect to the binaries bound only to localhost. For
+more information, including how to override and bind to other ip
+addresses, see :ref:`3.6-bind_ip-compatibility`.

--- a/source/tutorial/install-mongodb-enterprise-on-amazon.txt
+++ b/source/tutorial/install-mongodb-enterprise-on-amazon.txt
@@ -8,7 +8,7 @@ Install MongoDB Enterprise on Amazon Linux
    :local:
    :backlinks: none
    :depth: 1
-   :class: twocols
+   :class: singlecol
 
 .. admonition:: MongoDB Atlas and AWS
    :class: note
@@ -26,8 +26,6 @@ AMI. MongoDB Enterprise is available on select platforms and contains
 support for several features related to security and monitoring.
 
 .. include:: /includes/fact-installation-64bit.rst
-
-.. include:: /includes/list-mongodb-enterprise-packages.rst
 
 .. admonition:: Production Notes
    :class: note
@@ -58,23 +56,6 @@ Using ``.rpm`` Packages (Recommended)
 
          .. include:: /includes/steps/install-mongodb-enterprise-on-amazon.rst
 
-.. _install-amazon-from-tarball:
-
-Using ``.tar.gz`` Tarballs
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Prerequisites
-`````````````
-
-.. include:: /includes/fact-tarball-dependencies.rst
-
-.. include:: /includes/extracts/install-mongodb-enterprise-manually-redhat-6.rst
-
-Procedure
-`````````
-
-.. include:: /includes/steps/install-mongodb-enterprise-on-linux.rst
-
 Run MongoDB Enterprise
 ----------------------
 
@@ -99,3 +80,30 @@ Uninstall MongoDB
 .. include:: /includes/fact-uninstall.rst
 
 .. include:: /includes/steps/uninstall-mongodb-enterprise-on-redhat.rst
+
+Additional Information
+----------------------
+
+Security
+~~~~~~~~
+
+Starting with MongoDB 3.6, MongoDB binaries, :binary:`mongod
+<bin.mongod>` and :binary:`mongos <bin.mongos>`, bind to
+``localhost`` by default.
+
+When bound only to the localhost, these binaries can only accept
+connections from clients that are running on the same machine. Remote
+clients cannot connect to the binaries bound only to localhost. For
+more information, including how to override and bind to other ip
+addresses, see :ref:`3.6-bind_ip-compatibility`.
+
+Packages
+~~~~~~~~
+
+.. include:: /includes/list-mongodb-enterprise-packages.rst
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+
+   Install Using .tgz Tarball </tutorial/install-mongodb-enterprise-on-amazon-tarball>


### PR DESCRIPTION
Split the tarball installation to its own page. Moved Packages section to the bottom under Additional Info.

https://docs-mongodbcom-staging.corp.mongodb.com/docsworker-xlarge/install-improvements/tutorial/install-mongodb-enterprise-on-amazon.html