### PR TITLE
Refactoring changelog generation procedure

### DIFF
--- a/changelogs/changelog_conf.yaml
+++ b/changelogs/changelog_conf.yaml
@@ -1,0 +1,110 @@
+groups:
+  ## A mapping of top level components presented on the changelog
+  ## page, to the components in Jira that populate that group. Maps
+  ## group names to lists of components.
+
+  "Security":
+    - Security
+  "Sharding":
+    - Sharding
+  "Replication":
+    - Replication
+  "Query":
+    - Querying
+    - Indexing
+    - Geo
+    - Text Search
+  "Write Operations":
+    - Write Ops
+  "Aggregation":
+    - Aggregation Framework
+    - MapReduce
+  "JavaScript":
+    - JavaScript
+  "WiredTiger":
+    - WiredTiger
+  "MMAP":
+    - MMAPv1
+  "Storage":
+    - Storage
+  "Catalog":
+    - Catalog
+  "TTL":
+    - TTL
+  "GridFS":
+    - GridFS
+  "Operations":
+    - Operations
+    - Admin
+    - Diagnostics
+    - Logging
+    - Shell
+    - Usability
+    - HTTP Console
+  "Build and Packaging":
+    - Build
+    - Packaging
+    - Mobile
+  "Internals":
+    - Testing
+    - Testing Infrastructure
+    - Stability
+    - Performance
+    - Portability
+    - Networking
+    - Internal Code
+    - Internal Client
+    - Concurrency
+    - IDL
+    - Upgrade/Downgrade
+    - go-openssl
+    - Cache and eviction
+  "Tools":
+    - Tools
+    - All Tools
+    - bsondump
+    - mongodump
+    - mongoexport
+    - mongofiles
+    - mongoimport
+    - mongooplog
+    - mongorestore
+    - mongosniff
+    - mongostat
+    - mongotop
+    - mongoreplay
+    - llmgo
+
+ordering:
+  # Defines an order of groups. Issues with multiple components use
+  # the first component defined in the ordering. Issues without
+  # components use the last element in the ordering.
+
+  - Security
+  - Sharding
+  - Replication
+  - Query
+  - Write Operations
+  - Aggregation
+  - Catalog
+  - JavaScript
+  - WiredTiger
+  - MMAP
+  - Storage
+  - TTL
+  - GridFS
+  - Operations
+  - Build and Packaging
+  - Tools
+  - Internals
+
+nesting:
+  # Define nesting relationships between groups above. Map group names
+  # to lists of group names. Generally nested components should appear
+  # before their parent heading in the ordering, so that
+  # double-categorized issues get put in the more specific category.
+
+  Storage:
+    - WiredTiger
+    - MMAP
+...

