### PR TITLE
Use "range-based sharding" spelling

### DIFF
--- a/locale/es/LC_MESSAGES/core/ranged-sharding.po
+++ b/locale/es/LC_MESSAGES/core/ranged-sharding.po
@@ -26,7 +26,7 @@ msgstr ""
 # 78e7ba11a0394c67b8b4313054ffd931
 #: ../source/core/ranged-sharding.txt:9
 msgid ""
-"Ranged-based sharding involves dividing data into contiguous ranges "
+"Range-based sharding involves dividing data into contiguous ranges "
 "determined by the shard key values. In this model, documents with "
 "\"close\" shard key values are likely to be in the same :term:`chunk` or "
 ":term:`shard`. This allows for efficient queries where reads target "

--- a/locale/es/LC_MESSAGES/sharding.po
+++ b/locale/es/LC_MESSAGES/sharding.po
@@ -423,7 +423,7 @@ msgstr ""
 # be2d5bf11a044696a8a4fc580a0a9d41
 #: ../source/sharding.txt:243
 msgid ""
-"However, hashed distribution means that ranged-based queries on the shard"
+"However, hashed distribution means that range-based queries on the shard"
 " key are less likely to target a single shard, resulting in more cluster "
 "wide :ref:`broadcast operations<sharding-mongos-broadcast>`"
 msgstr ""

--- a/locale/es/LC_MESSAGES/tutorial/deploy-sharded-cluster-ranged-sharding.po
+++ b/locale/es/LC_MESSAGES/tutorial/deploy-sharded-cluster-ranged-sharding.po
@@ -36,7 +36,7 @@ msgstr ""
 # 367c4a77b09644d0ae1326e02f9d7e43
 #: ../source/tutorial/deploy-sharded-cluster-ranged-sharding.txt:16
 msgid ""
-"In ranged-based sharding, MongoDB automatically divides data into "
+"In range-based sharding, MongoDB automatically divides data into "
 "contiguous ranges determined by the shard key values. In this model, "
 "documents with \"close\" shard key values are likely to be in the same "
 ":term:`chunk` or :term:`shard`. This allows for efficient queries where "

--- a/locale/pot/core/ranged-sharding.pot
+++ b/locale/pot/core/ranged-sharding.pot
@@ -23,7 +23,7 @@ msgstr ""
 
 #: ../source/core/ranged-sharding.txt:9
 # 78e7ba11a0394c67b8b4313054ffd931
-msgid "Ranged-based sharding involves dividing data into contiguous ranges determined by the shard key values. In this model, documents with \"close\" shard key values are likely to be in the same :term:`chunk` or :term:`shard`. This allows for efficient queries where reads target documents within a contiguous range. However, both read and write performance may decrease with poor shard key selection. See :ref:`sharding-ranged-shard-key`."
+msgid "Range-based sharding involves dividing data into contiguous ranges determined by the shard key values. In this model, documents with \"close\" shard key values are likely to be in the same :term:`chunk` or :term:`shard`. This allows for efficient queries where reads target documents within a contiguous range. However, both read and write performance may decrease with poor shard key selection. See :ref:`sharding-ranged-shard-key`."
 msgstr ""
 
 #: ../source/core/ranged-sharding.txt:18

--- a/locale/pot/sharding.pot
+++ b/locale/pot/sharding.pot
@@ -283,7 +283,7 @@ msgstr ""
 
 #: ../source/sharding.txt:243
 # be2d5bf11a044696a8a4fc580a0a9d41
-msgid "However, hashed distribution means that ranged-based queries on the shard key are less likely to target a single shard, resulting in more cluster wide :ref:`broadcast operations<sharding-mongos-broadcast>`"
+msgid "However, hashed distribution means that range-based queries on the shard key are less likely to target a single shard, resulting in more cluster wide :ref:`broadcast operations<sharding-mongos-broadcast>`"
 msgstr ""
 
 #: ../source/sharding.txt:247

--- a/locale/pot/tutorial/deploy-sharded-cluster-ranged-sharding.pot
+++ b/locale/pot/tutorial/deploy-sharded-cluster-ranged-sharding.pot
@@ -33,7 +33,7 @@ msgstr ""
 
 #: ../source/tutorial/deploy-sharded-cluster-ranged-sharding.txt:16
 # 367c4a77b09644d0ae1326e02f9d7e43
