### PR TITLE
Adding run instructions for mdb enterprise tgz on amazon

### DIFF
--- a/source/includes/steps-run-mongodb-on-ubuntu-tarball.yaml
+++ b/source/includes/steps-run-mongodb-on-ubuntu-tarball.yaml
@@ -51,7 +51,7 @@ ref: verify
 pre: |
   Verify that MongoDB has started successfully by
   checking the process output for the following line in the 
-  log file ``/var/log/mongodb/mongod.log``:
+  log file ``/data/logs/mongod.log``:
 action:
   language: none
   copyable: false

--- a/source/tutorial/install-mongodb-enterprise-on-amazon-tarball.txt
+++ b/source/tutorial/install-mongodb-enterprise-on-amazon-tarball.txt
@@ -31,6 +31,11 @@ Procedure
 
 .. include:: /includes/steps/install-mongodb-enterprise-on-linux.rst
 
+Run MongoDB
+-----------
+
+.. include:: /includes/steps/run-mongodb-on-ubuntu-tarball.rst
+
 Additional Considerations
 -------------------------
 


### PR DESCRIPTION
Tweaked the include file to point to the correct log file. Tested and the ubuntu instructions also work on Amazon Linux.

Staged: https://docs-mongodbcom-staging.corp.mongodb.com/docsworker-xlarge/install-improvements/tutorial/install-mongodb-enterprise-on-amazon-tarball.html#run-mongodb