### PR TITLE
Docs 13108 add rhel centos8 support with 4.2.1

### DIFF
--- a/config/build_conf.yaml
+++ b/config/build_conf.yaml
@@ -10,7 +10,7 @@ project:
   branched: true
   siteroot: true
 version:
-  release: '4.2.0'
+  release: '4.2.1'
   branch: '4.2'
 system:
   files:

--- a/config/redirects
+++ b/config/redirects
@@ -1434,6 +1434,7 @@ raw: /master/release-notes/3.0-general-improvements -> ${base}/release-notes/3.0
 [v3.0-v4.0]: /${version}/reference/operator/aggregation/planCacheStats -> ${base}/${version}/reference/command/planCacheListPlans
 [v3.0-v4.0]: /${version}/tutorial/convert-command-line-options-to-yaml -> ${base}/${version}/reference/configuration-file-settings-command-line-options-mapping
 [v3.0-v4.0]: /${version}/reference/method/isInteractive -> ${base}/${version}/reference/method
+[v3.0-v4.0]: /${version}/reference/method/Bulk.find.hint -> ${base}/${version}/reference/method/Bulk.find
 
 
 # Redirects for 4.0 or earlier (i.e. before 4.2), stopping a v3.0 since otherwise to help slow the growth in the number of our redirects 

--- a/source/administration/production-notes.txt
+++ b/source/administration/production-notes.txt
@@ -81,7 +81,7 @@ While MongoDB supports a variety of platforms, the following operating
 systems are recommended for production use:
 
 - Amazon Linux 2
-- Debian 9
+- Debian 9 and 10
 - RHEL / CentOS 6 and 7
 - SLES 12
 - Ubuntu LTS 16.04 and 18.04

--- a/source/administration/production-notes.txt
+++ b/source/administration/production-notes.txt
@@ -82,7 +82,7 @@ systems are recommended for production use:
 
 - Amazon Linux 2
 - Debian 9 and 10
-- RHEL / CentOS 6 and 7
+- RHEL / CentOS 6, 7, and 8
 - SLES 12
 - Ubuntu LTS 16.04 and 18.04
 - Windows Server 2016
@@ -571,15 +571,13 @@ To see what the current swappiness level is, run:
 
 .. code-block:: sh
 
-   example@example:$ cat /proc/sys/vm/swappiness
-
-   60
+   cat /proc/sys/vm/swappiness
 
 To change swappiness while the system is running, run:
 
 .. code-block:: sh
 
-   example@example:$ sysctl vm.swappiness=1
+   sysctl vm.swappiness=1
 
 To change swappiness permanently, edit the ``/etc/sysctl.conf`` file in
 your preferred text editor and change this value:

--- a/source/core/map-reduce.txt
+++ b/source/core/map-reduce.txt
@@ -61,6 +61,11 @@ mapping. Map-reduce operations can also use a custom JavaScript
 function to make final modifications to the results at the end of the
 map and reduce operation, such as perform additional calculations.
 
+Starting in version 4.2.1, MongoDB deprecates the use of JavaScript
+with scope (i.e. :doc:`BSON type 15 </reference/bson-types/>`) for the
+``map``, ``reduce``, and ``finalize`` functions. To scope variables,
+use the ``scope`` parameter instead.
+    
 Map-Reduce Results
 -------------------
 

--- a/source/core/replica-set-architectures.txt
+++ b/source/core/replica-set-architectures.txt
@@ -66,8 +66,9 @@ Consider Fault Tolerance
 *Fault tolerance* for a replica set is the number of members that can
 become unavailable and still leave enough members in the set to elect a
 primary. In other words, it is the difference between the number of
-members in the set and the majority of voting members needed to elect a
-primary. Without a primary, a replica set cannot accept write
+members in the set and the :data:`majority
+<replSetGetStatus.majorityVoteCount>` of voting members needed to
+elect a primary. Without a primary, a replica set cannot accept write
 operations. Fault tolerance is an effect of replica set size, but the
 relationship is not direct. See the following table:
 
@@ -109,6 +110,9 @@ Adding a member to the replica set does not *always* increase the
 fault tolerance. However, in these cases, additional members can
 provide support for dedicated functions, such as backups or reporting.
 
+Starting in version 4.2.1, :method:`rs.status()` returns
+:data:`~replSetGetStatus.majorityVoteCount` for the replica set.
+       
 Use Hidden and Delayed Members for Dedicated Functions
 ``````````````````````````````````````````````````````
 

--- a/source/core/replica-set-elections.txt
+++ b/source/core/replica-set-elections.txt
@@ -111,8 +111,9 @@ A :term:`network partition` may segregate a primary into a partition
 with a minority of nodes. When the primary detects that it can only see
 a minority of nodes in the replica set, the primary steps down as
 primary and becomes a secondary. Independently, a member in the
-partition that can communicate with a majority of the nodes (including
-itself) holds an election to become the new primary.
+partition that can communicate with a :data:`majority
+<replSetGetStatus.majorityVoteCount>` of the nodes (including itself)
+holds an election to become the new primary.
 
 .. index:: replica set members; non-voting
 

--- a/source/includes/extracts-install-mongodb-manually.yaml
+++ b/source/includes/extracts-install-mongodb-manually.yaml
@@ -14,13 +14,25 @@ content: |
 ---
 
 
-ref: install-mongodb-enterprise-manually-debian
+ref: install-mongodb-enterprise-manually-debian-10
+content: |
+  .. code-block:: sh
+
+     sudo apt-get install libcurl4 libgssapi-krb5-2 libkrb5-dbg libldap-2.4-2 libpcap0.8 libsasl2-2 snmp openssl
+---
+ref: install-mongodb-enterprise-manually-debian-9
 content: |
   .. code-block:: sh
 
      sudo apt-get install libcurl3 libgssapi-krb5-2 libkrb5-dbg libldap-2.4-2 libpcap0.8 libsasl2-2 snmp openssl
 ---
-ref: install-mongodb-community-manually-debian
+ref: install-mongodb-community-manually-debian-10
+content: |
+  .. code-block:: sh
+
+     sudo apt-get install libcurl4 openssl
+---
+ref: install-mongodb-community-manually-debian-9
 content: |
   .. code-block:: sh
 
@@ -30,17 +42,17 @@ content: |
 ---
 
 
-ref: install-mongodb-enterprise-manually-redhat-6
-content: |
-  .. code-block:: sh
-
-     yum install cyrus-sasl cyrus-sasl-plain cyrus-sasl-gssapi krb5-libs libcurl libpcap net-snmp openldap openssl
----
 ref: install-mongodb-enterprise-manually-redhat-7
 content: |
   .. code-block:: sh
 
      yum install cyrus-sasl cyrus-sasl-gssapi cyrus-sasl-plain krb5-libs libcurl libpcap lm_sensors-libs net-snmp net-snmp-agent-libs openldap openssl rpm-libs tcp_wrappers-libs
+---
+ref: install-mongodb-enterprise-manually-redhat-6
+content: |
+  .. code-block:: sh
+
+     yum install cyrus-sasl cyrus-sasl-plain cyrus-sasl-gssapi krb5-libs libcurl libpcap net-snmp openldap openssl
 ---
 ref: install-mongodb-community-manually-redhat
 content: |

--- a/source/includes/extracts-install-mongodb-manually.yaml
+++ b/source/includes/extracts-install-mongodb-manually.yaml
@@ -40,23 +40,27 @@ content: |
 
 
 ---
+ref: install-mongodb-enterprise-manually-redhat-8
+content: |
+  .. code-block:: sh
 
-
+     sudo yum install cyrus-sasl cyrus-sasl-gssapi cyrus-sasl-plain krb5-libs libcurl libpcap lm_sensors-libs net-snmp net-snmp-agent-libs openldap openssl rpm-libs
+---
 ref: install-mongodb-enterprise-manually-redhat-7
 content: |
   .. code-block:: sh
 
-     yum install cyrus-sasl cyrus-sasl-gssapi cyrus-sasl-plain krb5-libs libcurl libpcap lm_sensors-libs net-snmp net-snmp-agent-libs openldap openssl rpm-libs tcp_wrappers-libs
+     sudo yum install cyrus-sasl cyrus-sasl-gssapi cyrus-sasl-plain krb5-libs libcurl libpcap lm_sensors-libs net-snmp net-snmp-agent-libs openldap openssl rpm-libs tcp_wrappers-libs
 ---
 ref: install-mongodb-enterprise-manually-redhat-6
 content: |
   .. code-block:: sh
 
-     yum install cyrus-sasl cyrus-sasl-plain cyrus-sasl-gssapi krb5-libs libcurl libpcap net-snmp openldap openssl
+     sudo yum install cyrus-sasl cyrus-sasl-plain cyrus-sasl-gssapi krb5-libs libcurl libpcap net-snmp openldap openssl
 ---
 ref: install-mongodb-community-manually-redhat
 content: |
   .. code-block:: sh
 
-     yum install libcurl openssl
+     sudo yum install libcurl openssl
 ...

--- a/source/includes/extracts-server-status-projection-base.yaml
+++ b/source/includes/extracts-server-status-projection-base.yaml
@@ -12,6 +12,10 @@ content: |
 ref: _serverStatus-output-changes
 content: |
 
+  - Starting in MongoDB 4.2.1 (and 4.0.13), {{operationName}} includes:
+
+    - :serverstatus:`electionMetrics`
+
   - Starting in MongoDB 4.2, {{operationName}}:
     
     - Returns :serverstatus:`opcounters` and
@@ -48,7 +52,7 @@ content: |
     
     - Reports ``ParallelBatchWriterMode`` lock information separately from
       ``Global`` lock information.  See :serverstatus:`locks`.
-   
+
   - Starting in MongoDB 4.0.6, {{operationName}} includes:
 
     - :serverstatus:`opReadConcernCounters`

--- a/source/includes/fact-installation-bind-ip-default-in-config.rst
+++ b/source/includes/fact-installation-bind-ip-default-in-config.rst
@@ -1,4 +1,4 @@
 The ``/etc/mongod.conf`` configuration file supplied by the
-package have :setting:`~net.bind_ip` set to ``127.0.0.1`` by default. Modify
+package sets :setting:`~net.bind_ip` to ``127.0.0.1`` by default. Modify
 this setting as needed for your environment before initializing a
 :term:`replica set`.

--- a/source/includes/fact-platform-x86_64.rst
+++ b/source/includes/fact-platform-x86_64.rst
@@ -89,6 +89,12 @@
      - |checkmark|
      - |checkmark|
 
+   * - RHEL/CentOS/Oracle Linux [#oracle-linux]_ 8.0 and later
+     - 4.2.1+
+     -
+     -
+     -
+
    * - SLES 12
      - |checkmark|
      - |checkmark|

--- a/source/includes/fact-platform-x86_64.rst
+++ b/source/includes/fact-platform-x86_64.rst
@@ -71,6 +71,12 @@
      - 3.6.5+
      -
 
+   * - Debian 10
+     - 4.2.1+
+     -
+     -
+     -
+
    * - RHEL/CentOS/Oracle Linux [#oracle-linux]_ 6.2 and later
      - |checkmark|
      - |checkmark|

--- a/source/includes/fact-rs-status-init-sync-availability.rst
+++ b/source/includes/fact-rs-status-init-sync-availability.rst
@@ -1,0 +1,18 @@
+.. admonition:: Availability
+   :class: important
+
+   Starting in MongoDB 4.2.1,
+   :data:`replSetGetStatus.initialSyncStatus` metrics are only
+   available when run on a member during its initial sync (i.e.
+   :replstate:`STARTUP2` state).
+      
+   In earlier versions (3.4.x-4.2.0),
+   :data:`replSetGetStatus.initialSyncStatus` metrics are available
+   when the command is run with ``initialSync: 1`` option on a
+   secondary or a member in its :replstate:`STARTUP2` state, even after
+   the member completes its initial sync. However, some fields that
+   relate to the progress of an on-going initial sync only appear while
+   the initial sync is in progress and do not appear once the initial
+   sync completes.
+   
+   

--- a/source/includes/options-mongod.yaml
+++ b/source/includes/options-mongod.yaml
@@ -2451,7 +2451,7 @@ description: |
    To change the maximum size during runtime, use the
    :parameter:`wiredTigerMaxCacheOverflowSizeGB` parameter.
 
-   *Available in 4.0-series starting in 4.0.12*
+   *Available starting in MongoDB 4.2.1 (and 4.0.12)*
 ---
 program: mongod
 name: wiredTigerJournalCompressor

--- a/source/includes/parameters-map-reduce.rst
+++ b/source/includes/parameters-map-reduce.rst
@@ -29,6 +29,11 @@ The ``map`` function has the following requirements:
 
 - The ``map`` function may optionally call ``emit(key,value)`` any number of
   times to create an output document associating ``key`` with ``value``.
+  
+- Starting in version 4.2.1, MongoDB deprecates the use of JavaScript
+  with scope (i.e. :doc:`BSON type 15 </reference/bson-types/>`) for
+  the ``map`` function. To scope variables, use the ``scope`` parameter
+  instead.
 
 The following ``map`` function will call ``emit(key,value)`` either
 0 or 1 times depending on the value of the input document's
@@ -93,6 +98,11 @@ The ``reduce`` function exhibits the following behaviors:
   requirement may be violated when large documents are returned and then
   joined together in subsequent ``reduce`` steps.
 
+- Starting in version 4.2.1, MongoDB deprecates the use of JavaScript
+  with scope (i.e. :doc:`BSON type 15 </reference/bson-types/>`) for
+  the ``reduce`` function. To scope variables, use the ``scope``
+  parameter instead.
+  
 Because it is possible to invoke the ``reduce`` function
 more than once for the same key, the following
 properties need to be true:
@@ -265,5 +275,10 @@ aware that:
 
 - The ``finalize`` function can access the variables defined in
   the ``scope`` parameter.
+
+- Starting in version 4.2.1, MongoDB deprecates the use of JavaScript
+  with scope (i.e. :doc:`BSON type 15 </reference/bson-types/>`) for
+  the ``finalize`` function. To scope variables, use the ``scope``
+  parameter instead.
 
 .. end-finalize

--- a/source/includes/ref-toc-method-bulk.yaml
+++ b/source/includes/ref-toc-method-bulk.yaml
@@ -26,6 +26,10 @@ name: ":method:`Bulk.find.collation()`"
 file: /reference/method/Bulk.find.collation
 description: "Specifies the :ref:`collation <collation>` for the query condition."
 ---
+name: ":method:`Bulk.find.hint()`"
+file: /reference/method/Bulk.find.hint
+description: "Specifies the index to use for the update/replace operation."
+---
 name: ":method:`Bulk.find.remove()`"
 file: /reference/method/Bulk.find.remove
 description: "Adds a multiple document remove operation to a list of operations."

--- a/source/includes/steps-install-mongodb-enterprise-on-debian.yaml
+++ b/source/includes/steps-install-mongodb-enterprise-on-debian.yaml
@@ -8,24 +8,50 @@ title: Create a ``/etc/apt/sources.list.d/mongodb-enterprise.list`` file for Mon
 stepnum: 2
 level: 4
 ref: sources-list
-action:
-  - pre: |
-      Create the list file using the command:
+content: |
 
-      Debian 9 "Stretch"
+  Create the list file using the command appropriate for your version
+  of Debian:
+
+  .. tabs::
+
+     .. tab:: Debian 10 "Buster"
+        :tabid: debian-10-buster
+
+        .. code-block:: sh
+
+           echo "deb http://repo.mongodb.com/apt/debian buster/mongodb-enterprise/{+package-branch+} main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+
+     .. tab:: Debian 9 "Stretch"
+        :tabid: debian-9-stretch
+
         .. code-block:: sh
 
            echo "deb http://repo.mongodb.com/apt/debian stretch/mongodb-enterprise/{+package-branch+} main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
-  - pre: |
-      If you'd like to install MongoDB Enterprise packages from a
-      particular :ref:`release series <release-version-numbers>` such as
-      4.0, you can specify the release series in the repository
-      configuration. For example, to restrict your system to the 4.0
-      release series, add the following repository:
-    language: sh
-    code: |
-      echo "deb http://repo.mongodb.com/apt/debian stretch/mongodb-enterprise/4.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise-4.0.list
 
+  If you'd like to install MongoDB Enterprise packages from a
+  particular :ref:`release series <release-version-numbers>`, you can
+  specify the release series of a version of MongoDB that is supported
+  for your Debian build in the repository configuration. For example,
+  to restrict your system to the 4.2 release series, add the following
+  repository:
+
+  .. tabs::
+     :hidden:
+     
+     .. tab:: Debian 10 "Buster"
+        :tabid: debian-10-buster
+
+        .. code-block:: sh
+
+           echo "deb http://repo.mongodb.com/apt/debian buster/mongodb-enterprise/4.2 main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise-4.2.list
+
+     .. tab:: Debian 9 "Stretch"
+        :tabid: debian-9-stretch
+
+        .. code-block:: sh
+
+           echo "deb http://repo.mongodb.com/apt/debian stretch/mongodb-enterprise/4.2 main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise-4.2.list
 ---
 stepnum: 3
 level: 4

--- a/source/includes/steps-install-mongodb-enterprise-on-ubuntu.yaml
+++ b/source/includes/steps-install-mongodb-enterprise-on-ubuntu.yaml
@@ -55,9 +55,6 @@ title: Install the MongoDB Enterprise packages.
 stepnum: 4
 level: 4
 ref: install
-# pre: |
-#   You can install either the latest stable version of MongoDB or a
-#   specific version of MongoDB.
 action:
   - heading:
       text: Install MongoDB Enterprise.

--- a/source/includes/steps-install-mongodb-on-debian.yaml
+++ b/source/includes/steps-install-mongodb-on-debian.yaml
@@ -8,15 +8,26 @@ title: Create a ``/etc/apt/sources.list.d/mongodb-org-{+version+}.list`` file fo
 stepnum: 2
 level: 4
 ref: sources-list
-action:
-  pre: |
-    Create the list file using the command appropriate for your version
-    of Debian:
+content: |
 
-    Debian 9 "Stretch"
-      .. code-block:: sh
+  Create the list file using the command appropriate for your version
+  of Debian:
 
-         echo "deb http://repo.mongodb.org/apt/debian stretch/mongodb-org/{+package-branch+} main" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+version+}.list
+  .. tabs::
+
+     .. tab:: Debian 10 "Buster"
+        :tabid: debian-10-buster
+
+        .. code-block:: sh
+
+           echo "deb http://repo.mongodb.com/apt/debian buster/mongodb-org/{+package-branch+} main" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+version+}.list
+
+     .. tab:: Debian 9 "Stretch"
+        :tabid: debian-9-stretch
+
+        .. code-block:: sh
+
+           echo "deb http://repo.mongodb.com/apt/debian stretch/mongodb-org/{+package-branch+} main" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+version+}.list
 ---
 stepnum: 3
 level: 4

