### PR TITLE
Fix typo in intentionally non-existent field

### DIFF
--- a/source/reference/operator/aggregation/sum.txt
+++ b/source/reference/operator/aggregation/sum.txt
@@ -147,7 +147,7 @@ The following operation attempts to :group:`$sum` on ``qty``:
           $group:
             {
               _id: { day: { $dayOfYear: "$date"}, year: { $year: "$date" } },
-              totalAmount: { $sum: "$quantity" },
+              totalAmount: { $sum: "$qty" },
               count: { $sum: 1 }
             }
         }


### PR DESCRIPTION
The paragraph above refers to an intentionally non-existent field $qty. This commit fixes the code so that it matches the non-existent field (rather than the real field).