### PR TITLE
Clarify the versions are for the driver library

### DIFF
--- a/source/includes/3.6-drivers.rst
+++ b/source/includes/3.6-drivers.rst
@@ -1,21 +1,21 @@
 .. list-table::
    :class: index-table
 
-   * - Java 3.6+
+   * - Java: mongodb-driver-sync 3.6+
 
-       Python 3.6+
+       Python: pymongo 3.6+
 
-       C 1.9+
+       C: libmongoc 1.9+
 
-     - C# 2.5+
+     - C#: MongoDB.Driver 2.5+
 
-       Node 3.0+
+       Node: mongodb 3.0+
 
-       Ruby 2.5+
+       Ruby: mongodb 2.5+
 
-     - Perl 2.0+
+     - Perl: MongoDB 2.0+
 
-       PHPC 1.4+
+       PHPC: mongodb 1.4+
 
-       Scala 2.2+
+       Scala: mongo-scala-driver 2.2+
 


### PR DESCRIPTION
Without the driver names, it looks like the version numbers might be for the language rather than the driver (which is confusing, at least for Ruby, which is currently at v2.7)