--- a/source/includes/steps-install-mongodb-on-ubuntu.yaml
+++ b/source/includes/steps-install-mongodb-on-ubuntu.yaml
@@ -10,7 +10,13 @@ content: |
 
        wget -qO - https://www.mongodb.org/static/pgp/server-{+pgp-version+}.asc | sudo apt-key add -
 
-    The operation should respond with an ``OK``.
+    The operation should respond with an ``OK``. If you receive an
+    error indicating that ``gnupg`` is not installed, you can install
+    it and its required libraries using the following command:
+    
+    .. code-block:: sh
+
+       sudo apt-get install gnupg
 
 ---
 title: Create a list file for MongoDB.

--- a/source/reference/command/replSetGetStatus.txt
+++ b/source/reference/command/replSetGetStatus.txt
@@ -76,37 +76,58 @@ Example
 
              {
                 "set" : "replset",
-                "date" : ISODate("2019-06-28T03:53:23.465Z"),
+                "date" : ISODate("2019-10-14T15:09:28.182Z"),
                 "myState" : 1,
                 "term" : NumberLong(1),
                 "syncingTo" : "",
                 "syncSourceHost" : "",
                 "syncSourceId" : -1,
                 "heartbeatIntervalMillis" : NumberLong(2000),
+                "majorityVoteCount" : 2,
+                "writeMajorityCount" : 2,
                 "optimes" : {
                    "lastCommittedOpTime" : {
-                      "ts" : Timestamp(1561694000, 1),
+                      "ts" : Timestamp(1571065766, 1),
                       "t" : NumberLong(1)
                    },
-                   "lastCommittedWallTime" : ISODate("2019-06-28T03:53:20.341Z"),
+                   "lastCommittedWallTime" : ISODate("2019-10-14T15:09:26.120Z"),
                    "readConcernMajorityOpTime" : {
-                      "ts" : Timestamp(1561694000, 1),
+                      "ts" : Timestamp(1571065766, 1),
                       "t" : NumberLong(1)
                    },
-                   "readConcernMajorityWallTime" : ISODate("2019-06-28T03:53:20.341Z"),
+                   "readConcernMajorityWallTime" : ISODate("2019-10-14T15:09:26.120Z"),
                    "appliedOpTime" : {
-                      "ts" : Timestamp(1561694000, 1),
+                      "ts" : Timestamp(1571065766, 1),
                       "t" : NumberLong(1)
                    },
                    "durableOpTime" : {
-                      "ts" : Timestamp(1561694000, 1),
+                      "ts" : Timestamp(1571065766, 1),
                       "t" : NumberLong(1)
                    },
-                   "lastAppliedWallTime" : ISODate("2019-06-28T03:53:20.341Z"),
-                   "lastDurableWallTime" : ISODate("2019-06-28T03:53:20.341Z")
+                   "lastAppliedWallTime" : ISODate("2019-10-14T15:09:26.120Z"),
+                   "lastDurableWallTime" : ISODate("2019-10-14T15:09:26.120Z")
                 },
-                "lastStableRecoveryTimestamp" : Timestamp(1561693980, 1),
-                "lastStableCheckpointTimestamp" : Timestamp(1561693980, 1),
+                "lastStableRecoveryTimestamp" : Timestamp(1571065746, 2),
+                "lastStableCheckpointTimestamp" : Timestamp(1571065746, 2),
+                "electionCandidateMetrics" : {
+                   "lastElectionReason" : "electionTimeout",
+                   "lastElectionDate" : ISODate("2019-10-14T15:09:05.328Z"),
+                   "termAtElection" : NumberLong(1),
+                   "lastCommittedOpTimeAtElection" : {
+                      "ts" : Timestamp(0, 0),
+                      "t" : NumberLong(-1)
+                   },
+                   "lastSeenOpTimeAtElection" : {
+                      "ts" : Timestamp(1571065734, 1),
+                      "t" : NumberLong(-1)
+                   },
+                   "numVotesNeeded" : 2,
+                   "priorityAtElection" : 1,
+                   "electionTimeoutMillis" : NumberLong(10000),
+                   "numCatchUpOps" : NumberLong(0),
+                   "newTermStartDate" : ISODate("2019-10-14T15:09:06.115Z"),
+                   "wMajorityWriteAvailabilityDate" : ISODate("2019-10-14T15:09:07.333Z")
+                },
                 "members" : [
                    {
                       "_id" : 0,
@@ -115,18 +136,18 @@ Example
                       "health" : 1,
                       "state" : 1,
                       "stateStr" : "PRIMARY",
-                      "uptime" : 339,
+                      "uptime" : 417,
                       "optime" : {
-                         "ts" : Timestamp(1561694000, 1),
+                         "ts" : Timestamp(1571066144, 1),
                          "t" : NumberLong(1)
                       },
-                      "optimeDate" : ISODate("2019-06-28T03:53:20Z"),
+                      "optimeDate" : ISODate("2019-10-14T15:15:44Z"),
                       "syncingTo" : "",
                       "syncSourceHost" : "",
                       "syncSourceId" : -1,
                       "infoMessage" : "",
-                      "electionTime" : Timestamp(1561693678, 1),
-                      "electionDate" : ISODate("2019-06-28T03:47:58Z"),
+                      "electionTime" : Timestamp(1571065745, 1),
+                      "electionDate" : ISODate("2019-10-14T15:09:05Z"),
                       "configVersion" : 1,
                       "self" : true,
                       "lastHeartbeatMessage" : ""
@@ -138,19 +159,19 @@ Example
                       "health" : 1,
                       "state" : 2,
                       "stateStr" : "SECONDARY",
-                      "uptime" : 335,
+                      "uptime" : 414,
                       "optime" : {
-                         "ts" : Timestamp(1561694000, 1),
+                         "ts" : Timestamp(1571066144, 1),
                          "t" : NumberLong(1)
                       },
                       "optimeDurable" : {
-                         "ts" : Timestamp(1561694000, 1),
+                         "ts" : Timestamp(1571066144, 1),
                          "t" : NumberLong(1)
                       },
-                      "optimeDate" : ISODate("2019-06-28T03:53:20Z"),
-                      "optimeDurableDate" : ISODate("2019-06-28T03:53:20Z"),
-                      "lastHeartbeat" : ISODate("2019-06-28T03:53:23.270Z"),
-                      "lastHeartbeatRecv" : ISODate("2019-06-28T03:53:21.835Z"),
+                      "optimeDate" : ISODate("2019-10-14T15:15:44Z"),
+                      "optimeDurableDate" : ISODate("2019-10-14T15:15:44Z"),
+                      "lastHeartbeat" : ISODate("2019-10-14T15:15:47.723Z"),
+                      "lastHeartbeatRecv" : ISODate("2019-10-14T15:15:47.586Z"),
                       "pingMs" : NumberLong(0),
                       "lastHeartbeatMessage" : "",
                       "syncingTo" : "m1.example.net:27017",
@@ -166,19 +187,19 @@ Example
                       "health" : 1,
                       "state" : 2,
                       "stateStr" : "SECONDARY",
-                      "uptime" : 335,
+                      "uptime" : 414,
                       "optime" : {
-                         "ts" : Timestamp(1561694000, 1),
+                         "ts" : Timestamp(1571066144, 1),
                          "t" : NumberLong(1)
                       },
                       "optimeDurable" : {
-                         "ts" : Timestamp(1561694000, 1),
+                         "ts" : Timestamp(1571066144, 1),
                          "t" : NumberLong(1)
                       },
-                      "optimeDate" : ISODate("2019-06-28T03:53:20Z"),
-                      "optimeDurableDate" : ISODate("2019-06-28T03:53:20Z"),
-                      "lastHeartbeat" : ISODate("2019-06-28T03:53:23.270Z"),
-                      "lastHeartbeatRecv" : ISODate("2019-06-28T03:53:21.922Z"),
+                      "optimeDate" : ISODate("2019-10-14T15:15:44Z"),
+                      "optimeDurableDate" : ISODate("2019-10-14T15:15:44Z"),
+                      "lastHeartbeat" : ISODate("2019-10-14T15:15:47.723Z"),
+                      "lastHeartbeatRecv" : ISODate("2019-10-14T15:15:47.612"),
                       "pingMs" : NumberLong(0),
                       "lastHeartbeatMessage" : "",
                       "syncingTo" : "m1.example.net:27017",
@@ -190,28 +211,26 @@ Example
                 ],
                 "ok" : 1,
                 "$clusterTime" : {
-                   "clusterTime" : Timestamp(1561694000, 1),
+                   "clusterTime" : Timestamp(1571066144, 1),
                    "signature" : {
-                      "hash" : BinData(0,"viA0mQK29rc5KPjG2vgWw3CWoUg="),
-                      "keyId" : NumberLong("6707423281969889282")
+                      "hash" : BinData(0,"7KPhkSeNOAlrA081F16Xl30ljOU="),
+                      "keyId" : NumberLong("6747675998935842818")
                    }
                 },
-                "operationTime" : Timestamp(1561694000, 1)
+                "operationTime" : Timestamp(1571066144, 1)
              }
-
+             
       - id: secondary
         name: Secondary
         content: |
 
           The following example runs the :dbcommand:`replSetGetStatus`
           command on the :term:`admin database` of the replica set
-          primary. In this example, the optional ``initialSync: 1`` is
-          included in the command (you can omit if you do not want to
-          return the initial sync status):
+          secondary.
 
           .. code-block:: javascript
 
-             db.adminCommand( { replSetGetStatus : 1, initialSync: 1 } )
+             db.adminCommand( { replSetGetStatus : 1 } )
 
           The command returns the following output for an example replica set secondary:
 
@@ -219,75 +238,39 @@ Example
 
              {
                 "set" : "replset",
-                "date" : ISODate("2019-06-28T15:09:15.752Z"),
+                "date" : ISODate("2019-10-14T15:20:18.135Z"),
                 "myState" : 2,
                 "term" : NumberLong(1),
                 "syncingTo" : "m1.example.net:27017",
                 "syncSourceHost" : "m1.example.net:27017",
                 "syncSourceId" : 0,
                 "heartbeatIntervalMillis" : NumberLong(2000),
+                "majorityVoteCount" : 2,
+                "writeMajorityCount" : 2,
                 "optimes" : {
                    "lastCommittedOpTime" : {
-                      "ts" : Timestamp(1561734546, 1),
+                      "ts" : Timestamp(1571066416, 1),
                       "t" : NumberLong(1)
                    },
-                   "lastCommittedWallTime" : ISODate("2019-06-28T15:09:06.084Z"),
+                   "lastCommittedWallTime" : ISODate("2019-10-14T15:20:16.247Z"),
                    "readConcernMajorityOpTime" : {
-                      "ts" : Timestamp(1561734546, 1),
+                      "ts" : Timestamp(1571066416, 1),
                       "t" : NumberLong(1)
                    },
-                   "readConcernMajorityWallTime" : ISODate("2019-06-28T15:09:06.084Z"),
+                   "readConcernMajorityWallTime" : ISODate("2019-10-14T15:20:16.247Z"),
                    "appliedOpTime" : {
-                      "ts" : Timestamp(1561734546, 1),
+                      "ts" : Timestamp(1571066416, 1),
                       "t" : NumberLong(1)
                    },
                    "durableOpTime" : {
-                      "ts" : Timestamp(1561734546, 1),
+                      "ts" : Timestamp(1571066416, 1),
                       "t" : NumberLong(1)
                    },
-                   "lastAppliedWallTime" : ISODate("2019-06-28T15:09:06.084Z"),
-                   "lastDurableWallTime" : ISODate("2019-06-28T15:09:06.084Z")
+                   "lastAppliedWallTime" : ISODate("2019-10-14T15:20:16.247Z"),
+                   "lastDurableWallTime" : ISODate("2019-10-14T15:20:16.247Z")
                 },
-                "lastStableRecoveryTimestamp" : Timestamp(1561734518, 2),
-                "lastStableCheckpointTimestamp" : Timestamp(1561734518, 2),
-                "initialSyncStatus" : {
-                   "failedInitialSyncAttempts" : 0,
-                   "maxFailedInitialSyncAttempts" : 10,
-                   "initialSyncStart" : ISODate("2019-06-28T15:06:34.601Z"),
-                   "initialSyncEnd" : ISODate("2019-06-28T15:06:35.173Z"),
-                   "initialSyncElapsedMillis" : 572,
-                   "initialSyncAttempts" : [
-                      {
-                         "durationMillis" : 170,
-                         "status" : "OK",
-                         "syncSource" : m1.example.net:27017"
-                      }
-                   ],
-                   "fetchedMissingDocs" : 0,
-                   "appliedOps" : 0,
-                   "initialSyncOplogStart" : Timestamp(1561734392, 1),
-                   "initialSyncOplogEnd" : Timestamp(1561734392, 1),
-                   "databases" : {
-                      "databasesCloned" : 1,
-                      "admin" : {
-                         "collections" : 1,
-                         "clonedCollections" : 1,
-                         "start" : ISODate("2019-06-28T15:06:35.003Z"),
-                         "end" : ISODate("2019-06-28T15:06:35.168Z"),
-                         "elapsedMillis" : 165,
-                         "admin.system.version" : {
-                            "documentsToCopy" : 1,
-                            "documentsCopied" : 1,
-                            "indexes" : 1,
-                            "fetchedBatches" : 1,
-                            "start" : ISODate("2019-06-28T15:06:35.005Z"),
-                            "end" : ISODate("2019-06-28T15:06:35.168Z"),
-                            "elapsedMillis" : 163,
-                            "receivedBatches" : 1
-                         }
-                      }
-                   }
-                },
+                "lastStableRecoveryTimestamp" : Timestamp(1571066406, 1),
+                "lastStableCheckpointTimestamp" : Timestamp(1571066406, 1),
                 "members" : [
                    {
                       "_id" : 0,
@@ -296,27 +279,27 @@ Example
                       "health" : 1,
                       "state" : 1,
                       "stateStr" : "PRIMARY",
-                      "uptime" : 161,
+                      "uptime" : 683,
                       "optime" : {
-                         "ts" : Timestamp(1561734546, 1),
+                         "ts" : Timestamp(1571066416, 1),
                          "t" : NumberLong(1)
                       },
                       "optimeDurable" : {
-                         "ts" : Timestamp(1561734546, 1),
+                         "ts" : Timestamp(1571066416, 1),
                          "t" : NumberLong(1)
                       },
-                      "optimeDate" : ISODate("2019-06-28T15:09:06Z"),
-                      "optimeDurableDate" : ISODate("2019-06-28T15:09:06Z"),
-                      "lastHeartbeat" : ISODate("2019-06-28T15:09:15.497Z"),
-                      "lastHeartbeatRecv" : ISODate("2019-06-28T15:09:14.569Z"),
+                      "optimeDate" : ISODate("2019-10-14T15:20:16Z"),
+                      "optimeDurableDate" : ISODate("2019-10-14T15:20:16Z"),
+                      "lastHeartbeat" : ISODate("2019-10-14T15:20:17.875Z"),
+                      "lastHeartbeatRecv" : ISODate("2019-10-14T15:20:18.008Z"),
                       "pingMs" : NumberLong(0),
                       "lastHeartbeatMessage" : "",
                       "syncingTo" : "",
                       "syncSourceHost" : "",
                       "syncSourceId" : -1,
                       "infoMessage" : "",
-                      "electionTime" : Timestamp(1561734404, 1),
-                      "electionDate" : ISODate("2019-06-28T15:06:44Z"),
+                      "electionTime" : Timestamp(1571065745, 1),
+                      "electionDate" : ISODate("2019-10-14T15:09:05Z"),
                       "configVersion" : 1
                    },
                    {
@@ -326,12 +309,12 @@ Example
                       "health" : 1,
                       "state" : 2,
                       "stateStr" : "SECONDARY",
-                      "uptime" : 165,
+                      "uptime" : 687,
                       "optime" : {
-                         "ts" : Timestamp(1561734546, 1),
+                         "ts" : Timestamp(1571066416, 1),
                          "t" : NumberLong(1)
                       },
-                      "optimeDate" : ISODate("2019-06-28T15:09:06Z"),
+                      "optimeDate" : ISODate("2019-10-14T15:20:16Z"),
                       "syncingTo" : "m1.example.net:27017",
                       "syncSourceHost" : "m1.example.net:27017",
                       "syncSourceId" : 0,
@@ -347,19 +330,19 @@ Example
                       "health" : 1,
                       "state" : 2,
                       "stateStr" : "SECONDARY",
-                      "uptime" : 161,
+                      "uptime" : 683,
                       "optime" : {
-                         "ts" : Timestamp(1561734546, 1),
+                         "ts" : Timestamp(1571066416, 1),
                          "t" : NumberLong(1)
                       },
                       "optimeDurable" : {
-                         "ts" : Timestamp(1561734546, 1),
+                         "ts" : Timestamp(1571066416, 1),
                          "t" : NumberLong(1)
                       },
-                      "optimeDate" : ISODate("2019-06-28T15:09:06Z"),
-                      "optimeDurableDate" : ISODate("2019-06-28T15:09:06Z"),
-                      "lastHeartbeat" : ISODate("2019-06-28T15:09:15.497Z"),
-                      "lastHeartbeatRecv" : ISODate("2019-06-28T15:09:15.419Z"),
+                      "optimeDate" : ISODate("2019-10-14T15:20:16Z"),
+                      "optimeDurableDate" : ISODate("2019-10-14T15:20:16Z"),
+                      "lastHeartbeat" : ISODate("2019-10-14T15:20:17.875Z"),
+                      "lastHeartbeatRecv" : ISODate("2019-10-14T15:20:17.906Z"),
                       "pingMs" : NumberLong(0),
                       "lastHeartbeatMessage" : "",
                       "syncingTo" : "m1.example.net:27017",
@@ -371,13 +354,13 @@ Example
                 ],
                 "ok" : 1,
                 "$clusterTime" : {
-                   "clusterTime" : Timestamp(1561734546, 1),
+                   "clusterTime" : Timestamp(1571066416, 1),
                    "signature" : {
-                      "hash" : BinData(0,"zfGCL5xIqO1dzgE9NBeanPn73qY="),
-                      "keyId" : NumberLong("6707598198807986177")
+                      "hash" : BinData(0,"d1AJtiPijIVVTwzQDzHlNjlnCyM="),
+                      "keyId" : NumberLong("6747675998935842818")
                    }
                 },
-                "operationTime" : Timestamp(1561734546, 1)
+                "operationTime" : Timestamp(1571066416, 1)
              }
 
 Output
@@ -560,6 +543,102 @@ following fields:
    .. versionadded:: 4.2
 
    *For internal use only*
+
+.. data:: replSetGetStatus.electionCandidateMetrics
+
+   .. versionadded:: 4.2.1
+
+   Metrics related to the election of the current primary.
+   :data:`~replSetGetStatus.electionCandidateMetrics` is only available
+   on the primary or a candidate for election. For a candidate, the
+   metrics becomes unavailable once the candidate loses the election.
+
+   .. data:: replSetGetStatus.electionCandidateMetrics.lastElectionReason
+
+      .. versionadded:: 4.2.1
+
+      Reason the member called the election.
+
+   .. data:: replSetGetStatus.electionCandidateMetrics.lastElectionDate
+
+      .. versionadded:: 4.2.1
+
+      The date and time the member called the election.
+
+   .. data:: replSetGetStatus.electionCandidateMetrics.termAtElection
+
+      .. versionadded:: 4.2.1
+
+      The member's election count (i.e. :data:`~replSetGetStatus.term`)
+      at the time it called for the new election.
+
+   .. data:: replSetGetStatus.electionCandidateMetrics.lastCommittedOpTimeAtElection
+
+      .. versionadded:: 4.2.1
+
+      The most recent :data:`majority-committed optime
+      <replSetGetStatus.optimes.lastCommittedOpTime>`, as seen by this
+      member, at the time it called for the new election.
+
+   .. data:: replSetGetStatus.electionCandidateMetrics.lastSeenOpTimeAtElection
+
+      .. versionadded:: 4.2.1
+
+      The member's most recent :data:`applied optime
+      <replSetGetStatus.optimes.appliedOpTime>` at the time it called
+      for the new election.
+
+   .. data:: replSetGetStatus.electionCandidateMetrics.numVotesNeeded
+
+      .. versionadded:: 4.2.1
+
+      The number of votes needed to win the election.
+
+   .. data:: replSetGetStatus.electionCandidateMetrics.priorityAtElection
+
+      .. versionadded:: 4.2.1
+
+      The member's :rsconf:`priority <members[n].priority>` at the time
+      it called the election.
+      
+   .. data:: replSetGetStatus.electionCandidateMetrics.electionTimeoutMillis
+
+      .. versionadded:: 4.2.1
+
+      The replica set's configured
+      :rsconf:`~settings.electionTimeoutMillis` setting at the time of
+      the election.
+
+   .. data:: replSetGetStatus.electionCandidateMetrics.priorPrimaryMemberId
+
+      .. versionadded:: 4.2.1
+
+      The :rsconf:`members[n]._id` of the previous primary. If
+      there is no previous primary, then the field is not present.
+
+   .. data:: replSetGetStatus.electionCandidateMetrics.numCatchUpOps
+
+      .. versionadded:: 4.2.1
+
+      The number of operations applied by the newly-elected primary as
+      it successfully concludes its catchup process.
+
+   .. data:: replSetGetStatus.electionCandidateMetrics.newTermStartDate
+
+      .. versionadded:: 4.2.1
+
+      The date and time at which the member's term as the primary
+      started (i.e. the date and time at which a ``new term`` entry was
+      written to the oplog).
+
+   .. data:: replSetGetStatus.electionCandidateMetrics.wMajorityWriteAvailabilityDate
+
+      .. versionadded:: 4.2.1
+
+      The date and time at which the write concern
+      :writeconcern:`"majority"` became available after the election
+      for the replica set(i.e. the date and time at which the ``new
+      term`` oplog entry was majority committed).
 
 .. data:: replSetGetStatus.initialSyncStatus
 

--- a/source/reference/command/replSetGetStatus.txt
+++ b/source/reference/command/replSetGetStatus.txt
@@ -100,8 +100,8 @@ Example
                 "syncSourceHost" : "",
                 "syncSourceId" : -1,
                 "heartbeatIntervalMillis" : NumberLong(2000),
-                "majorityVoteCount" : 2,
-                "writeMajorityCount" : 2,
+                "majorityVoteCount" : 2,        // Available starting in 4.2.1
+                "writeMajorityCount" : 2,       // Available starting in 4.2.1
                 "optimes" : {
                    "lastCommittedOpTime" : {
                       "ts" : Timestamp(1571065766, 1),
@@ -262,8 +262,8 @@ Example
                 "syncSourceHost" : "m2.example.net:27017",
                 "syncSourceId" : 1,
                 "heartbeatIntervalMillis" : NumberLong(2000),
-                "majorityVoteCount" : 2,
-                "writeMajorityCount" : 2,
+                "majorityVoteCount" : 2,                // Available starting in 4.2.1
+                "writeMajorityCount" : 2,               // Available starting in 4.2.1
                 "optimes" : {
                    "lastCommittedOpTime" : {
                       "ts" : Timestamp(1571113692, 1),
@@ -719,6 +719,21 @@ following fields:
    .. versionadded:: 3.2
 
    The frequency in milliseconds of the heartbeats.
+
+.. data:: replSetGetStatus.majorityVoteCount
+
+   .. versionadded:: 4.2.1
+
+   The number that corresponds to the majority votes needed to elect a
+   new primary in an election.
+
+.. data:: replSetGetStatus.writeMajorityCount
+
+   .. versionadded:: 4.2.1
+
+   The number of data-bearing voting members (i.e. not arbiters) needed
+   to fulfill write concern :writeconcern:`"majority"`. Writes can only
+   be applied to data-bearing members.
 
 .. data:: replSetGetStatus.optimes
 

--- a/source/reference/command/replSetGetStatus.txt
+++ b/source/reference/command/replSetGetStatus.txt
@@ -22,6 +22,11 @@ Definition
    The :binary:`~bin.mongod` instance must be a replica set member for
    :dbcommand:`replSetGetStatus` to return successfully.
 
+   Data provided by this command derives from data included in
+   heartbeats sent to the server by other members of the replica set.
+   Because of the frequency of heartbeats, these data can be several
+   seconds out of date.
+
 Syntax
 ------
 
@@ -31,23 +36,34 @@ The command has the following syntax:
 
    db.adminCommand( { replSetGetStatus: 1 } )
 
-Starting in MongoDB 3.4, when running on a :doc:`secondary
-</core/replica-set-secondary>` member, you can optionally include
-``initialSync: 1`` to return :ref:`initial sync
-<replica-set-initial-sync>` status information:
+- Starting in MongoDB 4.2.1
+      If you run :dbcommand:`replSetGetStatus` or the
+      :binary:`~bin.mongo` shell helper :method:`rs.status()` on a
+      member during its :ref:`initial sync <replica-set-initial-sync>`
+      (i.e. :replstate:`STARTUP2` state), the command returns
+      :data:`replSetGetStatus.initialSyncStatus` metrics.
+      
+      Once the member finishes its initial sync and transitions to
+      another state, the :data:`replSetGetStatus.initialSyncStatus`
+      metrics are no longer available.
 
-.. code-block:: javascript
+- In earlier versions (3.4.x-4.2.0)
+      To return :ref:`initial sync <replica-set-initial-sync>` status
+      information, include ``initialSync: 1`` in the command on a
+      secondary member or a member in :replstate:`STARTUP2` state:
 
-   db.adminCommand( { replSetGetStatus: 1, initialSync: 1 } )
+      .. code-block:: javascript
 
-Data provided by this command derives from data included in
-heartbeats sent to the server by other members of the replica set.
-Because of the frequency of heartbeats, these data can be several
-seconds out of date.
+         db.adminCommand( { replSetGetStatus: 1, initialSync: 1 } )
 
-The :binary:`~bin.mongo` shell provides the :method:`rs.status()`
-helper; however, you cannot specify the ``initialSync: 1`` option
-using the helper.
+      The :data:`replSetGetStatus.initialSyncStatus` metrics remains
+      available after the member completes its initial sync. That is,
+      you can run the :dbcommand:`replSetGetStatus` command with the
+      ``initialSync: 1`` on the secondary member to return its initial
+      sync information.
+
+      You cannot specify ``initialSync: 1`` in the :binary:`~bin.mongo`
+      shell helper :method:`rs.status()`.
 
 .. _rs-status-output:
 
@@ -70,7 +86,8 @@ Example
 
              db.adminCommand( { replSetGetStatus : 1 } )
 
-          The command returns the following output for an example replica set primary:
+          The command returns the following output for an example
+          replica set primary:
 
           .. code-block:: javascript
 
@@ -219,7 +236,7 @@ Example
                 },
                 "operationTime" : Timestamp(1571066144, 1)
              }
-             
+
       - id: secondary
         name: Secondary
         content: |
@@ -238,36 +255,309 @@ Example
 
              {
                 "set" : "replset",
-                "date" : ISODate("2019-10-14T15:20:18.135Z"),
+                "date" : ISODate("2019-10-15T04:28:13.318Z"),
                 "myState" : 2,
                 "term" : NumberLong(1),
-                "syncingTo" : "m1.example.net:27017",
-                "syncSourceHost" : "m1.example.net:27017",
-                "syncSourceId" : 0,
+                "syncingTo" : "m2.example.net:27017",
+                "syncSourceHost" : "m2.example.net:27017",
+                "syncSourceId" : 1,
                 "heartbeatIntervalMillis" : NumberLong(2000),
                 "majorityVoteCount" : 2,
                 "writeMajorityCount" : 2,
                 "optimes" : {
                    "lastCommittedOpTime" : {
-                      "ts" : Timestamp(1571066416, 1),
+                      "ts" : Timestamp(1571113692, 1),
                       "t" : NumberLong(1)
                    },
-                   "lastCommittedWallTime" : ISODate("2019-10-14T15:20:16.247Z"),
+                   "lastCommittedWallTime" : ISODate("2019-10-15T04:28:12.660Z"),
                    "readConcernMajorityOpTime" : {
-                      "ts" : Timestamp(1571066416, 1),
+                      "ts" : Timestamp(1571113692, 1),
                       "t" : NumberLong(1)
                    },
-                   "readConcernMajorityWallTime" : ISODate("2019-10-14T15:20:16.247Z"),
+                   "readConcernMajorityWallTime" : ISODate("2019-10-15T04:28:12.660Z"),
                    "appliedOpTime" : {
-                      "ts" : Timestamp(1571066416, 1),
+                      "ts" : Timestamp(1571113692, 1),
                       "t" : NumberLong(1)
                    },
                    "durableOpTime" : {
-                      "ts" : Timestamp(1571066416, 1),
+                      "ts" : Timestamp(1571113692, 1),
                       "t" : NumberLong(1)
                    },
-                   "lastAppliedWallTime" : ISODate("2019-10-14T15:20:16.247Z"),
-                   "lastDurableWallTime" : ISODate("2019-10-14T15:20:16.247Z")
+                   "lastAppliedWallTime" : ISODate("2019-10-15T04:28:12.660Z"),
+                   "lastDurableWallTime" : ISODate("2019-10-15T04:28:12.660Z")
+                },
+                "lastStableRecoveryTimestamp" : Timestamp(1571113662, 1),
+                "lastStableCheckpointTimestamp" : Timestamp(1571113662, 1),
+                "members" : [
+                   {
+                      "_id" : 0,
+                      "name" : "m1.example.net:27017",
+                      "ip" : "198.51.100.1",
+                      "health" : 1,
+                      "state" : 1,
+                      "stateStr" : "PRIMARY",
+                      "uptime" : 178,
+                      "optime" : {
+                         "ts" : Timestamp(1571113682, 1),
+                         "t" : NumberLong(1)
+                      },
+                      "optimeDurable" : {
+                         "ts" : Timestamp(1571113682, 1),
+                         "t" : NumberLong(1)
+                      },
+                      "optimeDate" : ISODate("2019-10-15T04:28:02Z"),
+                      "optimeDurableDate" : ISODate("2019-10-15T04:28:02Z"),
+                      "lastHeartbeat" : ISODate("2019-10-15T04:28:11.857Z"),
+                      "lastHeartbeatRecv" : ISODate("2019-10-15T04:28:13.043Z"),
+                      "pingMs" : NumberLong(0),
+                      "lastHeartbeatMessage" : "",
+                      "syncingTo" : "",
+                      "syncSourceHost" : "",
+                      "syncSourceId" : -1,
+                      "infoMessage" : "",
+                      "electionTime" : Timestamp(1571113240, 1),
+                      "electionDate" : ISODate("2019-10-15T04:20:40Z"),
+                      "configVersion" : 2
+                   },
+                   {
+                      "_id" : 1,
+                      "name" : "m2.example.net:27017",
+                      "ip" : "198.51.100.2",
+                      "health" : 1,
+                      "state" : 2,
+                      "stateStr" : "SECONDARY",
+                      "uptime" : 178,
+                      "optime" : {
+                         "ts" : Timestamp(1571113682, 1),
+                         "t" : NumberLong(1)
+                      },
+                      "optimeDurable" : {
+                         "ts" : Timestamp(1571113682, 1),
+                         "t" : NumberLong(1)
+                      },
+                      "optimeDate" : ISODate("2019-10-15T04:28:02Z"),
+                      "optimeDurableDate" : ISODate("2019-10-15T04:28:02Z"),
+                      "lastHeartbeat" : ISODate("2019-10-15T04:28:11.857Z"),
+                      "lastHeartbeatRecv" : ISODate("2019-10-15T04:28:13.310Z"),
+                      "pingMs" : NumberLong(0),
+                      "lastHeartbeatMessage" : "",
+                      "syncingTo" : "m1.example.net:27017",
+                      "syncSourceHost" : "m1.example.net:27017",
+                      "syncSourceId" : 0,
+                      "infoMessage" : "",
+                      "configVersion" : 2
+                   },
+                   {
+                      "_id" : 2,
+                      "name" : "m3.example.net:27017",
+                      "ip" : "198.51.100.3",
+                      "health" : 1,
+                      "state" : 2,
+                      "stateStr" : "SECONDARY",
+                      "uptime" : 465,
+                      "optime" : {
+                         "ts" : Timestamp(1571113692, 1),
+                         "t" : NumberLong(1)
+                      },
+                      "optimeDate" : ISODate("2019-10-15T04:28:12Z"),
+                      "syncingTo" : "m2.example.net:27017",
+                      "syncSourceHost" : "m2.example.net:27017",
+                      "syncSourceId" : 1,
+                      "infoMessage" : "",
+                      "configVersion" : 2,
+                      "self" : true,
+                      "lastHeartbeatMessage" : ""
+                   }
+                ],
+                "ok" : 1,
+                "$clusterTime" : {
+                   "clusterTime" : Timestamp(1571113692, 1),
+                   "signature" : {
+                      "hash" : BinData(0,"YBSGbOPTeazPhppu6WnyVRZwYms="),
+                      "keyId" : NumberLong("6747879992702533634")
+                   }
+                },
+                "operationTime" : Timestamp(1571113692, 1)
+             }
+          
+          In earlier versions (3.4.x-4.2.0)
+             You can include the optional ``initialSync: 1`` to include
+             the :data:`replSetGetStatus.initialSyncStatus` in the
+             output (you can omit if you do not want to return the
+             initial sync status):
+      
+             .. code-block:: javascript
+
+                db.adminCommand( { replSetGetStatus : 1, initialSync: 1} )
+          
+      - id: startup2
+        name: Include Initial Sync Metrics
+        content: |
+
+          Starting in MongoDB 4.2.1, 
+             If you run :dbcommand:`replSetGetStatus` on a member
+             during its initial sync, the command returns
+             :data:`replSetGetStatus.initialSyncStatus` metrics.
+          
+             .. code-block:: javascript
+
+                db.adminCommand( { replSetGetStatus : 1} )
+             
+             Once the member finishes its initial sync and transitions to
+             another state,the :data:`replSetGetStatus.initialSyncStatus`
+             metrics is no longer available.
+
+          In earlier versions (3.4.x-4.2.0)
+             You can include the optional ``initialSync: 1`` to include
+             the :data:`replSetGetStatus.initialSyncStatus` in the
+             output (you can omit if you do not want to return the
+             initial sync status):
+      
+             .. code-block:: javascript
+
+                db.adminCommand( { replSetGetStatus : 1, initialSync: 1} )
+             
+             For 3.4.x-4.2.0 replica sets,
+             :data:`replSetGetStatus.initialSyncStatus` metrics remains
+             available after the member completes its initial sync.
+             That is, you can run the :dbcommand:`replSetGetStatus`
+             command with the ``initialSync: 1`` on the secondary
+             member to return its initial sync information.
+
+          The following example runs the :dbcommand:`replSetGetStatus`
+          command on the :term:`admin database` of the 4.2.1 replica
+          set member during its initial sync:
+
+          .. code-block:: javascript
+
+             {
+                "set" : "replset",
+                "date" : ISODate("2019-10-15T01:26:38.743Z"),
+                "myState" : 5,
+                "term" : NumberLong(1),
+                "syncingTo" : "m2.example.net:27017",
+                "syncSourceHost" : "m2.example.net:27017",
+                "syncSourceId" : 1,
+                "heartbeatIntervalMillis" : NumberLong(2000),
+                "majorityVoteCount" : 2,
+                "writeMajorityCount" : 2,
+                "optimes" : {
+                   "lastCommittedOpTime" : {
+                      "ts" : Timestamp(0, 0),
+                      "t" : NumberLong(-1)
+                   },
+                   "lastCommittedWallTime" : ISODate("1970-01-01T00:00:00Z"),
+                   "appliedOpTime" : {
+                      "ts" : Timestamp(0, 0),
+                      "t" : NumberLong(-1)
+                   },
+                   "durableOpTime" : {
+                      "ts" : Timestamp(0, 0),
+                      "t" : NumberLong(-1)
+                   },
+                   "lastAppliedWallTime" : ISODate("1970-01-01T00:00:00Z"),
+                   "lastDurableWallTime" : ISODate("1970-01-01T00:00:00Z")
+                },
+                "lastStableRecoveryTimestamp" : Timestamp(0, 0),
+                "lastStableCheckpointTimestamp" : Timestamp(0, 0),
+                "initialSyncStatus" : {
+                   "failedInitialSyncAttempts" : 0,
+                   "maxFailedInitialSyncAttempts" : 10,
+                   "initialSyncStart" : ISODate("2019-10-15T01:25:40.989Z"),
+                   "initialSyncAttempts" : [ ],
+                   "fetchedMissingDocs" : 0,
+                   "appliedOps" : 0,
+                   "initialSyncOplogStart" : Timestamp(1571102740, 1),
+                   "databases" : {
+                      "databasesCloned" : 2,
+                      "admin" : {
+                         "collections" : 4,
+                         "clonedCollections" : 4,
+                         "start" : ISODate("2019-10-15T01:25:41.154Z"),
+                         "end" : ISODate("2019-10-15T01:25:41.848Z"),
+                         "elapsedMillis" : 694,
+                         "admin.system.keys" : {
+                            "documentsToCopy" : 2,
+                            "documentsCopied" : 2,
+                            "indexes" : 1,
+                            "fetchedBatches" : 1,
+                            "start" : ISODate("2019-10-15T01:25:41.156Z"),
+                            "end" : ISODate("2019-10-15T01:25:41.275Z"),
+                            "elapsedMillis" : 119,
+                            "receivedBatches" : 1
+                         },
+                         "admin.system.version" : {
+                            "documentsToCopy" : 2,
+                            "documentsCopied" : 2,
+                            "indexes" : 1,
+                            "fetchedBatches" : 1,
+                            "start" : ISODate("2019-10-15T01:25:41.275Z"),
+                            "end" : ISODate("2019-10-15T01:25:41.382Z"),
+                            "elapsedMillis" : 107,
+                            "receivedBatches" : 1
+                         },
+                         "admin.system.users" : {
+                            "documentsToCopy" : 22,
+                            "documentsCopied" : 22,
+                            "indexes" : 2,
+                            "fetchedBatches" : 1,
+                            "start" : ISODate("2019-10-15T01:25:41.382Z"),
+                            "end" : ISODate("2019-10-15T01:25:41.609Z"),
+                            "elapsedMillis" : 227,
+                            "receivedBatches" : 1
+                         },
+                         "admin.system.roles" : {
+                            "documentsToCopy" : 12,
+                            "documentsCopied" : 12,
+                            "indexes" : 2,
+                            "fetchedBatches" : 1,
+                            "start" : ISODate("2019-10-15T01:25:41.609Z"),
+                            "end" : ISODate("2019-10-15T01:25:41.848Z"),
+                            "elapsedMillis" : 239,
+                            "receivedBatches" : 1
+                         }
+                      },
+                      "config" : {
+                         "collections" : 2,
+                         "clonedCollections" : 2,
+                         "start" : ISODate("2019-10-15T01:25:41.848Z"),
+                         "end" : ISODate("2019-10-15T01:25:42.243Z"),
+                         "elapsedMillis" : 395,
+                         "config.transactions" : {
+                            "documentsToCopy" : 0,
+                            "documentsCopied" : 0,
+                            "indexes" : 1,
+                            "fetchedBatches" : 0,
+                            "start" : ISODate("2019-10-15T01:25:41.849Z"),
+                            "end" : ISODate("2019-10-15T01:25:42.010Z"),
+                            "elapsedMillis" : 161,
+                            "receivedBatches" : 0
+                         },
+                         "config.system.sessions" : {
+                            "documentsToCopy" : 1,
+                            "documentsCopied" : 1,
+                            "indexes" : 2,
+                            "fetchedBatches" : 1,
+                            "start" : ISODate("2019-10-15T01:25:42.009Z"),
+                            "end" : ISODate("2019-10-15T01:25:42.243Z"),
+                            "elapsedMillis" : 234,
+                            "receivedBatches" : 1
+                         }
+                      },
+                      "test" : {
+                         "collections" : 1,
+                         "clonedCollections" : 0,
+                         "start" : ISODate("2019-10-15T01:25:42.243Z"),
+                         "test.hugeindex" : {
+                            "documentsToCopy" : 25000,
+                            "documentsCopied" : 22167,
+                            "indexes" : 2,
+                            "fetchedBatches" : 18,
+                            "start" : ISODate("2019-10-15T01:25:42.244Z"),
+                            "receivedBatches" : 19
+                         }
+                      }
+                   }
                 },
                 "lastStableRecoveryTimestamp" : Timestamp(1571066406, 1),
                 "lastStableCheckpointTimestamp" : Timestamp(1571066406, 1),
@@ -279,28 +569,28 @@ Example
                       "health" : 1,
                       "state" : 1,
                       "stateStr" : "PRIMARY",
-                      "uptime" : 683,
+                      "uptime" : 57,
                       "optime" : {
-                         "ts" : Timestamp(1571066416, 1),
+                         "ts" : Timestamp(1571102795, 1),
                          "t" : NumberLong(1)
                       },
                       "optimeDurable" : {
-                         "ts" : Timestamp(1571066416, 1),
+                         "ts" : Timestamp(1571102795, 1),
                          "t" : NumberLong(1)
                       },
-                      "optimeDate" : ISODate("2019-10-14T15:20:16Z"),
-                      "optimeDurableDate" : ISODate("2019-10-14T15:20:16Z"),
-                      "lastHeartbeat" : ISODate("2019-10-14T15:20:17.875Z"),
-                      "lastHeartbeatRecv" : ISODate("2019-10-14T15:20:18.008Z"),
+                      "optimeDate" : ISODate("2019-10-15T01:26:35Z"),
+                      "optimeDurableDate" : ISODate("2019-10-15T01:26:35Z"),
+                      "lastHeartbeat" : ISODate("2019-10-15T01:26:37.531Z"),
+                      "lastHeartbeatRecv" : ISODate("2019-10-15T01:26:38.697Z"),
                       "pingMs" : NumberLong(0),
                       "lastHeartbeatMessage" : "",
                       "syncingTo" : "",
                       "syncSourceHost" : "",
                       "syncSourceId" : -1,
                       "infoMessage" : "",
-                      "electionTime" : Timestamp(1571065745, 1),
-                      "electionDate" : ISODate("2019-10-14T15:09:05Z"),
-                      "configVersion" : 1
+                      "electionTime" : Timestamp(1571101495, 1),
+                      "electionDate" : ISODate("2019-10-15T01:04:55Z"),
+                      "configVersion" : 2
                    },
                    {
                       "_id" : 1,
@@ -309,58 +599,50 @@ Example
                       "health" : 1,
                       "state" : 2,
                       "stateStr" : "SECONDARY",
-                      "uptime" : 687,
+                      "uptime" : 57,
                       "optime" : {
-                         "ts" : Timestamp(1571066416, 1),
-                         "t" : NumberLong(1)
-                      },
-                      "optimeDate" : ISODate("2019-10-14T15:20:16Z"),
-                      "syncingTo" : "m1.example.net:27017",
-                      "syncSourceHost" : "m1.example.net:27017",
-                      "syncSourceId" : 0,
-                      "infoMessage" : "",
-                      "configVersion" : 1,
-                      "self" : true,
-                      "lastHeartbeatMessage" : ""
-                   },
-                   {
-                      "_id" : 2,
-                      "name" : "m3.example.net:27017",
-                      "ip" : "198.51.100.3",
-                      "health" : 1,
-                      "state" : 2,
-                      "stateStr" : "SECONDARY",
-                      "uptime" : 683,
-                      "optime" : {
-                         "ts" : Timestamp(1571066416, 1),
+                         "ts" : Timestamp(1571102795, 1),
                          "t" : NumberLong(1)
                       },
                       "optimeDurable" : {
-                         "ts" : Timestamp(1571066416, 1),
+                         "ts" : Timestamp(1571102795, 1),
                          "t" : NumberLong(1)
                       },
-                      "optimeDate" : ISODate("2019-10-14T15:20:16Z"),
-                      "optimeDurableDate" : ISODate("2019-10-14T15:20:16Z"),
-                      "lastHeartbeat" : ISODate("2019-10-14T15:20:17.875Z"),
-                      "lastHeartbeatRecv" : ISODate("2019-10-14T15:20:17.906Z"),
+                      "optimeDate" : ISODate("2019-10-15T01:26:35Z"),
+                      "optimeDurableDate" : ISODate("2019-10-15T01:26:35Z"),
+                      "lastHeartbeat" : ISODate("2019-10-15T01:26:37.531Z"),
+                      "lastHeartbeatRecv" : ISODate("2019-10-15T01:26:36.981Z"),
                       "pingMs" : NumberLong(0),
                       "lastHeartbeatMessage" : "",
                       "syncingTo" : "m1.example.net:27017",
                       "syncSourceHost" : "m1.example.net:27017",
                       "syncSourceId" : 0,
                       "infoMessage" : "",
-                      "configVersion" : 1
+                      "configVersion" : 2
+                   },
+                   {
+                      "_id" : 2,
+                      "name" : "m3.example.net:27017",
+                      "ip" : "198.51.100.3",
+                      "health" : 1,
+                      "state" : 5,
+                      "stateStr" : "STARTUP2",
+                      "uptime" : 1316,
+                      "optime" : {
+                         "ts" : Timestamp(0, 0),
+                         "t" : NumberLong(-1)
+                      },
+                      "optimeDate" : ISODate("1970-01-01T00:00:00Z"),
+                      "syncingTo" : "m2.example.net:27017",
+                      "syncSourceHost" : "m2.example.net:27017",
+                      "syncSourceId" : 1,
+                      "infoMessage" : "",
+                      "configVersion" : 2,
+                      "self" : true,
+                      "lastHeartbeatMessage" : ""
                    }
                 ],
-                "ok" : 1,
-                "$clusterTime" : {
-                   "clusterTime" : Timestamp(1571066416, 1),
-                   "signature" : {
-                      "hash" : BinData(0,"d1AJtiPijIVVTwzQDzHlNjlnCyM="),
-                      "keyId" : NumberLong("6747675998935842818")
-                   }
-                },
-                "operationTime" : Timestamp(1571066416, 1)
+                "ok" : 1
              }
 
 Output
@@ -644,77 +926,62 @@ following fields:
 
    .. versionadded:: 3.4
 
-      *Available only if the command is run with the initialSync: 1
-      option on a secondary*
-
    A document provides information on the progress and status of
-   :ref:`initial sync <replica-set-initial-sync>` on this secondary.
+   :ref:`initial sync <replica-set-initial-sync>` on this member.
 
-   .. note::
-
-      Some fields that relate to the progress of an on-going initial
-      sync only appear while the initial sync is in progress and do not
-      appear once the initial sync completes.
+   .. include:: /includes/fact-rs-status-init-sync-availability.rst
 
    .. data:: replSetGetStatus.initialSyncStatus.failedInitialSyncAttempts
 
       .. versionadded:: 3.4
 
-         *Available only if the command is run with the initialSync: 1
-         option on a secondary*
-
       The number of times the :ref:`initial sync
       <replica-set-initial-sync>` failed and had to restart on this
-      secondary.
+      member.
+
+      .. include:: /includes/fact-rs-status-init-sync-availability.rst
 
    .. data:: replSetGetStatus.initialSyncStatus.maxFailedInitialSyncAttempts
 
       .. versionadded:: 3.4
 
-         *Available only if the command is run with the initialSync: 1
-         option on a secondary*
+      The maximum number of times the :ref:`initial sync
+      <replica-set-initial-sync>` can restart on this member before
+      the member shuts down.
 
-         The maximum number of times the :ref:`initial sync
-         <replica-set-initial-sync>` can restart on this secondary
-         before the member shuts down.
+      .. include:: /includes/fact-rs-status-init-sync-availability.rst
 
    .. data:: replSetGetStatus.initialSyncStatus.initialSyncStart
 
       .. versionadded:: 3.4
 
-         *Available only if the command is run with the initialSync: 1
-         option on a secondary*
-
       The start timestamp of the :ref:`initial sync
-      <replica-set-initial-sync>` for this secondary.
+      <replica-set-initial-sync>` for this member.
+
+      .. include:: /includes/fact-rs-status-init-sync-availability.rst
 
    .. data:: replSetGetStatus.initialSyncStatus.initialSyncEnd
 
       .. versionadded:: 3.4
 
-         *Available only if the command is run with the initialSync: 1
-         option on a secondary*
-
       The end timestamp of the :ref:`initial sync
-      <replica-set-initial-sync>` for this secondary.
+      <replica-set-initial-sync>` for this member.
+
+      .. include:: /includes/fact-rs-status-init-sync-availability.rst
 
    .. data:: replSetGetStatus.initialSyncStatus.initialSyncElapsedMillis
 
       .. versionadded:: 3.4
 
-         *Available only if the command is run with the initialSync: 1
-         option on a secondary*
+      The number of milliseconds between
+      :data:`~replSetGetStatus.initialSyncStatus.initialSyncStart` and
+      :data:`~replSetGetStatus.initialSyncStatus.initialSyncEnd`.
 
-         The number of milliseconds between
-         :data:`~replSetGetStatus.initialSyncStatus.initialSyncStart`
-         and :data:`~replSetGetStatus.initialSyncStatus.initialSyncEnd`.
+      .. include:: /includes/fact-rs-status-init-sync-availability.rst
 
    .. data:: replSetGetStatus.initialSyncStatus.initialSyncAttempts
 
       .. versionadded:: 3.4
-
-         *Available only if the command is run with the initialSync: 1
-         option on a secondary*
 
       Array of documents where each document corresponds to a single
       :ref:`initial sync <replica-set-initial-sync>` attempt. See also
@@ -727,98 +994,92 @@ following fields:
          {
             "durationMillis" : <duration in milliseconds>,
             "status" : <exit status>,
-            "syncSource" : <source node from which this secondary performs initial sync>
+            "syncSource" : <source node from which this member performs initial sync>
          }
+
+      .. include:: /includes/fact-rs-status-init-sync-availability.rst
 
    .. data:: replSetGetStatus.initialSyncStatus.fetchedMissingDocs
 
       .. versionadded:: 3.4
-
-         *Available only if the command is run with the initialSync: 1
-         option on a secondary*
 
       The number of missing (i.e. uncloned) documents that were fetched
       from the sync source in order to apply to those documents the
       updates that occurred after the :ref:`initial sync
       <replica-set-initial-sync>` started.
 
-      As part of the initial sync process, the secondary uses the oplog
+      As part of the initial sync process, the member uses the oplog
       to update its data set to reflect the current state of the
       replica set.
+
+      .. include:: /includes/fact-rs-status-init-sync-availability.rst
 
    .. data:: replSetGetStatus.initialSyncStatus.appliedOps
 
       .. versionadded:: 3.4
 
-         *Available only if the command is run with the initialSync: 1
-         option on a secondary*
-
       The number of ops that occurred after the :ref:`initial sync
       <replica-set-initial-sync>` started and were applied after cloning
       the databases.
 
-      As part of the initial sync process, the secondary uses the oplog
+      As part of the initial sync process, the member uses the oplog
       to update its data set to reflect the current state of the
       replica set.
-   
+
+      .. include:: /includes/fact-rs-status-init-sync-availability.rst
+
    .. data:: replSetGetStatus.initialSyncStatus.initialSyncOplogStart
 
       .. versionadded:: 3.4
 
-         *Available only if the command is run with the initialSync: 1
-         option on a secondary*
-
       The start timestamp of the oplog application stage of the
       :ref:`initial sync <replica-set-initial-sync>` where the
-      secondary applies changes that occurred after the initial sync
+      member applies changes that occurred after the initial sync
       start.
 
-      As part of the initial sync process, the secondary uses the oplog
+      As part of the initial sync process, the member uses the oplog
       to update its data set to reflect the current state of the
       replica set.
+
+      .. include:: /includes/fact-rs-status-init-sync-availability.rst
    
    .. data:: replSetGetStatus.initialSyncStatus.initialSyncOplogEnd 
 
       .. versionadded:: 3.4
 
-         *Available only if the command is run with the initialSync: 1
-         option on a secondary*
 
       The end timestamp of the oplog application stage of the
       :ref:`initial sync <replica-set-initial-sync>` where the
-      secondary applies changes that occurred after the initial sync
+      member applies changes that occurred after the initial sync
       start.
 
-      As part of the initial sync process, the secondary uses the oplog
+      As part of the initial sync process, the member uses the oplog
       to update its data set to reflect the current state of the
       replica set.
+
+      .. include:: /includes/fact-rs-status-init-sync-availability.rst
 
    .. data:: replSetGetStatus.initialSyncStatus.databases
 
       .. versionadded:: 3.4
 
-         *Available only if the command is run with the initialSync: 1
-         option on a secondary*
-
       Detail on the databases cloned during :ref:`initial sync
       <replica-set-initial-sync>`.
+
+      .. include:: /includes/fact-rs-status-init-sync-availability.rst
 
    .. data:: replSetGetStatus.initialSyncStatus.databases.databasesCloned
 
       .. versionadded:: 3.4
 
-         *Available only if the command is run with the initialSync: 1
-         option on a secondary*
-
       Number of databases cloned during :ref:`initial sync
       <replica-set-initial-sync>`.
+
+      .. include:: /includes/fact-rs-status-init-sync-availability.rst
 
    .. data:: replSetGetStatus.initialSyncStatus.databases.<dbname>
 
       .. versionadded:: 3.4
-
-         *Available only if the command is run with the initialSync: 1
-         option on a secondary*
 
       For each database, a document that returns information regarding
       the progress of the cloning of that database.
@@ -842,6 +1103,9 @@ following fields:
                "receivedBatches" : <number of batches of documents received to date>  // Added in 4.2
             }
          }
+
+      .. include:: /includes/fact-rs-status-init-sync-availability.rst
+
 
 .. data:: replSetGetStatus.members
 

--- a/source/reference/command/serverStatus.txt
+++ b/source/reference/command/serverStatus.txt
@@ -2912,11 +2912,19 @@ metrics
 
    .. versionadded:: 3.0
 
-   A document that reports on the use of database
-   commands. The fields in :serverstatus:`metrics.commands` are
-   the names of :doc:`database commands </reference/command>` and each
-   value is a document that reports the total number of commands
-   executed as well as the number of failed executions.
+   A document that reports on the use of database commands. The fields
+   in :serverstatus:`metrics.commands` are the names of :doc:`database
+   commands </reference/command>`. For each command, the
+   :dbcommand:`serverStatus` reports the total number of executions and
+   the number of failed executions.
+   
+   Starting in MongoDB 4.0.13 and 4.2.1,
+   :serverstatus:`metrics.commands` include
+   ``replSetStepDownWithForce`` (i.e. the :dbcommand:`replSetStepDown`
+   command with ``force: true``) as well as the overall
+   ``replSetStepDown``. In earlier versions, the command
+   reported only overall ``replSetStepDown`` metrics.
+
 
 .. serverstatus:: metrics.commands.<command>.failed
 

--- a/source/reference/command/serverStatus.txt
+++ b/source/reference/command/serverStatus.txt
@@ -63,6 +63,8 @@ all :ref:`server-status-repl` information in the output:
 
    db.runCommand( { serverStatus: 1,  repl: 1 } )
 
+.. _server-status-output:
+
 Output
 ------
 
@@ -248,6 +250,187 @@ connections
    operations in progress.
 
    .. versionadded:: 4.0.7
+
+.. _server-status-electionMetrics:
+
+electionMetrics
+~~~~~~~~~~~~~~~
+
+*Available starting in 4.2.1 (and 4.0.13)*
+
+The ``electionMetrics`` section provides information on elections
+called by this :binary:`~bin.mongod` instance in a bid to become the
+primary:
+
+.. code-block:: javascript
+
+   "electionMetrics" : {
+      "stepUpCmd" : {
+         "called" : <NumberLong>,
+         "successful" : <NumberLong>
+      },
+      "priorityTakeover" : {
+         "called" : <NumberLong>,
+         "successful" : <NumberLong>
+      },
+      "catchUpTakeover" : {
+         "called" : <NumberLong>,
+         "successful" : <NumberLong>
+      },
+      "electionTimeout" : {
+         "called" : <NumberLong>,
+         "successful" : <NumberLong>
+      },
+      "freezeTimeout" : {
+         "called" : <NumberLong>,
+         "successful" : <NumberLong>
+      },
+      "numStepDownsCausedByHigherTerm" : <NumberLong>,
+      "numCatchUps" : <NumberLong>,
+      "numCatchUpsSucceeded" : <NumberLong>,
+      "numCatchUpsAlreadyCaughtUp" : <NumberLong>,
+      "numCatchUpsSkipped" : <NumberLong>,
+      "numCatchUpsTimedOut" : <NumberLong>,
+      "numCatchUpsFailedWithError" :<NumberLong>,
+      "numCatchUpsFailedWithNewTerm" : <NumberLong>,
+      "numCatchUpsFailedWithReplSetAbortPrimaryCatchUpCmd" : <NumberLong>,
+      "averageCatchUpOps" : <double>
+   }
+
+.. serverstatus:: electionMetrics.stepUpCmd
+
+   Metrics on elections that were called by the :binary:`~bin.mongod`
+   instance as part of an :parameter:`election handoff
+   <enableElectionHandoff>` when the primary stepped down.
+
+   The :serverstatus:`~electionMetrics.stepUpCmd` includes both the number of elections
+   called and the number of elections that succeeded.
+
+   *Available starting in 4.2.1 (and 4.0.13)*
+
+.. serverstatus:: electionMetrics.priorityTakeover
+
+   Metrics on elections that were called by the :binary:`~bin.mongod`
+   instance because its :rsconf:`~members.[n].priority` is higher
+   than the primary's.
+
+   The :serverstatus:`electionMetrics.priorityTakeover` includes both the number of
+   elections called and the number of elections that succeeded.
+
+   *Available starting in 4.2.1 (and 4.0.13)*
+
+.. serverstatus:: electionMetrics.catchUpTakeover
+
+   Metrics on elections called by the :binary:`~bin.mongod` instance
+   because it is more-up-to-date than the primary.
+
+   The :serverstatus:`~electionMetrics.catchUpTakeover` includes both the number of
+   elections called and the number of elections that succeeded.
+
+   .. seealso:: :rsconf:`settings.catchUpTakeoverDelayMillis`
+
+   *Available starting in 4.2.1 (and 4.0.13)*
+
+.. serverstatus:: electionMetrics.electionTimeout
+
+   Metrics on elections called by the :binary:`~bin.mongod` instance
+   because it has not been able to reach the primary within
+   :rsconf:`settings.electionTimeoutMillis`.
+   
+   The :serverstatus:`~electionMetrics.electionTimeout` includes both the number of
+   elections called and the number of elections that succeeded.
+   
+   .. seealso:: :rsconf:`settings.electionTimeoutMillis`
+
+   *Available starting in 4.2.1 (and 4.0.13)*
+
+.. serverstatus:: electionMetrics.freezeTimeout
+
+   Metrics on elections called by the :binary:`~bin.mongod` instance
+   after its :dbcommand:`freeze period <replSetFreeze>` (during which the
+   member cannot seek an election) has expired.
+   
+   The :serverstatus:`electionMetrics.freezeTimeout` includes both the number of
+   elections called and the number of elections that succeeded.
+
+   *Available starting in 4.2.1 (and 4.0.13)*
+
+.. serverstatus:: electionMetrics.numStepDownsCausedByHigherTerm
+
+   Number of times the :binary:`~bin.mongod` instance stepped down
+   because it saw a higher term (i.e. other member/members have
+   participated in additional elections).
+
+   *Available starting in 4.2.1 (and 4.0.13)*
+
+.. serverstatus:: electionMetrics.numCatchUps
+
+   Number of elections where the :binary:`~bin.mongod` instance as the
+   newly-elected primary had to catch up to the highest known oplog
+   entry.
+
+   *Available starting in 4.2.1 (and 4.0.13)*
+
+.. serverstatus:: electionMetrics.numCatchUpsSucceeded
+
+   Number of times the :binary:`~bin.mongod` instance as the
+   newly-elected primary successfully caught up to the highest known
+   oplog entry.
+
+   *Available starting in 4.2.1 (and 4.0.13)*
+
+.. serverstatus:: electionMetrics.numCatchUpsAlreadyCaughtUp
+
+   Number of times the :binary:`~bin.mongod` instance as the
+   newly-elected primary concluded its catchup process because it was
+   already caught up when elected
+
+   *Available starting in 4.2.1 (and 4.0.13)*
+
+.. serverstatus:: electionMetrics.numCatchUpsSkipped
+
+   Number of times the :binary:`~bin.mongod` instance as the
+   newly-elected primary skipped the catchup process.
+
+   *Available starting in 4.2.1 (and 4.0.13)*
+
+.. serverstatus:: electionMetrics.numCatchUpsTimedOut
+
+   Number of times the :binary:`~bin.mongod` instance as the
+   newly-elected primary concluded its catchup process because of the
+   :rsconf:`settings.catchUpTimeoutMillis` limit.
+
+   *Available starting in 4.2.1 (and 4.0.13)*
+
+.. serverstatus:: electionMetrics.numCatchUpsFailedWithError
+
+   Number of times the newly-elected primary's catchup process failed
+   with an error.
+
+   *Available starting in 4.2.1 (and 4.0.13)*
+
+.. serverstatus:: electionMetrics.numCatchUpsFailedWithNewTerm
+
+   Number of times the newly-elected primary's catchup process
+   concluded because another member(s) had a higher term (i.e. other
+   member/members have participated in additional elections).
+
+   *Available starting in 4.2.1 (and 4.0.13)*
+
+.. serverstatus:: electionMetrics.numCatchUpsFailedWithReplSetAbortPrimaryCatchUpCmd
+
+   Number of times the newly-elected primary's catchup process
+   concluded because the :binary:`~bin.mongod` received the
+   :dbcommand:`replSetAbortPrimaryCatchUp` command.
+
+   *Available starting in 4.2.1 (and 4.0.13)*
+
+.. serverstatus:: electionMetrics.averageCatchUpOps
+
+   Average number of operations applied during the newly-elected
+   primary's catchup processes.
+
+   *Available starting in 4.2.1*
 
 .. _server-status-extra-info:
 .. _server-status-extra_info:

--- a/source/reference/method/Bulk.find.hint.txt
+++ b/source/reference/method/Bulk.find.hint.txt
@@ -1,0 +1,88 @@
+==================
+Bulk.find.hint()
+==================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+.. include:: /includes/fact-bulkwrite.rst
+
+Description
+-----------
+
+.. method:: Bulk.find.hint()
+
+   .. versionadded:: 4.2.1
+
+   Sets the ``hint`` option that specifies the :doc:`index </indexes>`
+   to support the :method:`Bulk.find()` for:
+
+   - :method:`Bulk.find.replaceOne()`
+
+   - :method:`Bulk.find.update()`
+
+   - :method:`Bulk.find.updateOne()`.
+
+   The option can take an index specification document or the index
+   name string.
+
+   If you specify an index that does not exist, the operation
+   errors.
+
+   :method:`Bulk.find.hint()` has no effect on :method:`Bulk.find.removeOne()`
+
+Example
+--------
+
+Create an example collection ``orders``:
+
+.. code-block:: javascript
+
+   db.orders.insert([
+      { "_id" : 1, "item" : "abc", "price" : NumberDecimal("12"), "quantity" : 2, "type": "apparel" },
+      { "_id" : 2, "item" : "jkl", "price" : NumberDecimal("20"), "quantity" : 1, "type": "electronics" },
+      { "_id" : 3, "item" : "abc", "price" : NumberDecimal("10"), "quantity" : 5, "type": "apparel" },
+      { "_id" : 4, "item" : "abc", "price" : NumberDecimal("8"), "quantity" : 10, "type": "apparel" },
+      { "_id" : 5, "item" : "jkl", "price" : NumberDecimal("15"), "quantity" : 15, "type": "electronics" }
+   ])
+
+Create the following indexes on the example collection:
+
+.. code-block:: javascript
+
+   db.orders.createIndex( { item: 1 } );
+   db.orders.createIndex( { item: 1, quantity: 1 } );
+   db.orders.createIndex( { item: 1, price: 1 } );
+
+The following bulk operations specify different index to use for the
+various update/replace document operations:
+
+.. code-block:: javascript
+
+   var bulk = db.orders.initializeUnorderedBulkOp();
+   bulk.find({ item: "abc", price: { $gte: NumberDecimal("10") }, quantity: { $lte: 10 } }).hint({item: 1, quantity: 1}).replaceOne( { item: "abc123", status: "P", points: 100 } );
+   bulk.find({ item: "abc", price: { $gte: NumberDecimal("10") }, quantity: { $lte: 10 } }).hint({item: 1, price: 1}).updateOne( { $inc: { points: 10 } } );
+   bulk.execute();
+
+To view the indexes used, you can use the :pipeline:`$indexStats` pipeline:
+
+.. code-block:: javascript
+
+   db.orders.aggregate( [ { $indexStats: { } }, { $sort: { name: 1 } } ] )
+
+.. seealso::
+
+   - :method:`db.collection.initializeUnorderedBulkOp()`
+
+   - :method:`db.collection.initializeOrderedBulkOp()`
+
+   - :method:`Bulk.find()`
+
+   - :method:`Bulk.execute()`
+
+   - :ref:`All Bulk Methods <bulk-methods>`

--- a/source/reference/method/Bulk.find.replaceOne.txt
+++ b/source/reference/method/Bulk.find.replaceOne.txt
@@ -56,6 +56,9 @@ Description
 
    To specify an :term:`upsert` for this operation, see
    :method:`Bulk.find.upsert()`.
+   
+   To specify the index to use for the associated
+   :method:`Bulk.find()`, see :method:`Bulk.find.hint()`.
 
 Example
 -------

--- a/source/reference/method/Bulk.find.update.txt
+++ b/source/reference/method/Bulk.find.update.txt
@@ -77,6 +77,9 @@ Description
    - To specify :ref:`3.6-arrayFilters` to specify which array elements
      to update, use with :method:`Bulk.find.arrayFilters()`.
 
+   - To specify the index to use for the associated
+     :method:`Bulk.find()`, see :method:`Bulk.find.hint()`.
+
    - To replace a document wholesale, see
      :method:`Bulk.find.replaceOne()`.
 

--- a/source/reference/method/Bulk.find.updateOne.txt
+++ b/source/reference/method/Bulk.find.updateOne.txt
@@ -74,6 +74,9 @@ Description
    - To specify :ref:`3.6-arrayFilters` to specify which array elements
      to update, use with :method:`Bulk.find.arrayFilters()`.
 
+   - To specify the index to use for the associated
+     :method:`Bulk.find()`, see :method:`Bulk.find.hint()`.
+
    - To replace a document wholesale, see
      :method:`Bulk.find.replaceOne()`.
 

--- a/source/reference/method/db.collection.bulkWrite.txt
+++ b/source/reference/method/db.collection.bulkWrite.txt
@@ -24,7 +24,7 @@ Definition
    Performs multiple write operations with controls for order of 
    execution.
    
-   :method:`~db.collection.bulkWrite()` has the following syntax:
+   :method:`db.collection.bulkWrite()` has the following syntax:
    
    .. code-block:: javascript
    

--- a/source/reference/method/db.collection.bulkWrite.txt
+++ b/source/reference/method/db.collection.bulkWrite.txt
@@ -56,21 +56,23 @@ Definition
           
           Valid operations are:
           
-          - :ref:`insertOne <bulkwrite-write-operations-insertOne>`
+          .. hlist::
+             :columns: 2
           
-          - :ref:`updateOne <bulkwrite-write-operations-updateOneMany>`
+             - :ref:`insertOne <bulkwrite-write-operations-insertOne>`
           
-          - :ref:`updateMany <bulkwrite-write-operations-updateOneMany>`
+             - :ref:`updateOne <bulkwrite-write-operations-updateOneMany>`
           
-          - :ref:`deleteOne <bulkwrite-write-operations-deleteOneMany>`
+             - :ref:`updateMany <bulkwrite-write-operations-updateOneMany>`
           
-          - :ref:`deleteMany <bulkwrite-write-operations-deleteOneMany>`
+             - :ref:`deleteOne <bulkwrite-write-operations-deleteOneMany>`
           
-          - :ref:`replaceOne <bulkwrite-write-operations-replaceOne>`
+             - :ref:`deleteMany <bulkwrite-write-operations-deleteOneMany>`
+          
+             - :ref:`replaceOne <bulkwrite-write-operations-replaceOne>`
           
           See :ref:`bulkwrite-write-operations` for usage of each operation.
-          
-          
+ 
    
       * - ``writeConcern``
    
@@ -126,85 +128,128 @@ insertOne
 
 Inserts a single document into the collection.
 
-See :method:`db.collection.insertOne()`.
-
 .. code-block:: javascript
 
    db.collection.bulkWrite( [
       { insertOne : { "document" : <document> } }
    ] )
 
+See :method:`db.collection.insertOne()`.
+
 .. _bulkwrite-write-operations-updateOneMany:
 
 updateOne and updateMany
 ++++++++++++++++++++++++
-
-``updateOne`` updates a *single* document in the collection that matches the 
-filter. If multiple documents match, ``updateOne`` will update the *first* 
-matching document only. See :method:`db.collection.updateOne()`.
  
-.. code-block:: javascript
+.. tabs::
 
-   db.collection.bulkWrite( [
-      { updateOne : 
-         { 
-            "filter" : <document>, 
-            "update" : <document or pipeline>,          // Changed in MongoDB 4.2
-            "upsert" : <boolean>,
-            "collation": <document>,                    // Available starting in 3.4
-            "arrayFilters": [ <filterdocument1>, ... ]  // Available starting in 3.6
-         } 
-      } 
-   ] )
+   tabs:
 
-``updateMany`` updates *all* documents in the collection that match the 
-filter. See :method:`db.collection.updateMany()`.
+      - id: updateOne
+        name: updateOne
+        content: |
 
-.. code-block:: javascript
+           ``updateOne`` updates a *single* document in the collection that matches the 
+           filter. If multiple documents match, ``updateOne`` will update the *first* 
+           matching document only.
 
-   db.collection.bulkWrite( [
-      { updateMany : 
-         { 
-            "filter" : <document>, 
-            "update" : <document or pipeline>,          // Changed in MongoDB 4.2 
-            "upsert" : <boolean>,
-            "collation": <document>,                    // Available starting in 3.4
-            "arrayFilters": [ <filterdocument1>, ... ]  // Available starting in 3.6
-         } 
-      } 
-   ] )
+           .. code-block:: javascript
+           
+              db.collection.bulkWrite( [
+                 { updateOne : 
+                    { 
+                       "filter": <document>, 
+                       "update": <document or pipeline>,            // Changed in 4.2
+                       "upsert": <boolean>,
+                       "collation": <document>,                     // Available starting in 3.4
+                       "arrayFilters": [ <filterdocument1>, ... ],  // Available starting in 3.6
+                       "hint": <document|string>                    // Available starting in 4.2.1
+                    } 
+                 } 
+              ] )
 
-For the ``filter`` field, use :ref:`query selectors<query-selectors>`
-such as those used with :method:`~db.collection.find()`.
+      - id: updateMany
+        name: updateMany
+        content: |
 
-For the ``update`` field, you can use:
+           ``updateMany`` updates *all* documents in the collection
+           that match the filter.
 
-- A document that only contains :ref:`update operator
-  <update-operators>` expressions.
+           .. code-block:: javascript
+           
+              db.collection.bulkWrite( [
+                 { updateMany : 
+                    { 
+                       "filter" : <document>, 
+                       "update" : <document or pipeline>,          // Changed in MongoDB 4.2 
+                       "upsert" : <boolean>,
+                       "collation": <document>,                    // Available starting in 3.4
+                       "arrayFilters": [ <filterdocument1>, ... ], // Available starting in 3.6
+                       "hint": <document|string>                   // Available starting in 4.2.1
+                    } 
+                 } 
+              ] )
 
-- An :doc:`aggregation pipeline </core/aggregation-pipeline>` ``[
-  <stage1>, <stage2>, ... ]`` that specifies the modifications to
-  perform.
+.. list-table::
+   :widths: 15 85
+   :header-rows: 1
 
-By default, ``upsert`` is ``false``.
+   * - Field
+     - Notes
+     
+   * - ``filter``
 
-For details on ``arrayFilters`` and :ref:`collation <collation>`, refer
-to :method:`db.collection.updateOne()` and
+     - The selection criteria for the update. The same :ref:`query
+       selectors <query-selectors>` as in the
+       :method:`db.collection.find()` method are available.
+
+   * - ``update``
+
+     - The update operation to perform. Can specify either:
+
+       - A document that only contains :ref:`update operator
+         <update-operators>` expressions.
+
+       - An :doc:`aggregation pipeline </core/aggregation-pipeline>` ``[
+         <stage1>, <stage2>, ... ]`` that specifies the modifications to
+         perform.
+
+   * - ``upsert``
+
+     - Optional. A boolean to indicate whether to perform an upsert.
+   
+       By default, ``upsert`` is ``false``.
+
+   * - ``arrayFilters``
+
+     - Optional. An array of filter documents that determine which
+       array elements to modify for an update operation on an array
+       field.
+
+   * - ``collation``
+
+     - Optional. Specifies the :ref:`collation <collation>` to use for
+       the operation.
+
+   * - ``hint``
+
+     - Optional. The :doc:`index </indexes>` to use to support the
+       update ``filter``. If you specify an index that does not exist,
+       the operation errors.
+
+       .. versionadded:: 4.2.1
+
+For details, see :method:`db.collection.updateOne()` and
 :method:`db.collection.updateMany()`.
-
+ 
 .. _bulkwrite-write-operations-replaceOne:
 
 replaceOne
 ++++++++++
 
-.. versionchanged:: 3.4
-
-   Add support for :ref:`collation <collation>`. Refer to
-   :method:`db.collection.replaceOne()` for details
-
 ``replaceOne`` replaces a *single* document in the collection that matches the 
 filter. If multiple documents match, ``replaceOne`` will replace the *first* 
-matching document only. See :method:`db.collection.replaceOne()`.
+matching document only.
 
 .. code-block:: javascript
 
@@ -213,51 +258,114 @@ matching document only. See :method:`db.collection.replaceOne()`.
          { 
             "filter" : <document>, 
             "replacement" : <document>, 
-            "upsert" : <boolean> 
+            "upsert" : <boolean>,
+            "collation": <document>,                    // Available starting in 3.4
+            "hint": <document|string>                   // Available starting in 4.2.1
          } 
       } 
    ] )
-   
-Use :ref:`query selectors<query-selectors>` such as those used with
-:method:`~db.collection.find()` for the ``filter`` field.
 
-The ``replacement`` field cannot contain 
-:doc:`update operators </reference/operator/update>`.
+.. list-table::
+   :widths: 15 85
+   :header-rows: 1
 
-By default, ``upsert`` is ``false``.
+   * - Field
+     - Notes
+     
+   * - ``filter``
+
+     - The selection criteria for the replacement operation. The same
+       :ref:`query selectors <query-selectors>` as in the
+       :method:`db.collection.find()` method are available.
+
+   * - ``replacement``
+
+     - The replacement document. The document cannot contain
+       :doc:`update operators </reference/operator/update>`.
+
+   * - ``upsert``
+
+     - Optional. A boolean to indicate whether to perform an upsert. By
+       default, ``upsert`` is ``false``.
+
+   * - ``collation``
+
+     - Optional. Specifies the :ref:`collation <collation>` to use for
+       the operation.
+
+   * - ``hint``
+
+     - Optional. The :doc:`index </indexes>` to use to support the
+       update ``filter``. If you specify an index that does not exist,
+       the operation errors.
+
+       .. versionadded:: 4.2.1
+
+For details, see to :method:`db.collection.replaceOne()`.
 
 .. _bulkwrite-write-operations-deleteOneMany:
 
 deleteOne and deleteMany
 ++++++++++++++++++++++++
-
-.. versionchanged:: 3.4
-
-   Add support for :ref:`collation <collation>`. Refer to
-   :method:`db.collection.deleteOne()` and
-   :method:`db.collection.deleteMany()` for details
-
-``deleteOne`` deletes a *single* document in the collection that match the 
-filter. If multiple documents match, ``deleteOne`` will delete the *first* 
-matching document only. See :method:`db.collection.deleteOne()`.
  
-.. code-block:: javascript
+.. tabs::
 
-   db.collection.bulkWrite([
-      { deleteOne :  { "filter" : <document> } } 
-   ] )
+   tabs:
 
-``deleteMany`` deletes *all* documents in the collection that match the 
-filter. See :method:`db.collection.deleteMany()`.
+      - id: deleteOne
+        name: deleteOne
+        content: |
 
-.. code-block:: javascript
+           ``deleteOne`` deletes a *single* document in the collection that match the 
+           filter. If multiple documents match, ``deleteOne`` will delete the *first* 
+           matching document only.
 
-   db.collection.bulkWrite([
-      { deleteMany :  { "filter" : <document> } } 
-   ] )
+           .. code-block:: javascript
+           
+              db.collection.bulkWrite([
+                 { deleteOne : { 
+                    "filter" : <document>, 
+                    "collation" : <document>                   // Available starting in 3.4
+                 } } 
+              ] )
 
-Use :ref:`query selectors<query-selectors>` such as those used with
-:method:`~db.collection.find()` for the ``filter`` field.
+      - id: deleteMany
+        name: deleteMany
+        content: |
+
+           ``deleteMany`` deletes *all* documents in the collection
+           that match the filter.
+
+           .. code-block:: javascript
+           
+              db.collection.bulkWrite([
+                 { deleteMany: { 
+                    "filter" : <document>, 
+                    "collation" : <document>                    // Available starting in 3.4
+                 } } 
+              ] )
+
+.. list-table::
+   :widths: 15 85
+   :header-rows: 1
+
+   * - Field
+     - Notes
+     
+   * - ``filter``
+
+     - The selection criteria for the delete operation. The same
+       :ref:`query selectors <query-selectors>` as in the
+       :method:`db.collection.find()` method are available.
+
+   * - ``collation``
+
+     - Optional. Specifies the :ref:`collation <collation>` to use for
+       the operation.
+
+
+For details, see :method:`db.collection.deleteOne()` and
+:method:`db.collection.deleteMany()`.
 
 .. _bulkwrite-write-operations-id:
 

--- a/source/reference/method/db.collection.countDocuments.txt
+++ b/source/reference/method/db.collection.countDocuments.txt
@@ -98,8 +98,15 @@ aggregation operation and returns just the value of ``n``:
       { $group: { _id: null, n: { $sum: 1 } } } )
    ])
 
-:method:`db.collection.countDocuments()` errors on an empty or
+Empty or Non-Existing Collections and Views
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Starting in version 4.2.1 (and 4.0-series in 4.0.13),
+:method:`db.collection.countDocuments()` returns ``0`` on an empty or
 non-existing collection or view.
+
+In earlier versions of MongoDB, :method:`db.collection.countDocuments()`
+errors on an empty or non-existing collection or view.
 
 .. _countDocuments-restrictions:
 

--- a/source/reference/method/db.collection.replaceOne.txt
+++ b/source/reference/method/db.collection.replaceOne.txt
@@ -36,7 +36,8 @@ Definition
          {
            upsert: <boolean>,
            writeConcern: <document>,
-           collation: <document>
+           collation: <document>,
+           hint: <document|string>                   // Available starting in 4.2.1
          }
       )
 
@@ -54,11 +55,13 @@ Definition
    
         - Description
    
-      * - ``filter``
+      * - :ref:`filter <replace-one-filter>`
    
         - document
    
-        - The selection criteria for the update. The same :ref:`query
+        - .. _replace-one-filter:
+          
+          The selection criteria for the update. The same :ref:`query
           selectors <query-selectors>` as in the :method:`find()
           <db.collection.find()>` method are available.
           
@@ -105,6 +108,27 @@ Definition
           
           .. include:: /includes/extracts/collation-option.rst
           
+          
+   
+      * - :ref:`hint <replace-one-hint>`
+   
+        - document
+   
+        - .. _replace-one-hint:
+          
+          Optional. A document or string that specifies the :doc:`index
+          </indexes>` to use to support the :ref:`filter
+          <replace-one-filter>`.
+       
+          The option can take an index specification document or the index
+          name string.
+       
+          If you specify an index that does not exist, the operation
+          errors.
+
+          For an example, see :ref:`ex-replace-one-hint`.
+
+          .. versionadded:: 4.2.1
           
    
 
@@ -354,5 +378,60 @@ option:
       { collation: { locale: "fr", strength: 1 } }
 
    );
+
+.. _ex-replace-one-hint:
+
+Specify ``hint`` for ``replaceOne``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 4.2.1
+
+Create a sample ``members`` collection with the following documents:
+
+.. code-block:: javascript
+
+   db.members.insertMany([
+      { "_id" : 1, "member" : "abc123", "status" : "P", "points" :  0,  "misc1" : null, "misc2" : null },
+      { "_id" : 2, "member" : "xyz123", "status" : "A", "points" : 60,  "misc1" : "reminder: ping me at 100pts", "misc2" : "Some random comment" },
+      { "_id" : 3, "member" : "lmn123", "status" : "P", "points" :  0,  "misc1" : null, "misc2" : null },
+      { "_id" : 4, "member" : "pqr123", "status" : "D", "points" : 20,  "misc1" : "Deactivated", "misc2" : null },
+      { "_id" : 5, "member" : "ijk123", "status" : "P", "points" :  0,  "misc1" : null, "misc2" : null },
+      { "_id" : 6, "member" : "cde123", "status" : "A", "points" : 86,  "misc1" : "reminder: ping me at 100pts", "misc2" : "Some random comment" }
+   ])
+
+Create the following indexes on the collection:
+
+.. code-block:: javascript
+
+   db.members.createIndex( { status: 1 } )
+   db.members.createIndex( { points: 1 } )
+
+The following update operation explicitly hints to use the index ``{
+status: 1 }``:
+
+.. note::
+
+   If you specify an index that does not exist, the operation errors.
+
+.. code-block:: javascript
+
+   db.members.replaceOne(
+      { "points": { $lte: 20 }, "status": "P" }, 
+      { "misc1": "using index on status", status: "P", member: "replacement", points: "20"},
+      { hint: { status: 1 } }
+   )
+
+The operation returns the following:
+
+.. code-block:: javascript
+
+   { "acknowledged" : true, "matchedCount" : 1, "modifiedCount" : 1 }
+
+
+To view the indexes used, you can use the :pipeline:`$indexStats` pipeline:
+
+.. code-block:: javascript
+
+   db.members.aggregate( [ { $indexStats: { } }, { $sort: { name: 1 } } ] )
 
 

--- a/source/reference/method/db.collection.updateMany.txt
+++ b/source/reference/method/db.collection.updateMany.txt
@@ -765,3 +765,9 @@ The update command returns the following:
 .. code-block:: javascript
 
    { "acknowledged" : true, "matchedCount" : 3, "modifiedCount" : 3 }
+
+To view the indexes used, you can use the :pipeline:`$indexStats` pipeline:
+
+.. code-block:: javascript
+
+   db.members.aggregate( [ { $indexStats: { } }, { $sort: { name: 1 } } ] )

--- a/source/reference/method/db.collection.updateMany.txt
+++ b/source/reference/method/db.collection.updateMany.txt
@@ -38,7 +38,8 @@ The :method:`~db.collection.updateMany()` method has the following form:
         upsert: <boolean>,
         writeConcern: <document>,
         collation: <document>,
-        arrayFilters: [ <filterdocument1>, ... ]
+        arrayFilters: [ <filterdocument1>, ... ],
+        hint:  <document|string>        // Available starting in MongoDB 4.2.1
       }
    )
 
