### PR TITLE
Typos

### DIFF
--- a/source/reference/configuration-options.txt
+++ b/source/reference/configuration-options.txt
@@ -3058,7 +3058,7 @@ Key Management Configuration Options
      [ dn  [ ? [attributes] [ ? [scope] [ ? [filter] [ ? [Extensions] ] ] ] ] ]
    
    If your query includes an attribute, :binary:`~bin.mongod` assumes that the query
-   retrieves a the DNs which this entity is member of.
+   retrieves a list of the DNs which this entity is a member of.
    
    If your query does not include an attribute, :binary:`~bin.mongod` assumes
    the query retrieves all entities which the user is member of.


### PR DESCRIPTION
Wording could maybe be improved even more too.. 
Something like "retrieves an object which includes attribute values corresponding to DNs this entity is a member of" or "retrieves object(s) which include attribute values corresponding to DNs this entity is a member of" 

Basically it's still not entirely clear what exactly the query is expected to retrieve but it's also not obvious to me how exactly to make it clearer. 
