### PR TITLE
adds php and ruby as csfle supported drivers

### DIFF
--- a/source/core/security-client-side-encryption.txt
+++ b/source/core/security-client-side-encryption.txt
@@ -445,6 +445,14 @@ the following official 4.2-compatible driver versions:
      - ``2.8.0+``
      - `Scala Documentation <https://mongodb.github.io/mongo-scala-driver/2.8/>`__
 
+   * - :ecosystem:`PHP </drivers/php>`
+     - ``1.6.0+``
+     - `PHP Driver Quickstart <https://docs.mongodb.com/php-library/current/tutorial/client-side-encryption/>`__
+
+   * - `Ruby <https://docs.mongodb.com/ruby-driver/current/>`__
+     - ``2.12.0+``
+     - `Ruby Driver Quickstart <https://docs.mongodb.com/ruby-driver/current/tutorials/client-side-encryption/>`__
+
 Please refer to the driver reference documentation for syntax and
 implementation examples.
 


### PR DESCRIPTION
Per [this comment](https://mongodb.slack.com/archives/C0V2QUP4H/p1588358916158800) in Slack, PHP and Ruby officially support CSFLE and should be added to the supported driver table.

[Staged](https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/csfle-driver-support/core/security-client-side-encryption.html#driver-compatibility-table)