### PR TITLE
Typo in `ss` command options

### DIFF
--- a/source/reference/installation-ubuntu-community-troubleshooting.txt
+++ b/source/reference/installation-ubuntu-community-troubleshooting.txt
@@ -200,7 +200,7 @@ without resolving any service names or hostnames (``-n``).
 
 .. code-block:: text
 
-   sudo ss --tulpn
+   sudo ss -tulpn
 
 The following partial output shows a ``mongod`` process 
 listening on the ``27017`` port. Attempting to run another ``mongod`` 


### PR DESCRIPTION
Using double `--` it is only valid for options in long format.

```
ubuntu@hostname:~$ cat /etc/issue
Ubuntu 18.04.4 LTS \n \l

ubuntu@host:~$ sudo ss --tulpn
ss: unrecognized option '--tulpn'
Usage: ss [ OPTIONS ]
(...)
```
Proposed fix:
```
ubuntu@hostname:~$ sudo ss -tulpn
Netid State   Recv-Q  Send-Q       Local Address:Port    Peer Address:Port                                                                                      
(...)
```
