### PR TITLE
(DOCS-13302): dateFromParts has lower bound of 1 for year and isoWeek…

### DIFF
--- a/source/reference/operator/aggregation/dateFromParts.txt
+++ b/source/reference/operator/aggregation/dateFromParts.txt
@@ -67,14 +67,18 @@ Definition
         - Calendar year. Can be any :ref:`expression
           <aggregation-expressions>` that evaluates to a number.
 
-          Value range: ``0``-``9999``
+          Value range: ``1``-``9999``
+
+          |outofrange-4.4|
 
       * - ``isoWeekYear``
         - Required if not using ``year``
         - ISO Week Date Year.  Can be any :ref:`expression
           <aggregation-expressions>` that evaluates to a number.
 
-          Value range:  ``0``-``9999``
+          Value range:  ``1``-``9999``
+
+          |outofrange-4.4|
 
       * - ``month``
         - Optional. Can only be used with ``year``.
@@ -190,6 +194,12 @@ Definition
    range, :expression:`$dateFromParts` incorporates the difference in
    the date calculation. See :ref:`dateFromParts-values` for examples.
 
+.. |outofrange-4.4| replace::
+   If the number specified is outside this range,
+   :expression:`$dateFromParts` errors. Starting in MongoDB 4.4, the
+   lower bound for this value is ``1``. In previous versions of MongoDB,
+   the lower bound was ``0``.
+
 Behavior
 --------
 
@@ -198,8 +208,13 @@ Behavior
 Value Range
 ~~~~~~~~~~~
 
+Starting in MongoDB 4.4, the supported value range for ``year`` and
+``isoWeekYear`` is ``1-9999``. In prior versions of MongoDB, the lower
+bound for these values was ``0`` and the supported value range was
+``0-9999``.
+
 Starting in MongoDB 4.0, if the value specified for fields other than
-``year``, ``isoYear``, and ``timezone`` is outside the valid range,
+``year``, ``isoWeekYear``, and ``timezone`` is outside the valid range,
 :expression:`$dateFromParts` carries or subtracts the difference from
 other date parts to calculate the date.
 

--- a/source/release-notes/4.4-compatibility.txt
+++ b/source/release-notes/4.4-compatibility.txt
@@ -76,6 +76,10 @@ General Changes
   :serverstatus:`flowControl.locksPerKiloOp` instead of
   :serverstatus:`flowControl.locksPerOp`.
 
+- The :expression:`$dateFromParts` expression operator now supports
+  a value range of ``1-9999`` for the ``year`` and ``isoWeekYear``
+  fields. In previous versions, the supported value range for these
+  fields was ``0-9999``.
 
 .. _4.4-compatibility-enabled:
 


### PR DESCRIPTION
…Year