### PR TITLE
rephrase warning

### DIFF
--- a/source/reference/operator/aggregation/merge.txt
+++ b/source/reference/operator/aggregation/merge.txt
@@ -395,8 +395,8 @@ The :pipeline:`$merge` takes a document with the following fields:
 
            - ..  _merge-whenNotMatched-fail:
 
-             Stop and fail the aggregation operation. Any changes to
-             the output collection from previous documents are not
+             Stop and fail the aggregation operation. Any changes 
+             already written to the output collection are not
              reverted.
 
 


### PR DESCRIPTION
To avoid implying that writes happen in certain order