### PR TITLE
Fix typo in the documentation of Compact page

### DIFF
--- a/source/reference/command/compact.txt
+++ b/source/reference/command/compact.txt
@@ -113,14 +113,14 @@ For more information on configuring the ``resource`` document, see
 :ref:`resource-document`.
 
 To add the :authrole:`dbAdmin` or the custom role to an existing
-user, use :method:`db.grantRoleToUser` or :method:`db.updateUser()`.
+user, use :method:`db.grantRolesToUser` or :method:`db.updateUser()`.
 The following operation grants the custom ``compact`` role to the 
 ``myCompactUser`` on the ``admin`` database:
 
 .. code-block:: javascript
 
    use admin
-   db.grantRoleToUser("myCompactUser", [ "dbAdmin" | "myCustomCompactRole" ] )
+   db.grantRolesToUser("myCompactUser", [ "dbAdmin" | "myCustomCompactRole" ] )
 
 To add the :authrole:`dbAdmin` or the custom role to a new user,
 specify the role to the ``roles`` array of the


### PR DESCRIPTION
grantRoleToUser method does not exists, the method is grantRolesToUser