### PR TITLE
correction to scope of metric

### DIFF
--- a/source/reference/command/serverStatus.txt
+++ b/source/reference/command/serverStatus.txt
@@ -949,7 +949,7 @@ opLatencies
 
 .. serverstatus:: opLatencies
 
-   A document containing operation latencies for the database as a whole.
+   A document containing operation latencies for the instance as a whole.
    See :ref:`latency-stats-document` for an description of this document.
 
    Only :binary:`~bin.mongod` instances report


### PR DESCRIPTION
serverStatus shows metrics for mongod as a whole, not for an individual database.