### PR TITLE
Fix typo in size.txt

### DIFF
--- a/source/reference/operator/aggregation/size.txt
+++ b/source/reference/operator/aggregation/size.txt
@@ -17,7 +17,7 @@ Definition
 
 .. expression:: $size
 
-   Counts and returns the total the number of items in an array.
+   Counts and returns the total number of items in an array.
 
    :expression:`$size` has the following syntax:
 


### PR DESCRIPTION
Just removing an extra 'the'.