### PR TITLE
Keep key separate from main trusted.gpg file.

### DIFF
--- a/source/includes/steps-install-mongodb-on-ubuntu.yaml
+++ b/source/includes/steps-install-mongodb-on-ubuntu.yaml
@@ -8,7 +8,7 @@ content: |
 
     .. code-block:: sh
 
-       wget -qO - https://www.mongodb.org/static/pgp/server-{+pgp-version+}.asc | sudo apt-key add -
+       wget -qO - https://www.mongodb.org/static/pgp/server-{+pgp-version+}.asc | sudo apt-key --keyring /etc/apt/trusted.gpg.d/mongodb.gpg add -
 
     The operation should respond with an ``OK``. 
     


### PR DESCRIPTION
This is similar to how the source is kept in `sources.list.d` further down. This will keep it all consistent and make it very easier to maintain the mongo repository and its keys.