### PR TITLE
multiple reference are removed from same paragraph\page

### DIFF
--- a/source/reference/program/mongo.txt
+++ b/source/reference/program/mongo.txt
@@ -30,7 +30,7 @@ Description
 :binary:`~bin.mongo` is an interactive JavaScript shell interface to
 MongoDB, which provides a powerful interface for system
 administrators as well as a way for developers to test queries and
-operations directly with the database. :binary:`~bin.mongo` also provides
+operations directly with the database. :program:`mongo` also provides
 a fully functional JavaScript environment for use with a MongoDB.
 
 .. include:: /includes/fact-download-mongo-shell.rst
@@ -51,7 +51,7 @@ Syntax
 
      mongo
 
-- You can run :binary:`~bin.mongo` shell with a :doc:`connection string
+- You can run :program:`mongo` shell with a :doc:`connection string
   </reference/connection-string>` that specifies the host and port and
   other connection options. For example, the following includes the
   :urioption:`tls`:


### PR DESCRIPTION
removal of multiple referencing : the key word 'mongo' is referenced multiple times in same paragraph of same page under the same section.