### PR TITLE
Kafka reference in Restrictions-on-Field-Names

### DIFF
--- a/source/includes/fact-document-field-name-restrictions.rst
+++ b/source/includes/fact-document-field-name-restrictions.rst
@@ -14,4 +14,5 @@
 
      Until support is added in the query language, the use of ``$`` and
      ``.`` in field names is not recommended and is not supported by
-     the official MongoDB drivers.
+     the official MongoDB drivers or services implementing the drivers
+     such as the [MongoDB Kafka Connector](https://docs.mongodb.com/kafka-connector/current/).


### PR DESCRIPTION
Field names that contain periods will fail when processed by the Kafka connector with "Invalid BSON field name". Even though this is failing due to JAVA-2810 it's worth noting explicitly in the documentation.