-msgid "In ranged-based sharding, MongoDB automatically divides data into contiguous ranges determined by the shard key values. In this model, documents with \"close\" shard key values are likely to be in the same :term:`chunk` or :term:`shard`. This allows for efficient queries where reads target documents within a contiguous range. However, both read and write performance may decrease with poor shard key selection. See :ref:`sharding-ranged-shard-key`."
+msgid "In range-based sharding, MongoDB automatically divides data into contiguous ranges determined by the shard key values. In this model, documents with \"close\" shard key values are likely to be in the same :term:`chunk` or :term:`shard`. This allows for efficient queries where reads target documents within a contiguous range. However, both read and write performance may decrease with poor shard key selection. See :ref:`sharding-ranged-shard-key`."
 msgstr ""
 
 #: ../source/tutorial/deploy-sharded-cluster-ranged-sharding.txt:23

--- a/locale/zh/LC_MESSAGES/core/ranged-sharding.po
+++ b/locale/zh/LC_MESSAGES/core/ranged-sharding.po
@@ -26,7 +26,7 @@ msgstr ""
 # 78e7ba11a0394c67b8b4313054ffd931
 #: ../source/core/ranged-sharding.txt:9
 msgid ""
-"Ranged-based sharding involves dividing data into contiguous ranges "
+"Range-based sharding involves dividing data into contiguous ranges "
 "determined by the shard key values. In this model, documents with "
 "\"close\" shard key values are likely to be in the same :term:`chunk` or "
 ":term:`shard`. This allows for efficient queries where reads target "

--- a/locale/zh/LC_MESSAGES/sharding.po
+++ b/locale/zh/LC_MESSAGES/sharding.po
@@ -413,7 +413,7 @@ msgstr ""
 # be2d5bf11a044696a8a4fc580a0a9d41
 #: ../source/sharding.txt:243
 msgid ""
-"However, hashed distribution means that ranged-based queries on the shard"
+"However, hashed distribution means that range-based queries on the shard"
 " key are less likely to target a single shard, resulting in more cluster "
 "wide :ref:`broadcast operations<sharding-mongos-broadcast>`"
 msgstr ""

--- a/locale/zh/LC_MESSAGES/tutorial/deploy-sharded-cluster-ranged-sharding.po
+++ b/locale/zh/LC_MESSAGES/tutorial/deploy-sharded-cluster-ranged-sharding.po
@@ -36,7 +36,7 @@ msgstr ""
 # 367c4a77b09644d0ae1326e02f9d7e43
 #: ../source/tutorial/deploy-sharded-cluster-ranged-sharding.txt:16
 msgid ""
-"In ranged-based sharding, MongoDB automatically divides data into "
+"In range-based sharding, MongoDB automatically divides data into "
 "contiguous ranges determined by the shard key values. In this model, "
 "documents with \"close\" shard key values are likely to be in the same "
 ":term:`chunk` or :term:`shard`. This allows for efficient queries where "

--- a/source/core/ranged-sharding.txt
+++ b/source/core/ranged-sharding.txt
@@ -6,7 +6,7 @@ Ranged Sharding
 
 .. default-domain:: mongodb
 
-Ranged-based sharding involves dividing data into contiguous ranges determined
+Range-based sharding involves dividing data into contiguous ranges determined
 by the shard key values. In this model, documents with "close" shard key
 values are likely to be in the same :term:`chunk` or :term:`shard`. This
 allows for efficient queries where reads target documents within a contiguous

--- a/source/sharding.txt
+++ b/source/sharding.txt
@@ -254,7 +254,7 @@ to be on the same :term:`chunk`. Data distribution based on hashed values
 facilitates more even data distribution, especially in data sets where the
 shard key changes :ref:`monotonically<shard-key-monotonic>`.
 
-However, hashed distribution means that ranged-based queries on the shard key
+However, hashed distribution means that range-based queries on the shard key
 are less likely to target a single shard, resulting in more cluster wide
 :ref:`broadcast operations<sharding-mongos-broadcast>`
 

--- a/source/tutorial/deploy-shard-cluster.txt
+++ b/source/tutorial/deploy-shard-cluster.txt
@@ -265,7 +265,7 @@ MongoDB provides two strategies to shard collections:
 
      sh.shardCollection("<database>.<collection>", { <shard key field> : "hashed" } )
 
-- :ref:`Ranged-based sharding <sharding-ranged>` can use multiple
+- :ref:`Range-based sharding <sharding-ranged>` can use multiple
   fields as the shard key and divides data into contiguous ranges
   determined by the shard key values.
 


### PR DESCRIPTION
I think "ranged-based sharding" is not proper English