--- a/changelogs/generatechangelogs.py
+++ b/changelogs/generatechangelogs.py
@@ -1,0 +1,180 @@
+import collections
+import logging
+import os
+import rstcloth.rstcloth as rstcloth
+import yaml
+from jira import JIRA
+
+logger = logging.getLogger('generatechangelogs.py')
+
+
+def get_config():
+    with open('./changelog_conf.yaml') as stream:
+        try:
+            config_yaml = yaml.safe_load(stream)
+            return config_yaml
+        except yaml.YAMLError as exc:
+            print(exc)
+
+
+def get_issue_structure(version, config):
+    projects = '("SERVER", "TOOLS", "WiredTiger")'
+
+    oauth_dict = {}
+    with open('./.mongodb-jira.yaml') as stream:
+        try:
+            jira_yaml = yaml.safe_load(stream)
+            oauth_dict = jira_yaml.get('jira')
+        except yaml.YAMLError as exc:
+            print(exc)
+
+    # Connect to JIRA
+    auth_jira = JIRA(oauth=oauth_dict, options={
+                     'server': 'https://jira.mongodb.org'})
+
+    # Run the JIRA query
+    query = "project in {0} and fixVersion = {1} and resolution = 'Fixed' ORDER BY key ASC".format(
+        projects, version)
+    print(query + '\n')
+    issues = auth_jira.search_issues(query, maxResults=200)
+    logger.info("building changelog for {0} with {1} issue(s)".format(
+        version, len(issues)))
+
+    # setup container of heading groups using the defined ordering.
+    headings = collections.OrderedDict()
+    for k in config.get('ordering'):
+        headings[k] = list()
+
+    # invert the mapping of groups to components so we can filter
+    groups = dict()
+    for k, v in config.get('groups').items():
+        for c in v:
+            groups[c] = k
+
+    # run through all issues, and put each one in the headings structure at the
+    # best place
+    for issue in issues:
+        print(issue)
+        components = []
+        for c in issue.fields.components:
+            components.append(c.name)
+
+            if c.name not in groups:
+                logger.error(
+                    "undefined component %s. update configuration before continuing", c.name)
+
+        issue_pair = (issue.key.encode("utf-8"),
+                      issue.fields.summary.encode("utf-8"))
+
+        if len(components) == 0:
+            # if there isn't a component put this in the last grouping.
+            headings[next(reversed(headings))].append(issue_pair)
+        elif len(components) == 1:
+            headings[groups[components[0]]].append(issue_pair)
+        else:
+            # if an issue has multiple components use the one that appears first
+            # in the ordering of headings
+            located = False
+            for heading in groups:
+                if heading in components:
+                    headings[groups[heading]].append(issue_pair)
+                    located = True
+                    break
+
+            # if we get here, we should stop the build because someone added a
+            # ticket with a component and we don't know how to deal with this.
+            if located is False:
+                logger.error("skipping issue {0} in changelog {1} because its components aren't defined in the changelog configuration. Fix now.".format(
+                    issue_pair[0], version))
+                raise SystemExit
+
+    return headings
+
+
+def get_changelog_content():
+
+    fixVersion = raw_input("Enter changelog version: ")
+    config = get_config()
+    headings = get_issue_structure(fixVersion, config)
+
+    # invert the mapping of nested, so we can properly handle subheadings.
+    nested = dict()
+    for enclosing_level, sub_headings in config.get('nesting').items():
+        for component in sub_headings:
+            nested[component] = enclosing_level
+
+    # build the changelog content itself.
+    r = rstcloth.RstCloth()
+    level = 3
+
+    r.ref_target("{0}-changelog".format(fixVersion))
+    r.newline()
+    r.heading(text="{0} Changelog".format(fixVersion), char='-')
+    r.newline()
+
+    # process all of the issues by group.
+    for heading, issues in headings.items():
+        if heading in nested:
+            # we deal with nested headings when we do their parent. skip here.
+            continue
+        else:
+            if heading in config.get('nesting') and len(issues) == 0:
+                # if a heading has subheadings, and all are empty, then we should skip it entirely.
+                empty_sub_headings = 0
+                for sub in config.get('nesting').get(heading):
+                    if len(headings[sub]) == 0:
+                        empty_sub_headings += 1
+                if empty_sub_headings == len(config.get('nesting').get(heading)):
+                    continue
+            elif len(issues) == 0:
+                # skip empty headings.
+                continue
+
+            # format the heading.
+            r.heading(text=heading, indent=0,
+                      char='~')
+            r.newline()
+
+            if len(issues) == 1:
+                r.content("{1} {0}".format(issues[0][1], r.role(
+                    "issue", issues[0][0])), wrap=False)
+            else:
+                for issue in issues:
+                    r.li("{1} {0}".format(issue[1], r.role(
+                        "issue", issue[0])), wrap=False)
+            r.newline()
+
+            # repeat the above formatting with minor variations to do the nesting.
+            if heading in config.get('nesting'):
+                for sub in config.get('nesting').get(heading):
+                    if len(headings[sub]) == 0:
+                        continue
+
+                    r.heading(text=sub, indent=0,
+                              # char=giza.content.helper.character_levels[level+1])
+                              char='`')
+                    r.newline()
+
+                    sub_issues = headings[sub]
+                    if len(sub_issues) == 0:
+                        r.content("{1} {0}".format(sub_issues[0][1].strip(), r.role(
+                            "issue", sub_issues[0][0])), wrap=False)
+                    else:
+                        for issue in sub_issues:
+                            r.li("{1} {0}".format(issue[1].strip(), r.role(
+                                "issue", issue[0])), wrap=False)
+                    r.newline()
+
+    # Output the rst to source/includes/changelogs/releases
+    cwd = os.getcwd()
+    sourceDir = os.path.dirname(cwd)
+    fn = fixVersion + ".rst"
+    outputDir = os.path.join(
+        sourceDir, "source/includes/changelogs/releases", fn)
+    r.write(outputDir)
+    print(outputDir)
+    logger.info(
+        "wrote changelog '{0}'. Commit this file independently.".format(outputDir))
+
+# main function
+get_changelog_content()


### PR DESCRIPTION
Refactoring changelog generation procedure

To run, execute the new `generatechangelog.py` file. e.g., from the root of the `docs` directory, run: `python changelogs/generatechangelogs.py`

The program prompts you for the version to generate the changelogs. Specify the MongoDB version (e.g., `4.0.13`).