### PR TITLE
(DOCS-12863): Forbid dropping oplog in all scenarios

### DIFF
--- a/source/core/replica-set-oplog.txt
+++ b/source/core/replica-set-oplog.txt
@@ -202,3 +202,15 @@ For more information on setting the slow operation threshold, see
 - The :dbcommand:`profile` command or :method:`db.setProfilingLevel()`
   shell helper method.
 
+.. _oplog-coll-behavior:
+
+Oplog Collection Behavior
+-------------------------
+
+If your MongoDB deployment uses the
+:ref:`WiredTiger Storage Engine <storage-wiredtiger>`, you cannot
+:dbcommand:`drop` the ``local.oplog.rs`` collection from any replica
+set member. This restriction applies to both single-member and
+multi-member replica sets. Dropping the oplog can lead to data
+inconsistencies in the replica set if a node temporarily
+goes down and attempts to replay the oplog during the restart process.

--- a/source/reference/command/replSetResizeOplog.txt
+++ b/source/reference/command/replSetResizeOplog.txt
@@ -46,6 +46,14 @@ You can only use :dbcommand:`replSetResizeOplog` on
 :binary:`~bin.mongod` instances running with the 
 :ref:`Wired Tiger storage engine <storage-wiredtiger>`.
 
+In MongoDB versions 3.4 and earlier, the oplog was resized by dropping
+and recreating the ``local.oplog.rs`` collection. In MongoDB versions
+3.6 and later, use the :dbcommand:`replSetResizeOplog` command to resize
+the oplog as shown in the :ref:`tutorial-change-oplog-size` tutorial.
+Starting in MongoDB 4.0, MongoDB forbids dropping the ``local.oplog.rs``
+collection. For more information on this restriction, see
+:ref:`oplog-coll-behavior`.
+
 Changing the oplog size of a given replica set member with
 :dbcommand:`replSetResizeOplog` does not change the oplog size of any
 other member in the replica set. You must run
@@ -132,4 +140,3 @@ The above command returns:
 .. [#oplog]
 
    .. include:: /includes/fact-oplog-size.rst
-

--- a/source/tutorial/change-oplog-size.txt
+++ b/source/tutorial/change-oplog-size.txt
@@ -1,3 +1,5 @@
+.. _tutorial-change-oplog-size:
+
 ============================
 Change the Size of the Oplog
 ============================
@@ -9,6 +11,19 @@ Change the Size of the Oplog
    :backlinks: none
    :depth: 1
    :class: singlecol
+
+.. warning::
+
+   In MongoDB versions 3.4 and earlier, the oplog was resized by
+   dropping and recreating the ``local.oplog.rs`` collection.
+   
+   In MongoDB versions 3.6 and later, use the
+   :dbcommand:`replSetResizeOplog` command to resize the oplog as shown
+   in this tutorial.
+   
+   Starting in MongoDB 4.0, MongoDB forbids dropping the
+   ``local.oplog.rs`` collection. For more information on this
+   restriction, see :ref:`oplog-coll-behavior`.
 
 This procedure changes the size of the oplog [#oplog]_ on each member of a
 replica set using the :dbcommand:`replSetResizeOplog` command, starting


### PR DESCRIPTION
I believe we should backport this change to v4.0