### PR TITLE
Update steps-install-mongodb-enterprise-on-red-hat.yaml

### DIFF
--- a/source/includes/steps-install-mongodb-enterprise-on-red-hat.yaml
+++ b/source/includes/steps-install-mongodb-enterprise-on-red-hat.yaml
@@ -26,7 +26,7 @@ post: |
     {{distro_link}}. Downloads are organized by {{distro_name_full}}
     version (e.g. ``{{distro_num}}``), then MongoDB
     :doc:`release version </reference/versioning>`
-    (e.g. ``{+package-branch+}``), then architecture (e.g. ``x86_64``).
+    (e.g. ``3.4``), then architecture (e.g. ``x86_64``).
     Odd-numbered MongoDB release versions, such as 4.1, are development
     versions and are unsuitable for production deployment.
 replacement:


### PR DESCRIPTION
v3.4 doesn't support the use of {+package-branch+} -- hardcoding instead.