### PR TITLE
DOCS-9518 clarify dbname and collection naming restriction

### DIFF
--- a/source/core/databases-and-collections.txt
+++ b/source/core/databases-and-collections.txt
@@ -44,11 +44,8 @@ non-existent database and perform the following operation in the
 
 The :method:`~db.collection.insertOne()` operation creates both the
 database ``myNewDB`` and the collection ``myNewCollection1`` if they do
-not already exist.
-
-
-For a list of restrictions on database names, see
-:ref:`restrictions-on-db-names`.
+not already exist. Be sure that both the database and collection names
+follow MongoDB :ref:`restrictions-on-db-names`.
 
 .. _collections:
 
@@ -70,11 +67,9 @@ first store data for that collection.
    db.myNewCollection3.createIndex( { y: 1 } )
 
 Both the :method:`~db.collection.insertOne()` and the
-:method:`~db.collection.createIndex()` operations create their respective
-collection if they do not already exist.
-
-For a list of restrictions on collection names, see
-:ref:`restrictions-on-collection-names`.
+:method:`~db.collection.createIndex()` operations create their
+respective collection if they do not already exist. Be sure that the
+collection name follows MongoDB :ref:`restrictions-on-db-names`.
 
 Explicit Creation
 ~~~~~~~~~~~~~~~~~

--- a/source/reference/command/create.txt
+++ b/source/reference/command/create.txt
@@ -67,7 +67,8 @@ Definition
    
         - string
    
-        - The name of the new collection or view.
+        - The name of the new collection or view. See
+          :ref:`restrictions-on-db-names`.
           
           
    

--- a/source/reference/command/renameCollection.txt
+++ b/source/reference/command/renameCollection.txt
@@ -47,8 +47,6 @@ Definition
    
         - The :term:`namespace` of the collection to rename. The namespace is a
           combination of the database name and the name of the collection.
-          
-          
    
       * - ``to``
    
@@ -57,8 +55,7 @@ Definition
         - The new namespace of the collection. If the new namespace specifies a
           different database, the :dbcommand:`renameCollection` command copies
           the collection to the new database and drops the source collection.
-          
-          
+          See :ref:`restrictions-on-db-names`.
    
       * - ``dropTarget``
    

--- a/source/reference/method/db.collection.renameCollection.txt
+++ b/source/reference/method/db.collection.renameCollection.txt
@@ -38,9 +38,8 @@ Definition
         - string
    
         - The new name of the collection. Enclose the string in quotes.
-          
-          
-   
+          See :ref:`restrictions-on-db-names`.
+
       * - ``dropTarget``
    
         - boolean

--- a/source/reference/method/db.createCollection.txt
+++ b/source/reference/method/db.createCollection.txt
@@ -74,10 +74,9 @@ Definition
    
         - string
    
-        - The name of the collection to create.
-          
-          
-   
+        - The name of the collection to create. See
+          :ref:`restrictions-on-db-names`.
+
       * - ``options``
    
         - document

--- a/source/reference/mongo-shell.txt
+++ b/source/reference/mongo-shell.txt
@@ -491,7 +491,8 @@ administration:
    * - :method:`db.fromColl.renameCollection(\<toColl\>)
        <db.collection.renameCollection()>`
 
-     - Rename collection from ``fromColl`` to ``<toColl>``.
+     - Rename collection from ``fromColl`` to ``<toColl>``. See
+       :ref:`restrictions-on-db-names`.
 
    * - :method:`db.getCollectionNames()`
 

--- a/source/release-notes/3.4-compatibility.txt
+++ b/source/release-notes/3.4-compatibility.txt
@@ -206,6 +206,14 @@ Stricter validation include the following:
 General Compatibility Changes
 -----------------------------
 
+- Updates to namespace restrictions: in MongodDB 3.4, the ``$``
+  character is no longer supported in database names.
+
+  .. important::
+
+     You must drop any databases that contain a ``$`` in its name
+     before upgrading to MongoDB 3.4.
+
 - Removal of deprecated ``textSearchEnabled`` parameter. Starting from
   version 2.6, MongoDB enables the text search feature by default.
 


### PR DESCRIPTION
Provided deprecation notice for $ character beginning in 3.4, and provided links to naming restrictions doc for naming and renaming commands.