### PR TITLE
DOCSP-7910 remove versionchanged and versionadded tags for v2.6 ONLY …

### DIFF
--- a/source/core/auditing.txt
+++ b/source/core/auditing.txt
@@ -12,8 +12,6 @@ Auditing
    :depth: 1
    :class: singlecol
 
-.. versionadded:: 2.6
-
 MongoDB Enterprise includes an auditing capability for
 :binary:`~bin.mongod` and :binary:`~bin.mongos` instances. The auditing
 facility allows administrators and users to track system activity for

--- a/source/core/query-plans.txt
+++ b/source/core/query-plans.txt
@@ -212,8 +212,6 @@ The ``queryHash`` and ``planCacheKey`` are available in:
 Index Filters
 -------------
 
-.. versionadded:: 2.6
-
 Index filters determine which indexes the optimizer evaluates for a
 :term:`query shape`. A query shape consists of a combination of query,
 sort, and projection specifications. If an index filter exists for a

--- a/source/core/security-user-defined-roles.txt
+++ b/source/core/security-user-defined-roles.txt
@@ -12,8 +12,6 @@ User-Defined Roles
    :depth: 1
    :class: singlecol
 
-.. versionadded:: 2.6
-
 MongoDB provides a number of :doc:`built-in roles
 </reference/built-in-roles>`. However, if these roles cannot describe the
 desired set of privileges, you can create new roles.

--- a/source/core/security-users.txt
+++ b/source/core/security-users.txt
@@ -80,8 +80,6 @@ Authenticate a User
 Centralized User Data
 ---------------------
 
-.. versionchanged:: 2.6
-
 For users created in MongoDB, MongoDB stores all user information,
 including :data:`name <admin.system.users.user>`, :data:`password
 <admin.system.users.credentials>`, and the :data:`user's authentication
@@ -99,16 +97,11 @@ management commands <user-management-commands>`.
 Sharded Cluster Users
 ---------------------
 
-To create users for a sharded cluster, connect to the :binary:`~bin.mongos`
-instance and add the users. Clients then authenticate these users through the
-:binary:`~bin.mongos` instances.
-
-.. versionchanged:: 2.6
-
-   MongoDB stores these sharded cluster user data in the ``admin`` database of
-   the :term:`config servers <config server>`. Previously, the credentials for
-   authenticating to a database on a sharded cluster resided on the
-   :ref:`primary shard <primary-shard>` for that database.
+To create users for a sharded cluster, connect to the
+:binary:`~bin.mongos` instance and add the users. Clients then
+authenticate these users through the :binary:`~bin.mongos` instances.
+In sharded clusters, MongoDB stores user configuration data in the
+``admin`` database of the :term:`config servers <config server>`.
 
 .. _shard-local-users:
 

--- a/source/includes/access-mongodump-users.rst
+++ b/source/includes/access-mongodump-users.rst
@@ -1,5 +1,3 @@
-.. versionchanged:: 2.6
-
 To back up users and :ref:`user-defined roles <user-defined-roles>` for a
 given database, you must have access to the ``admin`` database. MongoDB
 stores the user data and role definitions for all databases in the

--- a/source/includes/access-mongorestore-users.rst
+++ b/source/includes/access-mongorestore-users.rst
@@ -1,5 +1,3 @@
-.. versionchanged:: 2.6
-
 To restore users and :ref:`user-defined roles <user-defined-roles>` on a
 given database, you must have access to the ``admin`` database. MongoDB
 stores the user data and role definitions for all databases in the

--- a/source/includes/fact-agg-helper-returns-cursor.rst
+++ b/source/includes/fact-agg-helper-returns-cursor.rst
@@ -1,5 +1,0 @@
-.. versionchanged:: 2.6
-   The :method:`db.collection.aggregate()` method returns a
-   cursor and can return result sets of any size. Previous
-   versions returned all results in a single document, and the
-   result set was subject to a size limit of 16 megabytes.

--- a/source/includes/fact-archiveMovedChunks.rst
+++ b/source/includes/fact-archiveMovedChunks.rst
@@ -1,5 +1,3 @@
-.. versionchanged:: 2.6
-
-   Chunk migrations can have an impact on disk space. Starting in
-   MongoDB 2.6, the source shard automatically archives the migrated
-   documents by default. For details, see :ref:`moveChunk-directory`.
+Chunk migrations can have an impact on disk space, as the source shard
+automatically archives the migrated documents by default. For details,
+see :ref:`moveChunk-directory`.

--- a/source/includes/fact-drop-database-users.rst
+++ b/source/includes/fact-drop-database-users.rst
@@ -1,7 +1,5 @@
-.. versionchanged:: 2.6
-
-   This command does not delete the
-   :ref:`users <authentication-client-users>` associated with the current
-   database. To drop the associated users, run the
-   :dbcommand:`dropAllUsersFromDatabase` command in the database you are
-   deleting.
+This command does not delete the
+:ref:`users <authentication-client-users>` associated with the current
+database. To drop the associated users, run the
+:dbcommand:`dropAllUsersFromDatabase` command in the database you are
+deleting.

--- a/source/includes/fact-snmp-configuration-files.rst
+++ b/source/includes/fact-snmp-configuration-files.rst
@@ -1,5 +1,3 @@
-.. versionchanged:: 2.6
-
 MongoDB Enterprise contains the following configuration files to
 support SNMP:
 

--- a/source/includes/fact-update-field-order.rst
+++ b/source/includes/fact-update-field-order.rst
@@ -7,9 +7,3 @@ operations *except* for the following cases:
 
 - Updates that include :update:`renaming <$rename>` of field names may
   result in the reordering of fields in the document.
-
-.. versionchanged:: 2.6
-
-   Starting in version 2.6, MongoDB actively attempts to preserve the
-   field order in a document. Before version 2.6, MongoDB did not
-   actively preserve the order of the fields in a document.

--- a/source/includes/note-deb-and-rpm-default-to-localhost.rst
+++ b/source/includes/note-deb-and-rpm-default-to-localhost.rst
@@ -1,9 +1,8 @@
 .. .. |mongodb-package| should be replaced with the binary name in other source
    files (mongod or mongos)
 
-.. versionadded:: 2.6
-   |mongodb-package| installed from official :doc:`.deb
-   </tutorial/install-mongodb-on-debian>` and :doc:`.rpm
-   </tutorial/install-mongodb-on-red-hat>` packages
-   have the :setting:`bind_ip` configuration set to ``127.0.0.1`` by
-   default.
+|mongodb-package| installed from official :doc:`.deb
+</tutorial/install-mongodb-on-debian>` and :doc:`.rpm
+</tutorial/install-mongodb-on-red-hat>` packages
+have the :setting:`bind_ip` configuration set to ``127.0.0.1`` by
+default.

--- a/source/includes/note-max-conns-max.rst
+++ b/source/includes/note-max-conns-max.rst
@@ -1,5 +1,0 @@
-.. note::
-
-   .. versionchanged:: 2.6
-      MongoDB removed the upward limit on the :setting:`~net.maxIncomingConnections`
-      setting.

--- a/source/indexes.txt
+++ b/source/indexes.txt
@@ -285,8 +285,6 @@ For more information on covered queries, see
 Index Intersection
 ------------------
 
-.. versionadded:: 2.6
-
 MongoDB can use the :doc:`intersection of indexes
 </core/index-intersection>` to fulfill queries. For queries that
 specify compound query conditions, if one index can fulfill a part of a

--- a/source/reference/built-in-roles.txt
+++ b/source/reference/built-in-roles.txt
@@ -115,13 +115,6 @@ Every database includes the following database administration roles:
    - :authaction:`dropCollection` and :authaction:`createCollection`
      on :data:`system.profile <<database>.system.profile>` *only*
 
-   .. versionchanged:: 2.6.4
-      :authrole:`dbAdmin` added the :authaction:`createCollection`
-      action for the :data:`system.profile <<database>.system.profile>`
-      collection. Previous versions only had the
-      :authaction:`dropCollection` action on the :data:`system.profile
-      <<database>.system.profile>` collection.
-
    Provides the following actions on all *non*-system
    collections. This role *does not* include full read access on non-system collections:
 

--- a/source/reference/command/cleanupOrphaned.txt
+++ b/source/reference/command/cleanupOrphaned.txt
@@ -15,8 +15,6 @@ Definition
 
 .. dbcommand:: cleanupOrphaned
 
-   .. versionadded:: 2.6
-
    Deletes from a shard the :term:`orphaned documents <orphaned
    document>` whose shard key values fall into a single or a single
    contiguous range that do not belong to the shard. For example, if

--- a/source/reference/command/compact.txt
+++ b/source/reference/command/compact.txt
@@ -218,7 +218,5 @@ command will attempt to compact the collection.
 Index Building
 ~~~~~~~~~~~~~~
 
-.. versionadded:: 2.6
-
 :binary:`~bin.mongod` rebuilds all indexes in parallel following the
 :dbcommand:`compact` operation.

--- a/source/reference/command/count.txt
+++ b/source/reference/command/count.txt
@@ -96,10 +96,7 @@ Definition
    
         - Optional. The index to use. Specify either the index name as a string or the
           index specification document.
-          
-          .. versionadded:: 2.6
-          
-          
+
    
       * - ``readConcern``
    

--- a/source/reference/command/createIndexes.txt
+++ b/source/reference/command/createIndexes.txt
@@ -230,28 +230,26 @@ Definition
           field. These indexes use less space but behave differently in some
           situations (particularly sorts). The default value is ``false``.
           See :doc:`/core/index-sparse` for more information.
-          
+
+          The following index types are sparse by default and ignore
+          this option:
+
+          - :doc:`2dsphere </core/2dsphere>`
+          - :doc:`2d </core/2d>`
+          - :doc:`geoHaystack </core/geohaystack>`
+          - :doc:`text </core/index-text>`
+
+          For a compound index that includes ``2dsphere`` index key(s)
+          along with keys of other types, only the ``2dsphere`` index
+          fields determine whether the index references a document.
+
           .. versionchanged:: 3.2 
-          
+
              Starting in MongoDB 3.2, MongoDB provides the option to create
              :ref:`partial indexes <index-type-partial>`. Partial indexes
              offer a superset of the functionality of sparse indexes. If you
              are using MongoDB 3.2 or later, :ref:`partial indexes
              <index-type-partial>` should be preferred over sparse indexes.
-          
-          .. versionchanged:: 2.6
-          
-             :doc:`2dsphere </core/2dsphere>` indexes are sparse by default and
-             ignore this option. For a compound index that includes
-             ``2dsphere`` index key(s) along with keys of other types, only the
-             ``2dsphere`` index fields determine whether the index references a
-             document.
-          
-             :doc:`2d </core/2d>`, :doc:`geoHaystack </core/geohaystack>`, and
-             :doc:`text </core/index-text>` indexes behave similarly to the
-             :doc:`2dsphere </core/2dsphere>` indexes.
-          
-          
    
       * - ``expireAfterSeconds``
    
@@ -333,11 +331,8 @@ Definition
           override the default version number.
           
           For available versions, see :ref:`text-versions`.
-          
-          .. versionadded:: 2.6
-          
-          
-   
+
+
       * - ``2dsphereIndexVersion``
    
         - integer
@@ -346,10 +341,7 @@ Definition
           override the default version number.
           
           For the available versions, see :ref:`2dsphere-v2`.
-          
-          .. versionadded:: 2.6
-          
-          
+
    
       * - ``bits``
    

