### PR TITLE
Added sytemctl enable command

### DIFF
--- a/source/tutorial/install-mongodb-on-ubuntu.txt
+++ b/source/tutorial/install-mongodb-on-ubuntu.txt
@@ -104,7 +104,16 @@ These instructions assume that you are using the official |package-name|
 package -- not the unofficial ``mongodb`` package provided by
 |distro-name| --  and are using the default settings.
 
-.. include:: /includes/steps/run-mongodb-on-debian.rst
+.. include:: /includes/steps/run-mongodb-on-debian.rst`
+
+Enable `service` **mongod**
+~~~~~~~~~
+
+Enabling `mongod` service will start mongod on system reboot:
+
+```
+systemctl enable mongod.service
+```
 
 Uninstall MongoDB Community Edition
 -----------------------------------


### PR DESCRIPTION
These commands will auto-start mongod server on each reboot and will keep mongod running. This is very important for every user, why this is not already there in the documentation?