### PR TITLE
DOCS-10088 clarify ulimit change behavior for manual installs

### DIFF
--- a/source/includes/note-suse-ulimit.rst
+++ b/source/includes/note-suse-ulimit.rst
@@ -3,6 +3,8 @@ with virtual memory address space limited to 8 GB by default. You *must*
 adjust this in order to prevent virtual memory allocation failures as the
 database grows.
 
-The SLES packages for MongoDB adjust these limits in the default scripts,
-but you will need to make this change manually if you are using custom
-scripts and/or the tarball release rather than the SLES packages.
+The SLES packages for MongoDB automatically adjust these limits in
+their default init script. If you are starting MongoDB manually without
+the provided init script, are using your own custom init script, or
+are using the TGZ tarball release, you must make these changes
+yourself.


### PR DESCRIPTION
Updated language to include cases where mongod is started manually, not necessarily just from the TGZ.