--- a/source/reference/command/delete.txt
+++ b/source/reference/command/delete.txt
@@ -15,8 +15,6 @@ Definition
 
 .. dbcommand:: delete
 
-   .. versionadded:: 2.6
-
    The :dbcommand:`delete` command removes documents from a collection.
    A single :dbcommand:`delete` command can contain multiple delete
    specifications. The command cannot operate on :doc:`capped

--- a/source/reference/command/getLastError.txt
+++ b/source/reference/command/getLastError.txt
@@ -111,8 +111,6 @@ subset of the fields listed below.
 
 .. data:: getLastError.errmsg
 
-   .. versionadded:: 2.6
-
    :data:`~getLastError.errmsg` contains the description of the error.
    :data:`~getLastError.errmsg` only appears if there was an error with
    the preceding operation.
@@ -184,11 +182,6 @@ subset of the fields listed below.
 
    If the update results in an insert, :data:`~getLastError.upserted`
    is the value of ``_id`` field of the document.
-
-   .. versionchanged:: 2.6
-      Earlier versions of MongoDB included
-      :data:`~getLastError.upserted` only if ``_id`` was an
-      :term:`ObjectId <objectid>`.
 
 .. data:: getLastError.wnote
 

--- a/source/reference/command/insert.txt
+++ b/source/reference/command/insert.txt
@@ -15,8 +15,6 @@ Definition
 
 .. dbcommand:: insert
 
-   .. versionadded:: 2.6
-
    The :dbcommand:`insert` command inserts one or more documents and
    returns a document containing the status of all inserts. The insert
    methods provided by the MongoDB drivers use this command internally.

--- a/source/reference/command/invalidateUserCache.txt
+++ b/source/reference/command/invalidateUserCache.txt
@@ -15,8 +15,6 @@ Definition
 
 .. dbcommand:: invalidateUserCache
 
-   .. versionadded:: 2.6
-
    Flushes user information from in-memory cache, including removal of each user's
    credentials and roles. This allows you to purge the cache
    at any given moment, regardless of the

--- a/source/reference/command/isMaster.txt
+++ b/source/reference/command/isMaster.txt
@@ -134,8 +134,6 @@ roles:
 
 .. data:: isMaster.minWireVersion
 
-   .. versionadded:: 2.6
-
    The earliest version of the wire protocol that this
    :binary:`~bin.mongod` or :binary:`~bin.mongos` instance is capable of using
    to communicate with clients.
@@ -144,8 +142,6 @@ roles:
    compatibility with MongoDB.
 
 .. data:: isMaster.maxWireVersion
-
-   .. versionadded:: 2.6
 
    The latest version of the wire protocol that this :binary:`~bin.mongod`
    or :binary:`~bin.mongos` instance is capable of using to communicate
@@ -254,8 +250,6 @@ of a replica set:
    The name of the current :replica set.
 
 .. data:: isMaster.setVersion
-
-   .. versionadded:: 2.6
 
    The current replica set config version.
 

--- a/source/reference/command/planCacheClear.txt
+++ b/source/reference/command/planCacheClear.txt
@@ -15,8 +15,6 @@ Definition
 
 .. dbcommand:: planCacheClear
 
-   .. versionadded:: 2.6
-
    Removes cached query plans for a collection. Specify a :term:`query
    shape` to remove cached query plans for that shape. Omit the query
    shape to clear all cached query plans.

--- a/source/reference/command/planCacheClearFilters.txt
+++ b/source/reference/command/planCacheClearFilters.txt
@@ -15,8 +15,6 @@ Definition
 
 .. dbcommand:: planCacheClearFilters
 
-   .. versionadded:: 2.6
-
    Removes :ref:`index filters <index-filters>` on a collection.
    Although index filters only exist for the duration of the server
    process and do not persist after shutdown, you can also clear

--- a/source/reference/command/planCacheListFilters.txt
+++ b/source/reference/command/planCacheListFilters.txt
@@ -15,8 +15,6 @@ Definition
 
 .. dbcommand:: planCacheListFilters
 
-   .. versionadded:: 2.6
-
    Lists the :ref:`index filters <index-filters>` associated with
    :term:`query shapes <query shape>` for a collection.
 

--- a/source/reference/command/planCacheSetFilter.txt
+++ b/source/reference/command/planCacheSetFilter.txt
@@ -15,8 +15,6 @@ Definition
 
 .. dbcommand:: planCacheSetFilter
 
-   .. versionadded:: 2.6
-
    Set an :ref:`index filter <index-filters>` for a collection. If
    an index filter already exists for the :term:`query shape`, the
    command overrides the previous index filter.

--- a/source/reference/command/serverStatus.txt
+++ b/source/reference/command/serverStatus.txt
@@ -3279,13 +3279,9 @@ metrics
 
 .. serverstatus:: metrics.cursor
 
-   .. versionadded:: 2.6
-
    A document that contains data regarding cursor state and use.
 
 .. serverstatus:: metrics.cursor.timedOut
-
-   .. versionadded:: 2.6
 
    The total number of cursors that have timed out since the server
    process started. If this number is large or growing at a regular
@@ -3293,13 +3289,9 @@ metrics
 
 .. serverstatus:: metrics.cursor.open
 
-   .. versionadded:: 2.6
-
    A document that contains data regarding open cursors.
 
 .. serverstatus:: metrics.cursor.open.noTimeout
-
-   .. versionadded:: 2.6
 
    The number of open cursors with the option
    :data:`DBQuery.Option.noTimeout` set to prevent timeout after a
@@ -3307,13 +3299,9 @@ metrics
 
 .. serverstatus:: metrics.cursor.open.pinned
 
-   .. versionadded:: 2.6
-
    The number of "pinned" open cursors.
 
 .. serverstatus:: metrics.cursor.open.total
-
-   .. versionadded:: 2.6
 
    The number of cursors that MongoDB is maintaining for clients.
    Because MongoDB exhausts unused cursors, typically this value small

--- a/source/reference/configuration-options.txt
+++ b/source/reference/configuration-options.txt
@@ -46,13 +46,6 @@ explain the server's settings.
 File Format
 ~~~~~~~~~~~
 
-.. versionchanged:: 2.6
-
-   MongoDB 2.6 introduced a YAML-based configuration file format.
-   The :v2.4:`2.4 configuration file format
-   </reference/configuration-options>` remains for backward
-   compatibility.
-
 MongoDB configuration files use the `YAML <http://www.yaml.org>`_ format
 [#yaml-json]_.
 
@@ -1597,9 +1590,7 @@ Core Options
    *Type*: string
 
    .. deprecated:: 4.2 Use :setting:`net.tls.mode` instead.
-   
-   .. versionadded:: 2.6
-   
+
    Enables TLS/SSL or mixed TLS/SSL used for all network connections. The
    argument to the :setting:`net.ssl.mode` setting can be one of the following:
    
@@ -1768,9 +1759,7 @@ Core Options
    *Type*: string
 
    .. deprecated:: 4.2 Use :setting:`net.tls.clusterPassword` instead.
-   
-   .. versionadded:: 2.6
-   
+
    The password to de-crypt the x.509 certificate-key file
    specified with ``--sslClusterFile``. Use the :setting:`net.ssl.clusterPassword` option only
    if the certificate-key file is encrypted. In all cases, the :binary:`~bin.mongos` or :binary:`~bin.mongod`
@@ -2116,8 +2105,6 @@ Core Options
 
    *Default*: keyFile
 
-   .. versionadded:: 2.6
-   
    The authentication mode used for cluster authentication. If you use
    :ref:`internal x.509 authentication <x509-internal-authentication>`,
    specify so here. This option can have one of the following values:
@@ -3852,8 +3839,6 @@ LDAP Parameters
 .. setting:: auditLog.destination
 
    *Type*: string
-
-   .. versionadded:: 2.6
    
    When set, :setting:`auditLog.destination` enables :doc:`auditing </core/auditing>` and
    specifies where :binary:`~bin.mongos` or :binary:`~bin.mongod` sends all audit events.
@@ -3894,8 +3879,6 @@ LDAP Parameters
 .. setting:: auditLog.format
 
    *Type*: string
-
-   .. versionadded:: 2.6
    
    The format of the output file for :doc:`auditing
    </core/auditing>` if :setting:`~auditLog.destination` is ``file``. The
@@ -3928,8 +3911,6 @@ LDAP Parameters
 .. setting:: auditLog.path
 
    *Type*: string
-
-   .. versionadded:: 2.6
    
    The output file for :doc:`auditing </core/auditing>` if
    :setting:`~auditLog.destination` has value of ``file``. The :setting:`auditLog.path`
@@ -3941,8 +3922,6 @@ LDAP Parameters
 .. setting:: auditLog.filter
 
    *Type*: string representation of a document
-
-   .. versionadded:: 2.6
    
    The filter to limit the :ref:`types of operations
    <audit-action-details-results>` the :doc:`audit system

--- a/source/reference/database-profiler.txt
+++ b/source/reference/database-profiler.txt
@@ -365,14 +365,10 @@ operation.
 
 .. data:: system.profile.nMatched
 
-   .. versionadded:: 2.6
-
    The number of documents that match the :data:`system.profile.query`
    condition for the update operation.
 
 .. data:: system.profile.nModified
-
-   .. versionadded:: 2.6
 
    The number of documents modified by the update operation.
 

--- a/source/reference/geojson.txt
+++ b/source/reference/geojson.txt
@@ -109,8 +109,7 @@ The following example represents a GeoJSON polygon with an interior ring:
 ``MultiPoint``
 --------------
 
-.. versionadded:: 2.6
-   Requires :ref:`2dsphere-v2`
+Requires :ref:`2dsphere-v2`
 
 GeoJSON `MultiPoint <https://tools.ietf.org/html/rfc7946#section-3.1.3>`_
 embedded documents encode a list of points.
@@ -132,8 +131,7 @@ embedded documents encode a list of points.
 ``MultiLineString``
 -------------------
 
-.. versionadded:: 2.6
-   Requires :ref:`2dsphere-v2`
+Requires :ref:`2dsphere-v2`
 
 The following example specifies a GeoJSON `MultiLineString
 <https://tools.ietf.org/html/rfc7946#section-3.1.5>`_:
@@ -155,8 +153,7 @@ The following example specifies a GeoJSON `MultiLineString
 ``MultiPolygon``
 ----------------
 
-.. versionadded:: 2.6
-   Requires :ref:`2dsphere-v2`
+Requires :ref:`2dsphere-v2`
 
 The following example specifies a GeoJSON `MultiPolygon
 <https://tools.ietf.org/html/rfc7946#section-3.1.7>`_:
@@ -176,8 +173,7 @@ The following example specifies a GeoJSON `MultiPolygon
 ``GeometryCollection``
 ----------------------
 
-.. versionadded:: 2.6
-   Requires :ref:`2dsphere-v2`
+Requires :ref:`2dsphere-v2`
 
 The following example stores coordinates of GeoJSON type
 `GeometryCollection

--- a/source/reference/limits.txt
+++ b/source/reference/limits.txt
@@ -243,8 +243,6 @@ Replica Sets
 
 .. limit:: Maximum Size of Auto-Created Oplog
 
-   .. versionchanged:: 2.6
-
    If you do not explicitly specify an oplog size (i.e. with
    :setting:`~replication.oplogSizeMB` or :option:`--oplogSize
    <mongod --oplogSize>`) MongoDB will create an oplog that is no

--- a/source/reference/method/Bulk.execute.txt
+++ b/source/reference/method/Bulk.execute.txt
@@ -17,8 +17,6 @@ Description
 
 .. method:: Bulk.execute()
 
-   .. versionadded:: 2.6
-
    Executes the list of operations built by the :method:`Bulk()`
    operations builder.
 

--- a/source/reference/method/Bulk.find.remove.txt
+++ b/source/reference/method/Bulk.find.remove.txt
@@ -17,8 +17,6 @@ Description
 
 .. method:: Bulk.find.remove()
 
-   .. versionadded:: 2.6
-
    Adds a remove operation to a bulk operations list. Use the
    :method:`Bulk.find()` method to specify the condition that
    determines which documents to remove. The

--- a/source/reference/method/Bulk.find.removeOne.txt
+++ b/source/reference/method/Bulk.find.removeOne.txt
@@ -17,8 +17,6 @@ Description
 
 .. method:: Bulk.find.removeOne()
 
-   .. versionadded:: 2.6
-
    Adds a single document remove operation to a bulk operations list.
    Use the :method:`Bulk.find()` method to specify the condition that
    determines which document to remove. The

--- a/source/reference/method/Bulk.find.replaceOne.txt
+++ b/source/reference/method/Bulk.find.replaceOne.txt
@@ -17,8 +17,6 @@ Description
 
 .. method:: Bulk.find.replaceOne(<document>)
 
-   .. versionadded:: 2.6
-
    Adds a single document replacement operation to a bulk operations
    list. Use the :method:`Bulk.find()` method to specify the condition
    that determines which document to replace. The

--- a/source/reference/method/Bulk.find.txt
+++ b/source/reference/method/Bulk.find.txt
@@ -17,8 +17,6 @@ Description
 
 .. method:: Bulk.find(<query>)
 
-   .. versionadded:: 2.6
-
    Specifies a query condition for an update or a remove operation.
 
    :method:`Bulk.find()` accepts the following parameter:

--- a/source/reference/method/Bulk.find.update.txt
+++ b/source/reference/method/Bulk.find.update.txt
@@ -17,8 +17,6 @@ Description
 
 .. method:: Bulk.find.update(<update>)
 
-   .. versionadded:: 2.6
-
    Adds a ``multi`` update operation to a bulk operations list. The
    method updates specific fields in existing documents.
 

--- a/source/reference/method/Bulk.find.updateOne.txt
+++ b/source/reference/method/Bulk.find.updateOne.txt
@@ -17,8 +17,6 @@ Description
 
 .. method:: Bulk.find.updateOne(<update>)
 
-   .. versionadded:: 2.6
-
    Adds a single document update operation to a bulk operations list.
 
    Use the :method:`Bulk.find()` method to specify the condition that

--- a/source/reference/method/Bulk.find.upsert.txt
+++ b/source/reference/method/Bulk.find.upsert.txt
@@ -17,8 +17,6 @@ Description
 
 .. method:: Bulk.find.upsert()
 
-   .. versionadded:: 2.6
-
    Sets the :term:`upsert` option to true for an update or a
    replacement operation and has the following syntax:
 

--- a/source/reference/method/Bulk.getOperations.txt
+++ b/source/reference/method/Bulk.getOperations.txt
@@ -12,8 +12,6 @@ Bulk.getOperations()
 
 .. method:: Bulk.getOperations()
 
-   .. versionadded:: 2.6
-
    Returns an array of write operations executed through
    :method:`Bulk.execute()`. The returned write operations are in
    groups as determined by MongoDB for execution. For information on

--- a/source/reference/method/Bulk.insert.txt
+++ b/source/reference/method/Bulk.insert.txt
@@ -17,8 +17,6 @@ Description
 
 .. method:: Bulk.insert(<document>)
 
-   .. versionadded:: 2.6
-
    Adds an insert operation to a bulk operations list.
 
    :method:`Bulk.insert()` accepts the following parameter:

--- a/source/reference/method/Bulk.toString.txt
+++ b/source/reference/method/Bulk.toString.txt
@@ -12,8 +12,6 @@ Bulk.toString()
 
 .. method:: Bulk.toString()
 
-   .. versionadded:: 2.6
-
    Returns as a string a JSON document that contains the number of
    operations and batches in the :method:`Bulk()` object.
 

--- a/source/reference/method/Bulk.tojson.txt
+++ b/source/reference/method/Bulk.tojson.txt
@@ -12,8 +12,6 @@ Bulk.tojson()
 
 .. method:: Bulk.tojson()
 
-   .. versionadded:: 2.6
-
    Returns a JSON document that contains the number of operations and
    batches in the :method:`Bulk()` object.
 

--- a/source/reference/method/Bulk.txt
+++ b/source/reference/method/Bulk.txt
@@ -17,8 +17,6 @@ Description
 
 .. method:: Bulk()
 
-   .. versionadded:: 2.6
-
    Bulk operations builder used to construct a list of write operations
    to perform in bulk for a single collection. To instantiate the
    builder, use either the

--- a/source/reference/method/BulkWriteResult.txt
+++ b/source/reference/method/BulkWriteResult.txt
@@ -12,8 +12,6 @@ BulkWriteResult()
 
 .. method:: BulkWriteResult()
 
-   .. versionadded:: 2.6
-
    A wrapper that contains the results of the :method:`Bulk.execute()`
    method.
 

--- a/source/reference/method/cursor.maxTimeMS.txt
+++ b/source/reference/method/cursor.maxTimeMS.txt
@@ -13,8 +13,6 @@ cursor.maxTimeMS()
 Definition
 ----------
 
-.. versionadded:: 2.6
-
 .. method:: cursor.maxTimeMS(<time limit>)
 
 

--- a/source/reference/method/db.aggregate.txt
+++ b/source/reference/method/db.aggregate.txt
@@ -76,10 +76,7 @@ Definition
           - Optional. Specifies the *initial* batch size for the cursor. The value of the ``cursor``
             field is a document with the field ``batchSize``. See
             :ref:`example-aggregate-method-initial-batch-size` for syntax and example.
-            
-            .. versionadded:: 2.6
-            
-            
+
      
         * - ``maxTimeMS``
      

--- a/source/reference/method/db.collection.aggregate.txt
+++ b/source/reference/method/db.collection.aggregate.txt
@@ -40,11 +40,10 @@ Definition
           :doc:`aggregation pipeline operators
           </reference/operator/aggregation-pipeline>` for details.
           
-          .. versionchanged:: 2.6
-             The method can still accept the pipeline stages as separate
-             arguments instead of as elements in an array; however, if you do
-             not specify the ``pipeline`` as an array, you cannot specify the
-             ``options`` parameter.
+          The method can still accept the pipeline stages as separate
+          arguments instead of as elements in an array; however, if you do
+          not specify the ``pipeline`` as an array, you cannot specify the
+          ``options`` parameter.
           
           
    
@@ -53,10 +52,8 @@ Definition
         - document
    
         - Optional. Additional options that :method:`~db.collection.aggregate()` passes
-          to the :dbcommand:`aggregate` command.
-          
-          .. versionadded:: 2.6
-             Available only if you specify the ``pipeline`` as an array.
+          to the :dbcommand:`aggregate` command. Available only if you
+          specify the ``pipeline`` as an array.
           
           
    
@@ -106,10 +103,7 @@ Definition
         - Optional. Specifies the *initial* batch size for the cursor. The value of the ``cursor``
           field is a document with the field ``batchSize``. See
           :ref:`example-aggregate-method-initial-batch-size` for syntax and example.
-          
-          .. versionadded:: 2.6
-          
-          
+
    
       * - ``maxTimeMS``
    
@@ -223,8 +217,6 @@ Definition
       If the pipeline includes the :pipeline:`$out` operator,
       :method:`~db.collection.aggregate()` returns an empty cursor. See
       :pipeline:`$out` for more information.
-
-      .. include:: /includes/fact-agg-helper-returns-cursor.rst
 
 Behavior
 --------

--- a/source/reference/method/db.collection.count.txt
+++ b/source/reference/method/db.collection.count.txt
@@ -114,10 +114,8 @@ Definition
         - string or document
    
         - Optional. An index name hint or specification for the query.
-          
-          .. versionadded:: 2.6
-          
-          
+
+
    
       * - ``maxTimeMS``
    

--- a/source/reference/method/db.collection.createIndex.txt
+++ b/source/reference/method/db.collection.createIndex.txt
@@ -227,7 +227,19 @@ otherwise specified:
        field. These indexes use less space but behave differently in some
        situations (particularly sorts). The default value is ``false``.
        See :doc:`/core/index-sparse` for more information.
-       
+
+       The following index types are sparse by default and ignore
+       this option:
+
+       - :doc:`2dsphere </core/2dsphere>`
+       - :doc:`2d </core/2d>`
+       - :doc:`geoHaystack </core/geohaystack>`
+       - :doc:`text </core/index-text>`
+
+       For a compound index that includes ``2dsphere`` index key(s)
+       along with keys of other types, only the ``2dsphere`` index
+       fields determine whether the index references a document.
+
        .. versionchanged:: 3.2 
        
           Starting in MongoDB 3.2, MongoDB provides the option to create
@@ -235,20 +247,6 @@ otherwise specified:
           offer a superset of the functionality of sparse indexes. If you
           are using MongoDB 3.2 or later, :ref:`partial indexes
           <index-type-partial>` should be preferred over sparse indexes.
-       
-       .. versionchanged:: 2.6
-       
-          :doc:`2dsphere </core/2dsphere>` indexes are sparse by default and
-          ignore this option. For a compound index that includes
-          ``2dsphere`` index key(s) along with keys of other types, only the
-          ``2dsphere`` index fields determine whether the index references a
-          document.
-       
-          :doc:`2d </core/2d>`, :doc:`geoHaystack </core/geohaystack>`, and
-          :doc:`text </core/index-text>` indexes behave similarly to the
-          :doc:`2dsphere </core/2dsphere>` indexes.
-       
-       
 
    * - ``expireAfterSeconds``
 
@@ -404,9 +402,7 @@ indexes only:
        override the default version number.
        
        For available versions, see :ref:`text-versions`.
-       
-       .. versionadded:: 2.6
-       
+
        
 
 
@@ -436,9 +432,6 @@ indexes only:
        override the default version number.
        
        For the available versions, see :ref:`2dsphere-v2`.
-       
-       .. versionadded:: 2.6
-       
        
 
 

--- a/source/reference/method/db.collection.createIndexes.txt
+++ b/source/reference/method/db.collection.createIndexes.txt
@@ -239,7 +239,19 @@ otherwise specified:
        fields. These indexes use less space but behave differently in some
        situations (particularly sorts). The default value is ``false``.
        See :doc:`/core/index-sparse` for more information.
-       
+
+       The following index types are sparse by default and ignore
+       this option:
+
+       - :doc:`2dsphere </core/2dsphere>`
+       - :doc:`2d </core/2d>`
+       - :doc:`geoHaystack </core/geohaystack>`
+       - :doc:`text </core/index-text>`
+
+       For a compound index that includes ``2dsphere`` index key(s)
+       along with keys of other types, only the ``2dsphere`` index
+       fields determine whether the index references a document.
+
        .. versionchanged:: 3.2 
        
           Starting in MongoDB 3.2, MongoDB provides the option to create
@@ -247,20 +259,6 @@ otherwise specified:
           offer a superset of the functionality of sparse indexes. If you
           are using MongoDB 3.2 or later, :ref:`partial indexes
           <index-type-partial>` should be preferred over sparse indexes.
-       
-       .. versionchanged:: 2.6
-       
-          :doc:`2dsphere </core/2dsphere>` indexes are sparse by default and
-          ignore this option. For a compound index that includes
-          ``2dsphere`` index key(s) along with keys of other types, only the
-          ``2dsphere`` index fields determine whether the index references a
-          document.
-       
-          :doc:`2d </core/2d>`, :doc:`geoHaystack </core/geohaystack>`, and
-          :doc:`text </core/index-text>` indexes behave similarly to the
-          :doc:`2dsphere </core/2dsphere>` indexes.
-       
-       
 
    * - ``expireAfterSeconds``
 
@@ -404,11 +402,6 @@ indexes only:
        override the default version number.
        
        For available versions, see :ref:`text-versions`.
-       
-       .. versionadded:: 2.6
-       
-       
-
 
 
 Options for ``2dsphere`` Indexes
@@ -436,11 +429,6 @@ indexes only:
        override the default version number.
        
        For the available versions, see :ref:`2dsphere-v2`.
-       
-       .. versionadded:: 2.6
-       
-       
-
 
 
 Options for ``2d`` Indexes

--- a/source/reference/method/db.collection.initializeUnorderedBulkOp.txt
+++ b/source/reference/method/db.collection.initializeUnorderedBulkOp.txt
@@ -20,9 +20,6 @@ Definition
 
    .. include:: /includes/fact-mongo-shell-method.rst
 
-
-   .. versionadded:: 2.6
-
    Initializes and returns a new :method:`Bulk()` operations builder
    for a collection. The builder constructs an *unordered* list of
    write operations that MongoDB executes in bulk.

--- a/source/reference/method/db.collection.insert.txt
+++ b/source/reference/method/db.collection.insert.txt
@@ -24,8 +24,6 @@ Definition
    The :method:`~db.collection.insert()` method has the following
    syntax:
 
-   .. versionchanged:: 2.6
-
    .. code-block:: none
 
       db.collection.insert(
@@ -80,16 +78,10 @@ Definition
           in the array.
           
           Defaults to ``true``.
-          
-          .. versionadded:: 2.6
-          
-          
-   
 
 
-   .. versionchanged:: 2.6
-      The :method:`~db.collection.insert()` returns an object that
-      contains the status of the operation.
+   The :method:`~db.collection.insert()` returns an object that
+   contains the status of the operation.
 
    :returns:
       - A :ref:`writeresults-insert` object for single inserts.
@@ -103,8 +95,6 @@ Behaviors
 
 Write Concern
 ~~~~~~~~~~~~~
-
-.. versionchanged:: 2.6
 
 The :method:`~db.collection.insert()` method uses the
 :dbcommand:`insert` command, which uses the default :doc:`write concern
@@ -268,8 +258,6 @@ the method times out after 5 seconds.
 WriteResult
 -----------
 
-.. versionchanged:: 2.6
-
 When passed a single document, :method:`~db.collection.insert()`
 returns a ``WriteResult`` object.
 
@@ -323,8 +311,6 @@ field:
 
 BulkWriteResult
 ---------------
-
-.. versionchanged:: 2.6
 
 When passed an array of documents, :method:`~db.collection.insert()`
 returns a :method:`BulkWriteResult()` object. See

--- a/source/reference/method/db.collection.remove.txt
+++ b/source/reference/method/db.collection.remove.txt
@@ -35,8 +35,6 @@ Definition
    Or the method can take a query document and an optional remove
    options document:
 
-   .. versionadded:: 2.6
-
    .. code-block:: javascript
 
       db.collection.remove(
@@ -66,13 +64,7 @@ Definition
         - Specifies deletion criteria using :doc:`query operators
           </reference/operator>`. To delete all documents in a collection,
           pass an empty document (``{}``).
-          
-          .. versionchanged:: 2.6
-             In previous versions, the method invoked with no query parameter
-             deleted all documents in a collection.
-          
-          
-   
+
       * - ``justOne``
    
         - boolean
@@ -102,14 +94,9 @@ Definition
         - Optional. 
           
           .. include:: /includes/extracts/collation-option.rst
-          
-          
-   
 
-
-   .. versionchanged:: 2.6
-      The :method:`~db.collection.remove()` returns an object that
-      contains the status of the operation.
+   The :method:`~db.collection.remove()` returns an object that
+   contains the status of the operation.
 
    :returns: A :ref:`writeresults-remove` object that contains the
       status of the operation.
@@ -121,8 +108,6 @@ Behavior
 
 Write Concern
 ~~~~~~~~~~~~~
-
-.. versionchanged:: 2.6
 
 The :method:`~db.collection.remove()` method uses the
 :dbcommand:`delete` command, which uses the default :doc:`write concern
@@ -265,8 +250,6 @@ option:
 
 WriteResult
 -----------
-
-.. versionchanged:: 2.6
 
 Successful Results
 ~~~~~~~~~~~~~~~~~~

--- a/source/reference/method/db.collection.save.txt
+++ b/source/reference/method/db.collection.save.txt
@@ -67,14 +67,9 @@ Definition
           See :ref:`save-wc`.
           
           .. include:: /includes/extracts/transactions-operations-write-concern.rst
-          
-          
-   
 
-
-   .. versionchanged:: 2.6
-      The :method:`~db.collection.save()` returns an object that
-      contains the status of the operation.
+   The :method:`~db.collection.save()` returns an object that
+   contains the status of the operation.
 
    :returns: A :ref:`writeresults-save` object that contains the
       status of the operation.
@@ -86,8 +81,6 @@ Behavior
 
 Write Concern
 ~~~~~~~~~~~~~
-
-.. versionchanged:: 2.6
 
 The :method:`~db.collection.save()` method uses either the
 :dbcommand:`insert` or the :dbcommand:`update` command, which use the
@@ -228,8 +221,6 @@ the method times out after 5 seconds.
 
 WriteResult
 -----------
-
-.. versionchanged:: 2.6
 
 The :method:`~db.collection.save()` returns a :method:`WriteResult`
 object that contains the status of the insert or update operation. See

--- a/source/reference/method/db.collection.update.txt
+++ b/source/reference/method/db.collection.update.txt
@@ -1422,8 +1422,6 @@ After the operation, the collection contains the following documents:
 WriteResult
 -----------
 
-.. versionchanged:: 2.6
-
 Successful Results
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/reference/method/js-bulk.txt
+++ b/source/reference/method/js-bulk.txt
@@ -2,8 +2,6 @@
 Bulk Operation Methods
 ======================
 
-.. versionadded:: 2.6
-
 .. default-domain:: mongodb
 
 .. contents:: On this page

--- a/source/reference/method/rs.printReplicationInfo.txt
+++ b/source/reference/method/rs.printReplicationInfo.txt
@@ -15,8 +15,6 @@ Definition
 
 .. method:: rs.printReplicationInfo()
 
-   .. versionadded:: 2.6
-
    Prints a formatted report of the replica set member's :term:`oplog`.
    The displayed report formats the data returned by
    :method:`db.getReplicationInfo()`.  The output of

--- a/source/reference/mongo-shell.txt
+++ b/source/reference/mongo-shell.txt
@@ -461,17 +461,10 @@ operators.
 Error Checking Methods
 ----------------------
 
-.. versionchanged:: 2.6
-
-The :binary:`~bin.mongo` shell write methods now integrates the
-:doc:`/reference/write-concern` directly into the method execution rather
-than with a separate :method:`db.getLastError()` method. As such, the
-write methods now return a :method:`WriteResult()` object that
-contains the results of the operation, including any write errors and
-write concern errors.
-
-Previous versions used :method:`db.getLastError()` and
-:method:`db.getLastErrorObj()` methods to return error information.
+The :binary:`~bin.mongo` shell write method integrates the
+:doc:`/reference/write-concern` directly into the method execution, and
+returns a :method:`WriteResult()` object that contains the results of
+the operation, including any write errors and write concern errors.
 
 .. _mongo-dba-helpers:
 .. _mongo-shell-admin-helpers:

--- a/source/reference/mongodb-extended-json-v1.txt
+++ b/source/reference/mongodb-extended-json-v1.txt
@@ -417,8 +417,6 @@ MaxKey
 NumberLong
 ~~~~~~~~~~
 
-.. versionadded:: 2.6
-
 .. bsontype:: data_numberlong
 
    .. list-table::

--- a/source/reference/operator/aggregation/allElementsTrue.txt
+++ b/source/reference/operator/aggregation/allElementsTrue.txt
@@ -15,8 +15,6 @@ Definition
 
 .. expression:: $allElementsTrue
 
-   .. versionadded:: 2.6
-
    Evaluates an array as a set and returns ``true`` if *no* element in
    the array is ``false``. Otherwise, returns ``false``. An empty array
    returns ``true``.

--- a/source/reference/operator/aggregation/anyElementTrue.txt
+++ b/source/reference/operator/aggregation/anyElementTrue.txt
@@ -15,8 +15,6 @@ Definition
 
 .. expression:: $anyElementTrue
 
-   .. versionadded:: 2.6
-
    Evaluates an array as a set and returns ``true`` if any of the
    elements are ``true`` and ``false`` otherwise. An empty array
    returns ``false``.

--- a/source/reference/operator/aggregation/cond.txt
+++ b/source/reference/operator/aggregation/cond.txt
@@ -20,8 +20,6 @@ Definition
 
    The :expression:`$cond` expression has one of two syntaxes:
 
-   .. versionadded:: 2.6
-
    .. code-block:: javascript
 
       { $cond: { if: <boolean-expression>, then: <true-case>, else: <false-case> } }

--- a/source/reference/operator/aggregation/meta.txt
+++ b/source/reference/operator/aggregation/meta.txt
@@ -15,8 +15,6 @@ Definition
 
 .. expression:: $meta
 
-   .. versionadded:: 2.6
-
    Returns the metadata associated with a document in a pipeline
    operations, e.g. ``"textScore"`` when performing text search.
 

--- a/source/reference/operator/aggregation/out.txt
+++ b/source/reference/operator/aggregation/out.txt
@@ -12,8 +12,6 @@ $out (aggregation)
    :depth: 1
    :class: singlecol
 
-.. versionadded:: 2.6
-
 Definition
 ----------
 

--- a/source/reference/operator/aggregation/redact.txt
+++ b/source/reference/operator/aggregation/redact.txt
@@ -15,8 +15,6 @@ Definition
 
 .. pipeline:: $redact
 
-   .. versionadded:: 2.6
-
    Restricts the contents of the documents based on information stored
    in the documents themselves.
 

--- a/source/reference/operator/aggregation/setDifference.txt
+++ b/source/reference/operator/aggregation/setDifference.txt
@@ -15,8 +15,6 @@ Definition
 
 .. expression:: $setDifference
 
-   .. versionadded:: 2.6
-
    Takes two sets and returns an array containing the elements that
    only exist in the first set; i.e. performs a `relative complement
    <http://en.wikipedia.org/wiki/Complement_(set_theory)>`_ of the

--- a/source/reference/operator/aggregation/setEquals.txt
+++ b/source/reference/operator/aggregation/setEquals.txt
@@ -15,8 +15,6 @@ Definition
 
 .. expression:: $setEquals
 
-   .. versionadded:: 2.6
-
    Compares two or more arrays and returns ``true`` if they have the
    same distinct elements and ``false`` otherwise.
 

--- a/source/reference/operator/aggregation/setIntersection.txt
+++ b/source/reference/operator/aggregation/setIntersection.txt
@@ -15,8 +15,6 @@ Definition
 
 .. expression:: $setIntersection
 
-   .. versionadded:: 2.6
-
    Takes two or more arrays and returns an array that contains the
    elements that appear in every input array.
 

--- a/source/reference/operator/aggregation/setIsSubset.txt
+++ b/source/reference/operator/aggregation/setIsSubset.txt
@@ -15,8 +15,6 @@ Definition
 
 .. expression:: $setIsSubset
 
-   .. versionadded:: 2.6
-
    Takes two arrays and returns ``true`` when the first array is a
    subset of the second, including when the first array equals the
    second array, and ``false`` otherwise.

--- a/source/reference/operator/aggregation/setUnion.txt
+++ b/source/reference/operator/aggregation/setUnion.txt
@@ -15,8 +15,6 @@ Definition
 
 .. expression:: $setUnion
 
-   .. versionadded:: 2.6
-
    Takes two or more arrays and returns an array containing the
    elements that appear in any input array.
 

--- a/source/reference/operator/aggregation/size.txt
+++ b/source/reference/operator/aggregation/size.txt
@@ -10,8 +10,6 @@ $size (aggregation)
    :depth: 1
    :class: singlecol
 
-.. versionadded:: 2.6
-
 Definition
 ----------
 

--- a/source/reference/operator/meta/maxTimeMS.txt
+++ b/source/reference/operator/meta/maxTimeMS.txt
@@ -14,11 +14,10 @@ $maxTimeMS
 
    .. include:: /includes/extracts/mongo-shell-deprecated-meta-operator-maxTimeMS.rst
 
-   .. versionadded:: 2.6
-      The :operator:`$maxTimeMS` operator specifies a cumulative
-      time limit in milliseconds for processing operations on the
-      cursor. MongoDB interrupts the operation at the earliest
-      following :term:`interrupt point`.
+   The :operator:`$maxTimeMS` operator specifies a cumulative
+   time limit in milliseconds for processing operations on the
+   cursor. MongoDB interrupts the operation at the earliest
+   following :term:`interrupt point`.
 
    The :binary:`~bin.mongo` shell provides the :method:`cursor.maxTimeMS()` method
 

--- a/source/reference/operator/projection/meta.txt
+++ b/source/reference/operator/projection/meta.txt
@@ -14,8 +14,6 @@ $meta
 
 .. projection:: $meta
 
-   .. versionadded:: 2.6
-
    The :projection:`$meta` projection operator returns for each
    matching document the metadata (e.g. ``"textScore"``) associated
    with the query.

--- a/source/reference/operator/query/all.txt
+++ b/source/reference/operator/query/all.txt
@@ -28,8 +28,6 @@ Behavior
 Equivalent to ``$and`` Operation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionchanged:: 2.6
-
 The :query:`$all` is equivalent to an :query:`$and` operation of the
 specified values; i.e. the following statement:
 
@@ -46,10 +44,8 @@ is equivalent to:
 Nested Array
 ~~~~~~~~~~~~
 
-.. versionchanged:: 2.6
-
 When passed an array of a nested array (e.g. ``[ [ "A" ] ]`` ),
-:query:`$all` can now match documents where the field contains the
+:query:`$all` matches documents where the field contains the
 nested array as an element (e.g. ``field: [ [ "A" ], ... ]``), *or* the
 field equals the nested array (e.g. ``field: [ "A" ]``).
 
@@ -71,7 +67,7 @@ which is equivalent to:
 
    db.articles.find( { tags: [ "ssl", "security" ] } )
 
-As such, the :query:`$all` expression can match documents where the
+As such, the :query:`$all` expression matches documents where the
 ``tags`` field is an array that contains the nested array ``[ "ssl",
 "security" ]`` or is an array that equals the nested array:
 
@@ -79,10 +75,6 @@ As such, the :query:`$all` expression can match documents where the
 
    tags: [ [ "ssl", "security" ], ... ]
    tags: [ "ssl", "security" ]
-
-This behavior for :query:`$all` allows for more matches than previous
-versions of MongoDB. Earlier versions could only match documents where
-the field contains the nested array.
 
 .. [#illustrative]
    The :query:`$all` expression with a *single* element is for

--- a/source/reference/operator/query/in.txt
+++ b/source/reference/operator/query/in.txt
@@ -27,12 +27,6 @@ $in
    at least one element that matches a value in the specified array
    (e.g. ``<value1>``, ``<value2>``, etc.)
 
-   .. versionchanged:: 2.6
-
-      MongoDB 2.6 removes the combinatorial limit for the :query:`$in`
-      operator that exists for :v2.4:`earlier versions
-      </reference/operator/query/in>` of the operator.
-
 Examples
 --------
 

--- a/source/reference/operator/query/maxDistance.txt
+++ b/source/reference/operator/query/maxDistance.txt
@@ -19,11 +19,8 @@ Definition
    geospatial :query:`$near` or :query:`$nearSphere` query to the
    specified distance. The measuring units for the maximum distance are
    determined by the coordinate system in use. For :term:`GeoJSON` point
-   object, specify the distance in meters, not radians.
-
-   .. versionchanged:: 2.6
-
-      Specify a non-negative number for :query:`$maxDistance`.
+   objects, specify the distance in meters, not radians. You must
+   specify a non-negative number for :query:`$maxDistance`.
 
    The :doc:`2dsphere </core/2dsphere>` and :doc:`2d </core/2d>`
    geospatial indexes both support :query:`$maxDistance`: .

--- a/source/reference/operator/query/minDistance.txt
+++ b/source/reference/operator/query/minDistance.txt
@@ -15,8 +15,6 @@ Definition
 
 .. query:: $minDistance
 
-  .. versionadded:: 2.6
-
   Filters the results of a geospatial :query:`$near` or
   :query:`$nearSphere` query to those documents that are *at least* the
   specified distance from the center point.

--- a/source/reference/operator/query/mod.txt
+++ b/source/reference/operator/query/mod.txt
@@ -21,16 +21,9 @@ $mod
 
       { field: { $mod: [ divisor, remainder ] } }
 
-   .. versionchanged:: 2.6
-
-      The :query:`$mod` operator errors when passed an array with fewer
-      or more elements. In previous versions, if passed an array with
-      one element, the :query:`$mod` operator uses ``0`` as the
-      remainder value, and if passed an array with more than two
-      elements, the :query:`$mod` ignores all but the first two
-      elements. Previous versions do return an error when passed an
-      empty array. See :ref:`mod-not-enough-elements` and
-      :ref:`mod-too-many-elements` for details.
+   The :query:`$mod` operator errors when passed an array with fewer
+   or more than two elements. See :ref:`mod-not-enough-elements` and
+   :ref:`mod-too-many-elements` for details.
 
 Examples
 --------
@@ -88,11 +81,6 @@ The statement results in the following error:
     	"code" : 16810
    }
 
-.. versionchanged:: 2.6
-   In previous versions, if passed an array with one element, the
-   :query:`$mod` operator uses the specified element as the divisor
-   and ``0`` as the remainder value.
-
 Empty Array
 ```````````
 
@@ -112,14 +100,6 @@ The statement results in the following error:
     	"code" : 16810
    }
 
-.. versionchanged:: 2.6
-
-   Previous versions returned the following error:
-
-   .. code-block:: javascript
-
-      error: { "$err" : "mod can't be 0", "code" : 10073 }
-
 .. _mod-too-many-elements:
 
 Too Many Elements Error
@@ -137,9 +117,3 @@ operator with an array that contains four elements:
    	"$err" : "bad query: BadValue malformed mod, too many elements",
    	"code" : 16810
    }
-
-.. versionchanged:: 2.6
-
-   In previous versions, if passed an array with more than two
-   elements, the :query:`$mod` ignores all but the first two
-   elements.

--- a/source/reference/operator/query/near.txt
+++ b/source/reference/operator/query/near.txt
@@ -55,8 +55,6 @@ Definition
    - :query:`$minDistance` limits the results to those documents that
      are *at least* the specified distance from the center point.
 
-     .. versionadded:: 2.6
-
    - :query:`$maxDistance` limits the results to those documents that
      are *at most* the specified distance from the center point.
 

--- a/source/reference/operator/query/nearSphere.txt
+++ b/source/reference/operator/query/nearSphere.txt
@@ -52,8 +52,6 @@ Definition
      documents that are *at least* the specified distance from the
      center point.
 
-     .. versionadded:: 2.6
-
    - The *optional* :query:`$maxDistance` is available for either index.
 
    To specify a point using legacy coordinates, use the following
@@ -71,8 +69,6 @@ Definition
      query uses the :doc:`2dsphere </core/2dsphere>` index.
      :query:`$minDistance` limits the results to those documents that
      are *at least* the specified distance from the center point.
-
-     .. versionadded:: 2.6
 
    - The *optional* :query:`$maxDistance` is available for either index.
 

--- a/source/reference/operator/query/or.txt
+++ b/source/reference/operator/query/or.txt
@@ -69,8 +69,6 @@ index to support :query:`$or` clauses.
 ``$or`` and ``text`` Queries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionchanged:: 2.6
-
 If :query:`$or` includes a :query:`$text` query, all clauses in the
 :query:`$or` array must be supported by an index. This is because a
 :query:`$text` query *must* use an index, and :query:`$or` can only use
@@ -81,8 +79,6 @@ error.
 ``$or`` and GeoSpatial Queries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionchanged:: 2.6
-
 :operator:`$or` supports :doc:`geospatial clauses
 </reference/operator/query-geospatial>` with the following exception
 for the near clause (near clause includes :query:`$nearSphere` and
@@ -91,8 +87,6 @@ other clause.
 
 ``$or`` and Sort Operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. versionchanged:: 2.6
 
 When executing :query:`$or` queries with a :method:`~cursor.sort()`,
 MongoDB can now use indexes that support the :query:`$or` clauses.

--- a/source/reference/operator/update/mul.txt
+++ b/source/reference/operator/update/mul.txt
@@ -15,8 +15,6 @@ Definition
 
 .. update:: $mul
 
-   .. versionadded:: 2.6
-
    Multiply the value of a field by a number. To specify a
    :update:`$mul` expression, use the following prototype:
 

--- a/source/reference/operator/update/slice.txt
+++ b/source/reference/operator/update/slice.txt
@@ -55,8 +55,6 @@ $slice
         - To update the array ``<field>`` contain only the first ``<num>``
           elements.
 
-          .. versionadded:: 2.6
-
 Behavior
 --------
 

--- a/source/reference/parameters.txt
+++ b/source/reference/parameters.txt
@@ -80,8 +80,6 @@ Authentication Parameters
 
 .. parameter:: clusterAuthMode
 
-   .. versionadded:: 2.6
-
    |both|
 
    Set the :setting:`~security.clusterAuthMode` to either ``sendX509`` or
@@ -356,15 +354,13 @@ Authentication Parameters
    .. note::
 
       :parameter:`saslHostName` supports Kerberos authentication and is
-      only included in MongoDB Enterprise. For Linux systems, see
-      :doc:`/tutorial/control-access-to-mongodb-with-kerberos-authentication`
-      for more information.
+      only included in MongoDB Enterprise. For more information, see the
+      following:
 
-      .. COMMENT
-         .. versionadded:: 2.6
-            MongoDB Enterprise now supports Windows systems,
-            which includes support for Kerberos. See also
-            :doc:`/tutorial/control-access-to-mongodb-with-kerberos-authentication-under-windows`.
+      - Linux:
+        :doc:`/tutorial/control-access-to-mongodb-with-kerberos-authentication`
+      - Windows:
+        :doc:`/tutorial/control-access-to-mongodb-windows-with-kerberos-authentication`
 
 .. parameter:: saslServiceName
 
@@ -465,8 +461,6 @@ Authentication Parameters
       - :method:`db.updateUser()`
 
 .. parameter:: sslMode
-
-   .. versionadded:: 2.6
 
    |both|
 
@@ -656,8 +650,6 @@ General Parameters
 
 .. parameter:: connPoolMaxShardedConnsPerHost
 
-   .. versionadded:: 2.6
-
    *Default*: 200
 
    |both|
@@ -725,8 +717,6 @@ General Parameters
    .. seealso:: :parameter:`connPoolMaxShardedConnsPerHost`
 
 .. parameter:: connPoolMaxConnsPerHost
-
-   .. versionadded:: 2.6
 
    *Default*: 200
 
@@ -2657,8 +2647,6 @@ Auditing Parameters
 ~~~~~~~~~~~~~~~~~~~~
 
 .. parameter:: auditAuthorizationSuccess
-
-   .. versionadded:: 2.6.5
 
    *Default*: ``false``
 

--- a/source/reference/privilege-actions.txt
+++ b/source/reference/privilege-actions.txt
@@ -4,8 +4,6 @@
 Privilege Actions
 =================
 
-.. versionadded:: 2.6
-
 .. default-domain:: mongodb
 
 .. contents:: On this page

--- a/source/reference/program/mongo.txt
+++ b/source/reference/program/mongo.txt
@@ -407,8 +407,6 @@ Authentication Options
 
 .. option:: --gssapiHostName
 
-   .. versionadded:: 2.6
-   
    Specify the hostname of a service using :doc:`GSSAPI/Kerberos
    </core/kerberos>`. *Only* required if the hostname of a machine does
    not match the hostname resolved by DNS.
@@ -419,8 +417,6 @@ Authentication Options
 
 .. option:: --gssapiServiceName
 
-   .. versionadded:: 2.6
-   
    Specify the name of the service using :doc:`GSSAPI/Kerberos
    </core/kerberos>`. Only required if the service does not use the
    default name of ``mongodb``.

--- a/source/reference/program/mongod.txt
+++ b/source/reference/program/mongod.txt
@@ -364,9 +364,6 @@ Core Options
    Do not assign too low of a value to this option, or you will
    encounter errors during normal application operation.
 
-   .. include:: /includes/note-max-conns-max.rst
-   
-
 
 .. option:: --logpath <path>
 
@@ -1987,8 +1984,6 @@ TLS Options
 
    *Default*: keyFile
 
-   .. versionadded:: 2.6
-   
    The authentication mode used for cluster authentication. If you use
    :ref:`internal x.509 authentication <x509-internal-authentication>`,
    specify so here. This option can have one of the following values:
@@ -2307,8 +2302,6 @@ SSL Options (Deprecated)
 
    .. deprecated:: 4.2 Use :option:`--tlsMode <mongod --tlsMode>` instead.
    
-   .. versionadded:: 2.6
-   
    Enables TLS/SSL or mixed TLS/SSL used for all network connections. The
    argument to the :option:`--sslMode` option can be one of the following:
    
@@ -2465,8 +2458,6 @@ SSL Options (Deprecated)
 .. option:: --sslClusterPassword <value>
 
    .. deprecated:: 4.2 Use :option:`--tlsClusterPassword <mongod --tlsClusterPassword>` instead.
-   
-   .. versionadded:: 2.6
    
    Specifies the password to de-crypt the x.509 certificate-key file
    specified with ``--sslClusterFile``. Use the :option:`--sslClusterPassword` option only
@@ -2742,8 +2733,6 @@ Audit Options
 
 .. option:: --auditFormat
 
-   .. versionadded:: 2.6
-   
    Specifies the format of the output file for :doc:`auditing
    </core/auditing>` if :option:`--auditDestination` is ``file``. The
    :option:`--auditFormat` option can have one of the following values:
@@ -2774,8 +2763,6 @@ Audit Options
 
 .. option:: --auditPath
 
-   .. versionadded:: 2.6
-   
    Specifies the output file for :doc:`auditing </core/auditing>` if
    :option:`--auditDestination` has value of ``file``. The :option:`--auditPath`
    option can take either a full path name or a relative path name.
@@ -2785,8 +2772,6 @@ Audit Options
 
 .. option:: --auditFilter
 
-   .. versionadded:: 2.6
-   
    Specifies the filter to limit the :ref:`types of operations
    <audit-action-details-results>` the :doc:`audit system
    </core/auditing>` records. The option takes a string representation

--- a/source/reference/program/mongodump.txt
+++ b/source/reference/program/mongodump.txt
@@ -449,8 +449,6 @@ Options
 
 .. option:: --ssl
 
-   .. versionadded:: 2.6
-   
    Enables connection to a :binary:`~bin.mongod` or :binary:`~bin.mongos` that has
    TLS/SSL support enabled.
    
@@ -460,8 +458,6 @@ Options
 
 .. option:: --sslCAFile=<filename>
 
-   .. versionadded:: 2.6
-   
    Specifies the :file:`.pem` file that contains the root certificate chain
    from the Certificate Authority. Specify the file name of the
    :file:`.pem` file using relative or absolute paths.
@@ -485,8 +481,6 @@ Options
 
 .. option:: --sslPEMKeyFile=<filename>
 
-   .. versionadded:: 2.6
-   
    Specifies the :file:`.pem` file that contains both the TLS/SSL certificate
    and key. Specify the file name of the :file:`.pem` file using relative
    or absolute paths.
@@ -502,8 +496,6 @@ Options
 
 .. option:: --sslPEMKeyPassword=<value>
 
-   .. versionadded:: 2.6
-   
    Specifies the password to de-crypt the certificate-key file (i.e.
    :option:`--sslPEMKeyFile`). Use the :option:`--sslPEMKeyPassword` option only if the
    certificate-key file is encrypted. In all cases, the :program:`mongodump` will
@@ -518,8 +510,6 @@ Options
 
 .. option:: --sslCRLFile=<filename>
 
-   .. versionadded:: 2.6
-   
    Specifies the :file:`.pem` file that contains the Certificate Revocation
    List. Specify the file name of the :file:`.pem` file using relative or
    absolute paths.
@@ -530,8 +520,6 @@ Options
 
 .. option:: --sslAllowInvalidCertificates
 
-   .. versionadded:: 2.6
-   
    Bypasses the validation checks for server certificates and allows
    the use of invalid certificates. When using the
    :setting:`~net.ssl.allowInvalidCertificates` setting, MongoDB logs as a
@@ -626,8 +614,6 @@ Options
 
 .. option:: --gssapiServiceName
 
-   .. versionadded:: 2.6
-   
    Specify the name of the service using :doc:`GSSAPI/Kerberos
    </core/kerberos>`. Only required if the service does not use the
    default name of ``mongodb``.
@@ -638,8 +624,6 @@ Options
 
 .. option:: --gssapiHostName
 
-   .. versionadded:: 2.6
-   
    Specify the hostname of a service using :doc:`GSSAPI/Kerberos
    </core/kerberos>`. *Only* required if the hostname of a machine does
    not match the hostname resolved by DNS.

--- a/source/reference/program/mongoexport.txt
+++ b/source/reference/program/mongoexport.txt
@@ -436,8 +436,6 @@ Options
 
 .. option:: --ssl
 
-   .. versionadded:: 2.6
-   
    Enables connection to a :binary:`~bin.mongod` or :binary:`~bin.mongos` that has
    TLS/SSL support enabled.
    
@@ -447,8 +445,6 @@ Options
 
 .. option:: --sslCAFile=<filename>
 
-   .. versionadded:: 2.6
-   
    Specifies the :file:`.pem` file that contains the root certificate chain
    from the Certificate Authority. Specify the file name of the
    :file:`.pem` file using relative or absolute paths.
@@ -472,8 +468,6 @@ Options
 
 .. option:: --sslPEMKeyFile=<filename>
 
-   .. versionadded:: 2.6
-   
    Specifies the :file:`.pem` file that contains both the TLS/SSL certificate
    and key. Specify the file name of the :file:`.pem` file using relative
    or absolute paths.
@@ -489,8 +483,6 @@ Options
 
 .. option:: --sslPEMKeyPassword=<value>
 
-   .. versionadded:: 2.6
-   
    Specifies the password to de-crypt the certificate-key file (i.e.
    :option:`--sslPEMKeyFile`). Use the :option:`--sslPEMKeyPassword` option only if the
    certificate-key file is encrypted. In all cases, the :program:`mongoexport` will
@@ -505,8 +497,6 @@ Options
 
 .. option:: --sslCRLFile=<filename>
 
-   .. versionadded:: 2.6
-   
    Specifies the :file:`.pem` file that contains the Certificate Revocation
    List. Specify the file name of the :file:`.pem` file using relative or
    absolute paths.
@@ -517,8 +507,6 @@ Options
 
 .. option:: --sslAllowInvalidCertificates
 
-   .. versionadded:: 2.6
-   
    Bypasses the validation checks for server certificates and allows
    the use of invalid certificates. When using the
    :setting:`~net.ssl.allowInvalidCertificates` setting, MongoDB logs as a
@@ -609,8 +597,6 @@ Options
 
 .. option:: --gssapiServiceName=<serviceName>
 
-   .. versionadded:: 2.6
-   
    Specify the name of the service using :doc:`GSSAPI/Kerberos
    </core/kerberos>`. Only required if the service does not use the
    default name of ``mongodb``.
@@ -621,8 +607,6 @@ Options
 
 .. option:: --gssapiHostName=<hostname>
 
-   .. versionadded:: 2.6
-   
    Specify the hostname of a service using :doc:`GSSAPI/Kerberos
    </core/kerberos>`. *Only* required if the hostname of a machine does
    not match the hostname resolved by DNS.

--- a/source/reference/program/mongofiles.txt
+++ b/source/reference/program/mongofiles.txt
@@ -230,8 +230,6 @@ Options
 
 .. option:: --ssl
 
-   .. versionadded:: 2.6
-   
    Enables connection to a :binary:`~bin.mongod` or :binary:`~bin.mongos` that has
    TLS/SSL support enabled.
    
@@ -241,8 +239,6 @@ Options
 
 .. option:: --sslCAFile=<filename>
 
-   .. versionadded:: 2.6
-   
    Specifies the :file:`.pem` file that contains the root certificate chain
    from the Certificate Authority. Specify the file name of the
    :file:`.pem` file using relative or absolute paths.
@@ -266,8 +262,6 @@ Options
 
 .. option:: --sslPEMKeyFile=<filename>
 
-   .. versionadded:: 2.6
-   
    Specifies the :file:`.pem` file that contains both the TLS/SSL certificate
    and key. Specify the file name of the :file:`.pem` file using relative
    or absolute paths.
@@ -283,8 +277,6 @@ Options
 
 .. option:: --sslPEMKeyPassword=<value>
 
-   .. versionadded:: 2.6
-   
    Specifies the password to de-crypt the certificate-key file (i.e.
    :option:`--sslPEMKeyFile`). Use the :option:`--sslPEMKeyPassword` option only if the
    certificate-key file is encrypted. In all cases, the :program:`mongofiles` will
@@ -299,8 +291,6 @@ Options
 
 .. option:: --sslCRLFile=<filename>
 
-   .. versionadded:: 2.6
-   
    Specifies the :file:`.pem` file that contains the Certificate Revocation
    List. Specify the file name of the :file:`.pem` file using relative or
    absolute paths.
@@ -311,8 +301,6 @@ Options
 
 .. option:: --sslAllowInvalidCertificates
 
-   .. versionadded:: 2.6
-   
    Bypasses the validation checks for server certificates and allows
    the use of invalid certificates. When using the
    :setting:`~net.ssl.allowInvalidCertificates` setting, MongoDB logs as a
@@ -400,8 +388,6 @@ Options
 
 .. option:: --gssapiServiceName=<serviceName>
 
-   .. versionadded:: 2.6
-   
    Specify the name of the service using :doc:`GSSAPI/Kerberos
    </core/kerberos>`. Only required if the service does not use the
    default name of ``mongodb``.
@@ -412,8 +398,6 @@ Options
 
 .. option:: --gssapiHostName=<hostname>
 
-   .. versionadded:: 2.6
-   
    Specify the hostname of a service using :doc:`GSSAPI/Kerberos
    </core/kerberos>`. *Only* required if the hostname of a machine does
    not match the hostname resolved by DNS.

--- a/source/reference/program/mongoimport.txt
+++ b/source/reference/program/mongoimport.txt
@@ -238,8 +238,6 @@ Options
 
 .. option:: --ssl
 
-   .. versionadded:: 2.6
-   
    Enables connection to a :binary:`~bin.mongod` or :binary:`~bin.mongos` that has
    TLS/SSL support enabled.
    
@@ -249,8 +247,6 @@ Options
 
 .. option:: --sslCAFile=<filename>
 
-   .. versionadded:: 2.6
-   
    Specifies the :file:`.pem` file that contains the root certificate chain
    from the Certificate Authority. Specify the file name of the
    :file:`.pem` file using relative or absolute paths.
@@ -274,8 +270,6 @@ Options
 
 .. option:: --sslPEMKeyFile=<filename>
 
-   .. versionadded:: 2.6
-   
    Specifies the :file:`.pem` file that contains both the TLS/SSL certificate
    and key. Specify the file name of the :file:`.pem` file using relative
    or absolute paths.
@@ -291,8 +285,6 @@ Options
 
 .. option:: --sslPEMKeyPassword=<value>
 
-   .. versionadded:: 2.6
-   
    Specifies the password to de-crypt the certificate-key file (i.e.
    :option:`--sslPEMKeyFile`). Use the :option:`--sslPEMKeyPassword` option only if the
    certificate-key file is encrypted. In all cases, the :program:`mongoimport` will
@@ -307,8 +299,6 @@ Options
 
 .. option:: --sslCRLFile=<filename>
 
-   .. versionadded:: 2.6
-   
    Specifies the :file:`.pem` file that contains the Certificate Revocation
    List. Specify the file name of the :file:`.pem` file using relative or
    absolute paths.
@@ -319,8 +309,6 @@ Options
 
 .. option:: --sslAllowInvalidCertificates
 
-   .. versionadded:: 2.6
-   
    Bypasses the validation checks for server certificates and allows
    the use of invalid certificates. When using the
    :setting:`~net.ssl.allowInvalidCertificates` setting, MongoDB logs as a
@@ -408,8 +396,6 @@ Options
 
 .. option:: --gssapiServiceName=<serviceName>
 
-   .. versionadded:: 2.6
-   
    Specify the name of the service using :doc:`GSSAPI/Kerberos
    </core/kerberos>`. Only required if the service does not use the
    default name of ``mongodb``.
@@ -420,8 +406,6 @@ Options
 
 .. option:: --gssapiHostName=<hostname>
 
-   .. versionadded:: 2.6
-   
    Specify the hostname of a service using :doc:`GSSAPI/Kerberos
    </core/kerberos>`. *Only* required if the hostname of a machine does
    not match the hostname resolved by DNS.
@@ -441,13 +425,10 @@ Options
 
 .. option:: --collection=<collection>, -c=<collection>
 
-   Specifies the collection to import.
-   
-   .. versionadded:: 2.6
-      If you do not specify :option:`--collection`,
-      :binary:`~bin.mongoimport` takes the collection name from the input
-      filename. MongoDB omits the extension of the file from the
-      collection name, if the input file has an extension.
+   Specifies the collection to import. If you do not specify
+   :option:`--collection`, :binary:`~bin.mongoimport` takes the
+   collection name from the input filename, omitting the file's
+   extension if it has one.
 
 
 .. option:: --fields=<field1[,field2]>, -f=<field1[,field2]>

--- a/source/reference/program/mongorestore.txt
+++ b/source/reference/program/mongorestore.txt
@@ -322,8 +322,6 @@ Options
 
 .. option:: --ssl
 
-   .. versionadded:: 2.6
-   
    Enables connection to a :binary:`~bin.mongod` or :binary:`~bin.mongos` that has
    TLS/SSL support enabled.
    
@@ -333,8 +331,6 @@ Options
 
 .. option:: --sslCAFile=<filename>
 
-   .. versionadded:: 2.6
-   
    Specifies the :file:`.pem` file that contains the root certificate chain
    from the Certificate Authority. Specify the file name of the
    :file:`.pem` file using relative or absolute paths.
@@ -358,8 +354,6 @@ Options
 
 .. option:: --sslPEMKeyFile=<filename>
 
-   .. versionadded:: 2.6
-   
    Specifies the :file:`.pem` file that contains both the TLS/SSL certificate
    and key. Specify the file name of the :file:`.pem` file using relative
    or absolute paths.
@@ -375,8 +369,6 @@ Options
 
 .. option:: --sslPEMKeyPassword=<value>
 
-   .. versionadded:: 2.6
-   
    Specifies the password to de-crypt the certificate-key file (i.e.
    :option:`--sslPEMKeyFile`). Use the :option:`--sslPEMKeyPassword` option only if the
    certificate-key file is encrypted. In all cases, the :program:`mongorestore` will
@@ -391,8 +383,6 @@ Options
 
 .. option:: --sslCRLFile=<filename>
 
-   .. versionadded:: 2.6
-   
    Specifies the :file:`.pem` file that contains the Certificate Revocation
    List. Specify the file name of the :file:`.pem` file using relative or
    absolute paths.
@@ -403,8 +393,6 @@ Options
 
 .. option:: --sslAllowInvalidCertificates
 
-   .. versionadded:: 2.6
-   
    Bypasses the validation checks for server certificates and allows
    the use of invalid certificates. When using the
    :setting:`~net.ssl.allowInvalidCertificates` setting, MongoDB logs as a
@@ -492,8 +480,6 @@ Options
 
 .. option:: --gssapiServiceName=<serviceName>
 
-   .. versionadded:: 2.6
-   
    Specify the name of the service using :doc:`GSSAPI/Kerberos
    </core/kerberos>`. Only required if the service does not use the
    default name of ``mongodb``.
@@ -504,8 +490,6 @@ Options
 
 .. option:: --gssapiHostName=<hostname>
 
-   .. versionadded:: 2.6
-   
    Specify the hostname of a service using :doc:`GSSAPI/Kerberos
    </core/kerberos>`. *Only* required if the hostname of a machine does
    not match the hostname resolved by DNS.

--- a/source/reference/program/mongos.txt
+++ b/source/reference/program/mongos.txt
@@ -264,9 +264,6 @@ Core Options
    encounter errors during normal application operation.
 
    .. include:: /includes/fact-maxconns-mongos.rst
-   
-   .. include:: /includes/note-max-conns-max.rst
-   
 
 
 .. option:: --syslog
@@ -782,8 +779,6 @@ TLS Options
 
    *Default*: keyFile
 
-   .. versionadded:: 2.6
-   
    The authentication mode used for cluster authentication. If you use
    :ref:`internal x.509 authentication <x509-internal-authentication>`,
    specify so here. This option can have one of the following values:
@@ -1101,8 +1096,6 @@ SSL Options (Deprecated)
 
    .. deprecated:: 4.2 Use :option:`--tlsMode <mongos --tlsMode>` instead.
    
-   .. versionadded:: 2.6
-   
    Enables TLS/SSL or mixed TLS/SSL used for all network connections. The
    argument to the :option:`--sslMode` option can be one of the following:
    
@@ -1212,8 +1205,6 @@ SSL Options (Deprecated)
 .. option:: --sslClusterPassword <value>
 
    .. deprecated:: 4.2 Use :option:`--tlsClusterPassword <mongos --tlsClusterPassword>` instead.
-   
-   .. versionadded:: 2.6
    
    Specifies the password to de-crypt the x.509 certificate-key file
    specified with ``--sslClusterFile``. Use the :option:`--sslClusterPassword` option only
@@ -1487,8 +1478,6 @@ Audit Options
 
 .. option:: --auditFormat
 
-   .. versionadded:: 2.6
-   
    Specifies the format of the output file for :doc:`auditing
    </core/auditing>` if :option:`--auditDestination` is ``file``. The
    :option:`--auditFormat` option can have one of the following values:
@@ -1519,8 +1508,6 @@ Audit Options
 
 .. option:: --auditPath
 
-   .. versionadded:: 2.6
-   
    Specifies the output file for :doc:`auditing </core/auditing>` if
    :option:`--auditDestination` has value of ``file``. The :option:`--auditPath`
    option can take either a full path name or a relative path name.
@@ -1530,8 +1517,6 @@ Audit Options
 
 .. option:: --auditFilter
 
-   .. versionadded:: 2.6
-   
    Specifies the filter to limit the :ref:`types of operations
    <audit-action-details-results>` the :doc:`audit system
    </core/auditing>` records. The option takes a string representation

--- a/source/reference/program/mongostat.txt
+++ b/source/reference/program/mongostat.txt
@@ -168,8 +168,6 @@ Options
 
 .. option:: --ssl
 
-   .. versionadded:: 2.6
-   
    Enables connection to a :binary:`~bin.mongod` or :binary:`~bin.mongos` that has
    TLS/SSL support enabled.
    
@@ -179,8 +177,6 @@ Options
 
 .. option:: --sslCAFile=<filename>
 
-   .. versionadded:: 2.6
-   
    Specifies the :file:`.pem` file that contains the root certificate chain
    from the Certificate Authority. Specify the file name of the
    :file:`.pem` file using relative or absolute paths.
@@ -204,8 +200,6 @@ Options
 
 .. option:: --sslPEMKeyFile=<filename>
 
-   .. versionadded:: 2.6
-   
    Specifies the :file:`.pem` file that contains both the TLS/SSL certificate
    and key. Specify the file name of the :file:`.pem` file using relative
    or absolute paths.
@@ -221,8 +215,6 @@ Options
 
 .. option:: --sslPEMKeyPassword=<value>
 
-   .. versionadded:: 2.6
-   
    Specifies the password to de-crypt the certificate-key file (i.e.
    :option:`--sslPEMKeyFile <mongostat --sslPEMKeyFile>`). Use the
    :option:`--sslPEMKeyPassword <mongostat --sslPEMKeyPassword>` option
@@ -240,8 +232,6 @@ Options
 
 .. option:: --sslCRLFile=<filename>
 
-   .. versionadded:: 2.6
-   
    Specifies the :file:`.pem` file that contains the Certificate Revocation
    List. Specify the file name of the :file:`.pem` file using relative or
    absolute paths.
@@ -252,8 +242,6 @@ Options
 
 .. option:: --sslAllowInvalidCertificates
 
-   .. versionadded:: 2.6
-   
    Bypasses the validation checks for server certificates and allows
    the use of invalid certificates. When using the
    :setting:`~net.ssl.allowInvalidCertificates` setting, MongoDB logs as a
@@ -353,8 +341,6 @@ Options
 
 .. option:: --gssapiServiceName=<string>
 
-   .. versionadded:: 2.6
-   
    Specify the name of the service using :doc:`GSSAPI/Kerberos
    </core/kerberos>`. Only required if the service does not use the
    default name of ``mongodb``.
@@ -365,8 +351,6 @@ Options
 
 .. option:: --gssapiHostName=<string>
 
-   .. versionadded:: 2.6
-   
    Specify the hostname of a service using :doc:`GSSAPI/Kerberos
    </core/kerberos>`. *Only* required if the hostname of a machine does
    not match the hostname resolved by DNS.
@@ -510,10 +494,10 @@ Options
    
    The :option:`mongostat --host` option is not required but
    potentially useful in this case.
-   
-   .. versionchanged:: 2.6
-      When running with :option:`--discover <mongostat --discover>`, :binary:`~bin.mongostat` now
-      respects :option:`--rowcount <mongostat --rowcount>`.
+
+   When running with :option:`--discover <mongostat --discover>`,
+   :binary:`~bin.mongostat` respects
+   :option:`--rowcount <mongostat --rowcount>`.
 
 
 .. option:: --http

--- a/source/reference/program/mongotop.txt
+++ b/source/reference/program/mongotop.txt
@@ -305,8 +305,6 @@ Options
 
 .. option:: --ssl
 
-   .. versionadded:: 2.6
-   
    Enables connection to a :binary:`~bin.mongod` or :binary:`~bin.mongos` that has
    TLS/SSL support enabled.
    
@@ -316,8 +314,6 @@ Options
 
 .. option:: --sslCAFile=<filename>
 
-   .. versionadded:: 2.6
-   
    Specifies the :file:`.pem` file that contains the root certificate chain
    from the Certificate Authority. Specify the file name of the
    :file:`.pem` file using relative or absolute paths.
@@ -341,8 +337,6 @@ Options
 
 .. option:: --sslPEMKeyFile=<filename>
 
-   .. versionadded:: 2.6
-   
    Specifies the :file:`.pem` file that contains both the TLS/SSL certificate
    and key. Specify the file name of the :file:`.pem` file using relative
    or absolute paths.
@@ -358,8 +352,6 @@ Options
 
 .. option:: --sslPEMKeyPassword=<value>
 
-   .. versionadded:: 2.6
-   
    Specifies the password to de-crypt the certificate-key file (i.e.
    :option:`--sslPEMKeyFile`). Use the :option:`--sslPEMKeyPassword` option only if the
    certificate-key file is encrypted. In all cases, the :program:`mongotop` will
@@ -374,8 +366,6 @@ Options
 
 .. option:: --sslCRLFile=<filename>
 
-   .. versionadded:: 2.6
-   
    Specifies the :file:`.pem` file that contains the Certificate Revocation
    List. Specify the file name of the :file:`.pem` file using relative or
    absolute paths.
@@ -386,8 +376,6 @@ Options
 
 .. option:: --sslAllowInvalidCertificates
 
-   .. versionadded:: 2.6
-   
    Bypasses the validation checks for server certificates and allows
    the use of invalid certificates. When using the
    :setting:`~net.ssl.allowInvalidCertificates` setting, MongoDB logs as a
@@ -481,8 +469,6 @@ Options
 
 .. option:: --gssapiServiceName=<serviceName>
 
-   .. versionadded:: 2.6
-   
    Specify the name of the service using :doc:`GSSAPI/Kerberos
    </core/kerberos>`. Only required if the service does not use the
    default name of ``mongodb``.
@@ -493,8 +479,6 @@ Options
 
 .. option:: --gssapiHostName=<hostname>
 
-   .. versionadded:: 2.6
-   
    Specify the hostname of a service using :doc:`GSSAPI/Kerberos
    </core/kerberos>`. *Only* required if the hostname of a machine does
    not match the hostname resolved by DNS.

--- a/source/reference/system-collections.txt
+++ b/source/reference/system-collections.txt
@@ -36,15 +36,11 @@ System collections include these collections stored in the ``admin`` database:
 
 .. data:: admin.system.roles
 
-   .. versionadded:: 2.6
-
    The :data:`admin.system.roles` collection stores custom roles that
    administrators create and assign to users to provide access to
    specific resources.
 
 .. data:: admin.system.users
-
-   .. versionchanged:: 2.6
 
    The :data:`admin.system.users` collection stores the user's
    authentication credentials as well as any roles assigned to the user.
@@ -52,8 +48,6 @@ System collections include these collections stored in the ``admin`` database:
    :data:`admin.system.roles` collection.
 
 .. data:: admin.system.version
-
-   .. versionadded:: 2.6
 
    Stores the schema version of the user credential documents.
 

--- a/source/reference/system-roles-collection.txt
+++ b/source/reference/system-roles-collection.txt
@@ -2,8 +2,6 @@
 ``system.roles`` Collection
 ===========================
 
-.. versionadded:: 2.6
-
 .. default-domain:: mongodb
 
 .. contents:: On this page

--- a/source/reference/text-search-languages.txt
+++ b/source/reference/text-search-languages.txt
@@ -15,20 +15,9 @@ Text Search Languages
 .. include:: /includes/promo-atlas-fts.rst
 
 The :ref:`text index <index-feature-text>` and the :query:`$text`
-operator supports the following languages:
-
-.. versionchanged:: 2.6
-
-   MongoDB introduces version 2 of the text search feature. With
-   version 2, text search feature supports using the two-letter
-   language codes defined in ISO 639-1. Version 1 of text search only
-   supported the long form of each language name.
-
-.. admonition:: Removal of Support for RLP
-   :class: admonition-example
-
-   MongoDB Enterprise no longer supports Text Search with Basis
-   Technology Rosette Linguistics Platform.
+operator may be used with the following languages, and accepts either the
+two-letter ISO 639-1 language code or the long form of the
+language name:
 
 .. list-table::
    :header-rows: 1

--- a/source/reference/ulimit.txt
+++ b/source/reference/ulimit.txt
@@ -73,8 +73,6 @@ For :binary:`~bin.mongos`, consider the following behaviors:
   cascade effect where the :binary:`~bin.mongos` creates too many
   connections on the :binary:`~bin.mongod` instances.
 
-  .. include:: /includes/note-max-conns-max.rst
-
 Review and Set Resource Limits
 ------------------------------
 

--- a/source/release-notes/2.6.txt
+++ b/source/release-notes/2.6.txt
@@ -314,7 +314,6 @@ data.
 
 - .. include:: /includes/fact-update-field-order.rst
      :start-after: order-of-document-fields
-     :end-before: .. versionchanged
 
 - New or enhanced update operators:
 

--- a/source/tutorial/configure-auditing.txt
+++ b/source/tutorial/configure-auditing.txt
@@ -22,8 +22,6 @@ Configure Auditing
    and
    :atlas:`Configure a Custom Auditing Filter </tutorial/auditing-custom-filter>`.
 
-.. versionadded:: 2.6
- 
 :products:`MongoDB Enterprise </mongodb-enterprise-advanced?jmp=docs>`
 supports :ref:`auditing <auditing>` of various operations. A complete
 auditing solution must involve **all** :binary:`~bin.mongod` server and

--- a/source/tutorial/configure-fips.txt
+++ b/source/tutorial/configure-fips.txt
@@ -10,8 +10,6 @@ Configure MongoDB for FIPS
    :depth: 1
    :class: singlecol
 
-.. versionadded:: 2.6
-
 Overview
 --------
 

--- a/source/tutorial/configure-x509-member-authentication.txt
+++ b/source/tutorial/configure-x509-member-authentication.txt
@@ -12,8 +12,6 @@ Use x.509 Certificate for Membership Authentication
    :depth: 1
    :class: singlecol
 
-.. versionadded:: 2.6
-
 MongoDB supports x.509 certificate authentication for use with a secure
 :doc:`TLS/SSL connection </tutorial/configure-ssl>`. Sharded cluster
 members and replica set members can use x.509 certificates to verify

--- a/source/tutorial/control-access-to-mongodb-windows-with-kerberos-authentication.txt
+++ b/source/tutorial/control-access-to-mongodb-windows-with-kerberos-authentication.txt
@@ -10,8 +10,6 @@ Configure MongoDB with Kerberos Authentication on Windows
    :depth: 1
    :class: singlecol
 
-.. versionadded:: 2.6
-
 Overview
 --------
 

--- a/source/tutorial/monitor-with-snmp-on-windows.txt
+++ b/source/tutorial/monitor-with-snmp-on-windows.txt
@@ -10,8 +10,6 @@ Monitor MongoDB Windows with SNMP
    :depth: 1
    :class: singlecol
 
-.. versionadded:: 2.6
-
 .. admonition:: Enterprise Feature
 
    SNMP is only available in `MongoDB Enterprise

--- a/source/tutorial/split-chunks-in-sharded-cluster.txt
+++ b/source/tutorial/split-chunks-in-sharded-cluster.txt
@@ -26,11 +26,10 @@ you may want to split chunks manually if:
 
 .. note::
 
-   .. versionadded:: 2.6
-      MongoDB provides the :dbcommand:`mergeChunks` command
-      to combine contiguous chunk ranges into a single chunk. See
-      :doc:`/tutorial/merge-chunks-in-sharded-cluster` for more
-      information.
+   MongoDB provides the :dbcommand:`mergeChunks` command
+   to combine contiguous chunk ranges into a single chunk. See
+   :doc:`/tutorial/merge-chunks-in-sharded-cluster` for more
+   information.
 
 The :term:`balancer` may migrate recently split chunks to a new shard
 immediately if the move benefits future insertions. The balancer does

--- a/source/tutorial/terminate-running-operations.txt
+++ b/source/tutorial/terminate-running-operations.txt
@@ -24,8 +24,6 @@ Available Procedures
 ``maxTimeMS``
 ~~~~~~~~~~~~~
 
-.. versionadded:: 2.6
-
 The :method:`~cursor.maxTimeMS()` method sets a time limit for an
 operation. When the operation reaches the specified time limit,
 MongoDB interrupts the operation at the next :term:`interrupt point`.

--- a/source/tutorial/text-search-in-aggregation.txt
+++ b/source/tutorial/text-search-in-aggregation.txt
@@ -10,8 +10,6 @@ Text Search in the Aggregation Pipeline
    :depth: 1
    :class: singlecol
 
-.. versionadded:: 2.6
-
 .. _text-agg-expression-behavior:
 
 In the aggregation pipeline, text search is available via the use of

--- a/source/tutorial/troubleshoot-snmp.txt
+++ b/source/tutorial/troubleshoot-snmp.txt
@@ -10,8 +10,6 @@ Troubleshoot SNMP
    :depth: 1
    :class: singlecol
 
-.. versionadded:: 2.6
-
 .. admonition:: Enterprise Feature
 
    SNMP is only available in MongoDB Enterprise.


### PR DESCRIPTION
…repo-wide

• Moved changes from options-mongo*.yaml to
   - mongo.txt
   - mongos.txt
   - mongod.txt
     (per DOCS-12989 and 84947f53da1d2bcf0605fea2f84c7bc53495ab3e)

• Small language updates to:
   - source/core/security-users.txt (config: admin db)
   - source/reference/program/mongoimport.txt (filename extension)

• Builds without (new) errors.