### PR TITLE
Change single quotes to double quotes

### DIFF
--- a/source/includes/extracts-clone-copy-db-examples.yaml
+++ b/source/includes/extracts-clone-copy-db-examples.yaml
@@ -20,7 +20,7 @@ content: |
 
           .. code-block:: sh
 
-             mongorestore --archive="mongodump-test-db" --nsFrom='test.*' --nsTo='examples.*'
+             mongorestore --archive="mongodump-test-db" --nsFrom="test.*" --nsTo="examples.*"
 
       .. tip::
 
@@ -34,5 +34,5 @@ content: |
 
       .. code-block:: sh
 
-         mongodump --archive --db=test | mongorestore --archive  --nsFrom='test.*' --nsTo='examples.*'  
+         mongodump --archive --db=test | mongorestore --archive  --nsFrom="test.*" --nsTo="examples.*"  
 ...


### PR DESCRIPTION
Single quotes in the --nsFrom and --nsTo parameters are NOT understood through the command line mongorestore tool, and prevent it from working as intended (instead of replacing test.*, it replaces 'test.*') . Double quotes maintain the consistency of the similarly double-quoted command arguments, and allow this command to function normally.