@@ -58,11 +59,13 @@ parameters:
 
      - Description
 
-   * - ``filter``
+   * - `filter <update-many-filter>`
 
      - document
 
-     - The selection criteria for the update. The same :ref:`query
+     - .. _update-many-filter:
+     
+       The selection criteria for the update. The same :ref:`query
        selectors <query-selectors>` as in the :method:`find()
        <db.collection.find()>` method are available.
        
@@ -127,7 +130,27 @@ parameters:
        For examples, see :ref:`updateMany-arrayFilters`.
        
        .. versionadded:: 3.6
-       
+
+   * - :ref:`hint <update-many-hint>` 
+
+     - Document or string
+
+     - .. _update-many-hint:
+
+       Optional. A document or string that specifies the :doc:`index
+       </indexes>` to use to support the :ref:`query predicate
+       <update-many-filter>`.
+
+       The option can take an index specification document or the index
+       name string.
+
+       If you specify an index that does not exist, the operation
+       errors.
+
+       For an example, see :ref:`ex-update-many-hint`.
+
+       .. versionadded:: 4.2.1
+
 Returns
 ~~~~~~~
 
@@ -694,3 +717,51 @@ After the operation, the collection has the following documents:
          { "grade" : 85, "mean" : 100, "std" : 4 }
       ]
    }
+
+.. _ex-update-many-hint:
+
+Specify ``hint`` for Update Operations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 4.2.1
+
+Create a sample ``members`` collection with the following documents:
+
+.. code-block:: javascript
+
+   db.members.insertMany([
+      { "_id" : 1, "member" : "abc123", "status" : "P", "points" :  0,  "misc1" : null, "misc2" : null },
+      { "_id" : 2, "member" : "xyz123", "status" : "A", "points" : 60,  "misc1" : "reminder: ping me at 100pts", "misc2" : "Some random comment" },
+      { "_id" : 3, "member" : "lmn123", "status" : "P", "points" :  0,  "misc1" : null, "misc2" : null },
+      { "_id" : 4, "member" : "pqr123", "status" : "D", "points" : 20,  "misc1" : "Deactivated", "misc2" : null },
+      { "_id" : 5, "member" : "ijk123", "status" : "P", "points" :  0,  "misc1" : null, "misc2" : null },
+      { "_id" : 6, "member" : "cde123", "status" : "A", "points" : 86,  "misc1" : "reminder: ping me at 100pts", "misc2" : "Some random comment" }
+   ])
+
+Create the following indexes on the collection:
+
+.. code-block:: javascript
+
+   db.members.createIndex( { status: 1 } )
+   db.members.createIndex( { points: 1 } )
+
+The following update operation explicitly hints to use the index ``{
+status: 1 }``:
+
+.. note::
+
+   If you specify an index that does not exist, the operation errors.
+
+.. code-block:: javascript
+
+   db.members.updateMany(
+      { "points": { $lte: 20 }, "status": "P" }, 
+      { $set: { "misc1": "Need to activate" } },
+      { hint: { status: 1 } }
+   )
+
+The update command returns the following:
+
+.. code-block:: javascript
+
+   { "acknowledged" : true, "matchedCount" : 3, "modifiedCount" : 3 }

--- a/source/reference/method/db.collection.updateOne.txt
+++ b/source/reference/method/db.collection.updateOne.txt
@@ -817,5 +817,11 @@ The update command returns the following:
 
    { "acknowledged" : true, "matchedCount" : 1, "modifiedCount" : 1 }
 
+To view the indexes used, you can use the :pipeline:`$indexStats` pipeline:
+
+.. code-block:: javascript
+
+   db.members.aggregate( [ { $indexStats: { } }, { $sort: { name: 1 } } ] )
+
 .. seealso:: To update multiple documents, see
    :method:`db.collection.updateMany()`.

--- a/source/reference/method/db.collection.updateOne.txt
+++ b/source/reference/method/db.collection.updateOne.txt
@@ -40,7 +40,8 @@ The :method:`~db.collection.updateOne()` method has the following syntax:
         upsert: <boolean>,
         writeConcern: <document>,
         collation: <document>,
-        arrayFilters: [ <filterdocument1>, ... ]
+        arrayFilters: [ <filterdocument1>, ... ],
+        hint:  <document|string>        // Available starting in MongoDB 4.2.1
       }
    )
 
@@ -60,12 +61,12 @@ parameters:
 
      - Description
 
-   * - :ref:`filter <updateOne-filter>`
+   * - :ref:`filter <update-one-filter>`
 
      - document
 
-     - .. _updateOne-filter:
-     
+     - .. _update-one-filter:
+       
        The selection criteria for the update. The same :ref:`query
        selectors <query-selectors>` as in the :method:`find()
        <db.collection.find()>` method are available.
@@ -131,6 +132,27 @@ parameters:
        For examples, see :ref:`updateOne-arrayFilters`.
        
        .. versionadded:: 3.6
+
+   * - :ref:`hint <update-one-hint>` 
+
+     - Document or string
+
+     - .. _update-one-hint:
+
+       Optional. A document or string that specifies the :doc:`index
+       </indexes>` to use to support the :ref:`query predicate
+       <update-one-filter>`.
+       
+       The option can take an index specification document or the index
+       name string.
+       
+       If you specify an index that does not exist, the operation
+       errors.
+
+       For an example, see :ref:`ex-update-one-hint`.
+
+       .. versionadded:: 4.2.1
+
 
 Returns
 ~~~~~~~
@@ -245,7 +267,7 @@ document based on the ``filter`` criteria and ``update`` modifications. See
 :ref:`updateOne-example-update-with-upsert`.
 
 If you specify ``upsert: true`` on a sharded collection, you must
-include the full shard key in the :ref:`filter <updateOne-filter>`. For
+include the full shard key in the :ref:`filter <update-one-filter>`. For
 additional :method:`db.collection.updateOne()` behavior on a sharded
 collection, see :ref:`updateOne-sharded-collection`.
 
@@ -265,9 +287,9 @@ To use :method:`db.collection.updateOne()` on a sharded collection:
 
 - If you don't specify ``upsert: true``, you must include an exact
   match on the ``_id`` field or target a single shard (such as by
-  including the shard key in the :ref:`filter <updateOne-filter>`).
+  including the shard key in the :ref:`filter <update-one-filter>`).
 
-- If you specify ``upsert: true``, the :ref:`filter <updateOne-filter>`
+- If you specify ``upsert: true``, the :ref:`filter <update-one-filter>`
   must include the shard key.
 
 Shard Key Modification
@@ -746,6 +768,54 @@ operation, the collection has the following documents:
          { "grade" : 85, "mean" : 85, "std" : 4 }
       ]
    }
+
+.. _ex-update-one-hint:
+
+Specify ``hint`` for Update Operations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 4.2.1
+
+Create a sample ``members`` collection with the following documents:
+
+.. code-block:: javascript
+
+   db.members.insertMany([
+      { "_id" : 1, "member" : "abc123", "status" : "P", "points" :  0,  "misc1" : null, "misc2" : null },
+      { "_id" : 2, "member" : "xyz123", "status" : "A", "points" : 60,  "misc1" : "reminder: ping me at 100pts", "misc2" : "Some random comment" },
+      { "_id" : 3, "member" : "lmn123", "status" : "P", "points" :  0,  "misc1" : null, "misc2" : null },
+      { "_id" : 4, "member" : "pqr123", "status" : "D", "points" : 20,  "misc1" : "Deactivated", "misc2" : null },
+      { "_id" : 5, "member" : "ijk123", "status" : "P", "points" :  0,  "misc1" : null, "misc2" : null },
+      { "_id" : 6, "member" : "cde123", "status" : "A", "points" : 86,  "misc1" : "reminder: ping me at 100pts", "misc2" : "Some random comment" }
+   ])
+
+Create the following indexes on the collection:
+
+.. code-block:: javascript
+
+   db.members.createIndex( { status: 1 } )
+   db.members.createIndex( { points: 1 } )
+
+The following update operation explicitly hints to use the index ``{
+status: 1 }``:
+
+.. note::
+
+   If you specify an index that does not exist, the operation errors.
+
+.. code-block:: javascript
+
+   db.members.updateOne(
+      { "points": { $lte: 20 }, "status": "P" }, 
+      { $set: { "misc1": "Need to activate" } },
+      { hint: { status: 1 } }
+   )
+
+The update command returns the following:
+
+.. code-block:: javascript
+
+   { "acknowledged" : true, "matchedCount" : 1, "modifiedCount" : 1 }
 
 .. seealso:: To update multiple documents, see
    :method:`db.collection.updateMany()`.

--- a/source/reference/method/db.serverStatus.txt
+++ b/source/reference/method/db.serverStatus.txt
@@ -15,8 +15,6 @@ db.serverStatus()
    Returns a :term:`document` that provides an overview of the
    database process's state.
 
-   .. include:: /includes/extracts/serverStatus-method-output-change.rst
-
    This command provides a wrapper around the database command
    :dbcommand:`serverStatus`.
 
@@ -39,7 +37,9 @@ information in the output:
 
    db.serverStatus( { repl: 1 } )
 
-.. seealso::
+Output
+------
 
-   :doc:`/reference/command/serverStatus` for complete documentation of
-   the output of this function.
+See :ref:`serverStatus Output <server-status-output>` for complete
+documentation of the output of this function.
+

--- a/source/reference/method/rs.status.txt
+++ b/source/reference/method/rs.status.txt
@@ -16,23 +16,46 @@ Definition
 .. method:: rs.status()
 
    Returns the replica set status from the point of view of the member
-   where the method is run.
+   where the method is run. This method provides a wrapper around the
+   :dbcommand:`replSetGetStatus` command.
 
    This output reflects the current status of the replica set, using
    data derived from the heartbeat packets sent by the other members
    of the replica set.
-
-   This method provides a wrapper around the
-   :dbcommand:`replSetGetStatus` command.
-
-   Starting in MongoDB 3.4, the :dbcommand:`replSetGetStatus` command
-   can accept the optional ``initialSync: 1`` to report on initial sync
-   status and progress if the command is run on the secondary. To
-   report on initial sync for the secondary, you must run the command
-   instead of the helper.
 
 Output
 ------
 
 For an example and details on the output, see :ref:`replSetGetStatus
 <rs-status-output>`.
+
+- Starting in MongoDB 4.2.1
+      If you run :binary:`~bin.mongo` shell helper
+      :method:`rs.status()` (or the :dbcommand:`replSetGetStatus`
+      command) on a member during its :ref:`initial sync
+      <replica-set-initial-sync>` (i.e. :replstate:`STARTUP2` state),
+      the command returns :data:`replSetGetStatus.initialSyncStatus`
+      metrics.
+      
+      Once the member completes its initial sync, the
+      :data:`replSetGetStatus.initialSyncStatus` metrics becomes
+      unavailable.
+      
+- In earlier versions (3.4.x-4.2.0)
+      To return :ref:`initial sync <replica-set-initial-sync>` status
+      information, you must the :dbcommand:`replSetGetStatus` command
+      with the ``initialSync: 1`` option on a secondary member or a
+      member in :replstate:`STARTUP2` state:
+
+      .. code-block:: javascript
+
+         db.adminCommand( { replSetGetStatus: 1, initialSync: 1 } )
+
+      The :data:`replSetGetStatus.initialSyncStatus` metrics remains
+      available after the member completes its initial sync. That is,
+      you can run the :dbcommand:`replSetGetStatus` command with the
+      ``initialSync: 1`` on the secondary member to return its initial
+      sync information.
+
+      You cannot specify ``initialSync: 1`` in the :binary:`~bin.mongo`
+      shell helper :method:`rs.status()`.

--- a/source/reference/parameters.txt
+++ b/source/reference/parameters.txt
@@ -2434,7 +2434,7 @@ WiredTiger Parameters
 
 .. parameter:: wiredTigerMaxCacheOverflowSizeGB
 
-   *Available in 4.0-series starting in 4.0.12*
+   *Available starting in MongoDB 4.2.1 (and 4.0.12)*
 
    *Default*: 0 (No specified maximum)
 

--- a/source/reference/ulimit.txt
+++ b/source/reference/ulimit.txt
@@ -185,6 +185,10 @@ To configure an ``nproc`` value for these versions, create a file named
 ``hard nproc`` values to increase the process limit. For recommended values,
 see :ref:`recommended-ulimit-settings`.
 
+With RHEL / CentOS 8, separate ``nproc`` values are no longer necessary.
+The ``ulimit`` command is sufficient to configure the required max
+process values on RHEL / CentOS 8.
+
 .. _recommended-ulimit-settings:
 
 Recommended ``ulimit`` Settings

--- a/source/reference/write-concern.txt
+++ b/source/reference/write-concern.txt
@@ -113,11 +113,12 @@ available:
    * - .. writeconcern:: "majority"
 
      - Requests acknowledgment that write operations have propagated to
-       the majority (``M``) of data-bearing voting members. The
-       majority (``M``) is calculated as the majority of *all* voting
-       members, but the write operation
-       returns acknowledgement after propagating to M-number of
-       data-bearing voting members (primary and secondaries with
+       the :data:`majority <replSetGetStatus.writeMajorityCount>`
+       (``M``) of data-bearing voting members. The majority (``M``) is
+       calculated as the majority of *all* voting members
+       [#arbiters-majority-count]_, but the write operation returns
+       acknowledgement after propagating to M-number of data-bearing
+       voting members (primary and secondaries with
        :rsconf:`members[n].votes` greater than ``0``).
 
        For example, consider a replica set with 3 voting members,
@@ -125,6 +126,9 @@ available:
        is two [#arbiters-majority-count]_, and the write must propagate
        to the primary and one secondary to acknowledge the
        write concern to the client.
+
+       Starting in version 4.2.1, the :method:`rs.status()` returns
+       :data:`~replSetGetStatus.writeMajorityCount`.
 
        .. note:: 
 
@@ -347,8 +351,9 @@ the write operation in memory or after writing to the on-disk journal.
 .. [#arbiters-majority-count]
 
    The majority (``M``) is calculated as the majority of *all* voting
-   members. As such, even if a replica set with 3 voting members is a
-   Primary-Secondary-Arbiter (P-S-A), the majority (``M``) is two.
-   However, since the write can only be applied to data-bearing
-   members, the write must propagate to the primary and the secondary
-   to acknowledge the write concern to the client.
+   members. As such, even if a replica set
+   with 3 voting members is a Primary-Secondary-Arbiter (P-S-A), the
+   majority (``M``) is two. However, since the write can only be
+   applied to data-bearing members, the write must propagate to the
+   primary and the secondary to acknowledge the write concern to the
+   client.

--- a/source/release-notes/4.2.txt
+++ b/source/release-notes/4.2.txt
@@ -1675,16 +1675,17 @@ Known Issues
 
 .. list-table::
    :header-rows: 1
-   :widths: 15 70 
+   :widths: 15 70 20
    
    * - In Version
      - Issues
-
+     - Status
+     
    * - 4.2.0
 
      - :issue:`SERVER-43075`: Missing :setting:`storage.journal.commitIntervalMs`
-     
 
+     - Fixed in 4.2.1
 
 Report an Issue
 ---------------

--- a/source/replication.txt
+++ b/source/replication.txt
@@ -85,9 +85,10 @@ replica set members. Because they do not store a data set, arbiters can
 be a good way to provide replica set quorum functionality with a
 cheaper resource cost than a fully functional replica set member with a
 data set. If your replica set has an even number of members, add an
-arbiter to obtain a majority of votes in an election for primary.
-Arbiters do not require dedicated hardware. For more information on
-arbiters, see :doc:`/core/replica-set-arbiter`.
+arbiter to obtain a :data:`majority
+<replSetGetStatus.majorityVoteCount>` of votes in an election for
+primary. Arbiters do not require dedicated hardware. For more
+information on arbiters, see :doc:`/core/replica-set-arbiter`.
 
 .. include:: /images/replica-set-primary-with-secondary-and-arbiter.rst
 

--- a/source/tutorial/install-mongodb-enterprise-on-debian.txt
+++ b/source/tutorial/install-mongodb-enterprise-on-debian.txt
@@ -38,8 +38,14 @@ Platform Support
 
    MongoDB 4.2 removes support for Debian 8 ("Jessie").
 
-MongoDB 4.2 only provides packages for 64-bit builds of Debian 9. See
-:ref:`mongodb-supported-platforms` for more information.
+MongodDB 4.2 supports:
+
+- Debian 10 "Buster" (Starting in version 4.2.1)
+
+- Debian 9 "Stretch"
+
+MongoDB only provides packages for the 64-bit builds of these releases.
+See :ref:`mongodb-supported-platforms` for more information.
 
 Install MongoDB Enterprise
 --------------------------
@@ -63,7 +69,17 @@ Prerequisites
 
 .. include:: /includes/fact-tarball-dependencies.rst
 
-.. include:: /includes/extracts/install-mongodb-enterprise-manually-debian.rst
+.. tabs::
+
+   .. tab:: Debian 10 "Buster"
+      :tabid: debian-10-buster
+
+      .. include:: /includes/extracts/install-mongodb-enterprise-manually-debian-10.rst
+
+   .. tab:: Debian 9 "Stretch"
+      :tabid: debian-9-stretch
+
+      .. include:: /includes/extracts/install-mongodb-enterprise-manually-debian-9.rst
 
 Procedure
 `````````

