### PR TITLE
Update appendixA-openssl-ca.txt

### DIFF
--- a/source/appendix/security/appendixA-openssl-ca.txt
+++ b/source/appendix/security/appendixA-openssl-ca.txt
@@ -154,12 +154,12 @@ B. Generate the Test CA PEM File
 
       openssl x509 -sha256 -req -days 730 -in mongodb-test-ia.csr -CA mongodb-test-ca.crt -CAkey mongodb-test-ca.key -set_serial 01 -out mongodb-test-ia.crt -extfile openssl-test-ca.cnf -extensions v3_ca
 
-#. Create the :red:`test` CA PEM file from the :red:`test` CA certificate  :file:`mongod-test-ca.crt` and
-   :red:`test` intermediate certificate :file:`mongodb-test-ia.crt`.
+#. Create the :red:`test` CA PEM file from the :red:`test` intermediate certificate :file:`mongodb-test-ia.crt` and
+   :red:`test` CA certificate  :file:`mongod-test-ca.crt`.
 
    .. code-block:: sh
 
-      cat mongodb-test-ca.crt mongodb-test-ia.crt  > test-ca.pem
+      cat mongodb-test-ia.crt mongodb-test-ca.crt > test-ca.pem
 
 You can use the :red:`test` PEM file when configuring :binary:`~bin.mongod`,
 :binary:`~bin.mongos`, or :binary:`~bin.mongo` for TLS/SSL :red:`testing`.


### PR DESCRIPTION
CA bundle has to be in order intermediate > root; see this pastebin for example: https://pastebin.com/raw/dWe8KkJE .. If this isn't the case, you will recent an error "error 7 at 0 depth lookup: certificate signature failure" when manually verifying, or this in mongod.log: "SSL peer certificate validation failed: certificate signature failure"