--- a/source/tutorial/install-mongodb-enterprise-on-red-hat.txt
+++ b/source/tutorial/install-mongodb-enterprise-on-red-hat.txt
@@ -15,8 +15,8 @@ Overview
 
 Use this tutorial to install :products:`MongoDB Enterprise
 </mongodb-enterprise-advanced?jmp=docs>` on Red Hat Enterprise Linux, 
-CentOS Linux, or Oracle Linux [#oracle-linux]_ versions 6 and 7 from 
-``.rpm`` packages.
+CentOS Linux, or Oracle Linux [#oracle-linux]_ versions 6, 7, and 8 from 
+``.rpm`` packages via the ``yum`` package manager.
 
 .. include:: /includes/fact-installation-64bit.rst
 
@@ -34,13 +34,6 @@ CentOS Linux, or Oracle Linux [#oracle-linux]_ versions 6 and 7 from
    MongoDB only supports Oracle Linux running the  Red Hat Compatible
    Kernel (RHCK). MongoDB does **not** support the Unbreakable
    Enterprise Kernel (UEK).
-
-Packages
----------
-
-.. include:: /includes/list-mongodb-enterprise-packages.rst
-
-.. include:: /includes/fact-installation-bind-ip-default-in-config.rst
 
 Install MongoDB Enterprise
 --------------------------
@@ -68,6 +61,9 @@ Red Hat Enterprise Linux 6
   .. include:: /includes/extracts/install-mongodb-enterprise-manually-redhat-6.rst
 
 Red Hat Enterprise Linux 7
+  .. include:: /includes/extracts/install-mongodb-enterprise-manually-redhat-7.rst
+
+Red Hat Enterprise Linux 8
   .. include:: /includes/extracts/install-mongodb-enterprise-manually-redhat-7.rst
 
 Procedure
@@ -191,3 +187,10 @@ Uninstall MongoDB
 .. include:: /includes/fact-uninstall.rst
 
 .. include:: /includes/steps/uninstall-mongodb-enterprise-on-redhat.rst
+
+Packages
+---------
+
+.. include:: /includes/list-mongodb-enterprise-packages.rst
+
+.. include:: /includes/fact-installation-bind-ip-default-in-config.rst

--- a/source/tutorial/install-mongodb-on-debian.txt
+++ b/source/tutorial/install-mongodb-on-debian.txt
@@ -38,9 +38,15 @@ Platform Support
 .. topic:: EOL Notice
 
    MongoDB 4.2 removes support for Debian 8 ("Jessie").
-   
-MongoDB 4.2 only provides packages for 64-bit builds of Debian 9. See
-:ref:`mongodb-supported-platforms` for more information.
+
+MongodDB 4.2 supports:
+
+- Debian 10 "Buster" (Starting in version 4.2.1)
+
+- Debian 9 "Stretch"
+
+MongoDB only provides packages for the 64-bit builds of these releases.
+See :ref:`mongodb-supported-platforms` for more information.
 
 .. include:: /includes/admonition-wsl.rst
 
@@ -71,7 +77,17 @@ Using ``.tgz`` Tarballs
 
 .. include:: /includes/fact-tarball-dependencies.rst
 
-.. include:: /includes/extracts/install-mongodb-community-manually-debian.rst
+.. tabs::
+
+   .. tab:: Debian 10 "Buster"
+      :tabid: debian-10-buster
+
+      .. include:: /includes/extracts/install-mongodb-community-manually-debian-10.rst
+
+   .. tab:: Debian 9 "Stretch"
+      :tabid: debian-9-stretch
+
+      .. include:: /includes/extracts/install-mongodb-community-manually-debian-9.rst
 
 Procedure
 `````````

--- a/source/tutorial/install-mongodb-on-red-hat.txt
+++ b/source/tutorial/install-mongodb-on-red-hat.txt
@@ -17,7 +17,7 @@ Overview
 
 Use this tutorial to install MongoDB {+version+} Community Edition on Red Hat
 Enterprise Linux, CentOS Linux, or Oracle Linux [#oracle-linux]_ 
-versions 6 and 7 using ``.rpm`` packages.
+versions 6, 7, and 8 using ``.rpm`` packages via the ``yum`` package manager.
 
 .. include:: /includes/fact-installation-64bit.rst
 
@@ -34,11 +34,6 @@ versions 6 and 7 using ``.rpm`` packages.
    MongoDB only supports Oracle Linux running the  Red Hat Compatible
    Kernel (RHCK). MongoDB does **not** support the Unbreakable
    Enterprise Kernel (UEK).
-
-Packages
---------
-
-.. include:: /includes/list-mongodb-org-packages.rst
 
 Install MongoDB Community Edition
 ---------------------------------
@@ -190,3 +185,8 @@ Uninstall MongoDB Community Edition
 .. include:: /includes/fact-uninstall.rst
 
 .. include:: /includes/steps/uninstall-mongodb-on-redhat.rst
+
+Packages
+--------
+
+.. include:: /includes/list-mongodb-org-packages.rst

--- a/source/tutorial/troubleshoot-map-function.txt
+++ b/source/tutorial/troubleshoot-map-function.txt
@@ -14,6 +14,13 @@ The ``map`` function is a JavaScript function that associates or “maps”
 a value with a key and emits the key and value pair during a
 :doc:`map-reduce </core/map-reduce>` operation.
 
+.. note::
+
+   Starting in version 4.2.1, MongoDB deprecates the use of JavaScript
+   with scope (i.e. :doc:`BSON type 15 </reference/bson-types/>`) for
+   the ``map``, ``reduce``, and ``finalize`` functions. To scope
+   variables, use the ``scope`` parameter instead.
+
 To verify the ``key`` and ``value`` pairs emitted by the ``map``
 function, write your own ``emit`` function.
 

--- a/source/tutorial/troubleshoot-reduce-function.txt
+++ b/source/tutorial/troubleshoot-reduce-function.txt
@@ -29,6 +29,13 @@ For a list of all the requirements for the ``reduce`` function, see
 :dbcommand:`mapReduce`, or the :binary:`~bin.mongo` shell helper method
 :method:`db.collection.mapReduce()`.
 
+.. note::
+
+   Starting in version 4.2.1, MongoDB deprecates the use of JavaScript
+   with scope (i.e. :doc:`BSON type 15 </reference/bson-types/>`) for
+   the ``map``, ``reduce``, and ``finalize`` functions. To scope
+   variables, use the ``scope`` parameter instead.
+
 Confirm Output Type
 -------------------
 


### PR DESCRIPTION
Platform Support: Add RHEL / CentOS / Oracle 8 to supported platforms, update installation instructions as appropriate.