### PR TITLE
Updated info for opcounters and opcountersRepl

### DIFF
--- a/source/reference/command/serverStatus.txt
+++ b/source/reference/command/serverStatus.txt
@@ -1315,6 +1315,8 @@ opcounters
 
       Additionally, these values reflect received operations, and
       increment even when operations are not successful.
+      
+      Data in :serverstatus:`opcounters` counts the number of operations in a node only when the node is the PRIMARY node for the replica set.  See opcountersRepl for counting operations when a node is SECONDARY in a replica set.
 
 .. serverstatus:: opcounters.insert
 
@@ -1389,10 +1391,10 @@ opcountersRepl
    since the :binary:`~bin.mongod` instance last started.
 
    These values only appear when the current host is a member of a
-   replica set.
+   replica set.  These counters only count operations on secondary nodes of a replica set. See :serverstatus:`opcounters` for counters for the primary node.
 
    These values will differ from the :serverstatus:`opcounters` values
-   because of how MongoDB serializes operations during replication.
+   because of how MongoDB serializes operations during replication.  I.e., A single operation on the primary can translate to multiple operations on the replicate.
    See :doc:`/replication` for more information on replication.
 
    These numbers will grow over time in response to database use until
@@ -1403,35 +1405,35 @@ opcountersRepl
 
 .. serverstatus:: opcountersRepl.insert
 
-   The total number of replicated insert operations since the
+   The total number of insert operations on a replicate node since the
    :binary:`~bin.mongod` instance last started.
 
    .. include:: /includes/extracts/4.2-changes-opcountersRepl-type.rst
 
 .. serverstatus:: opcountersRepl.query
 
-   The total number of replicated queries since the :binary:`~bin.mongod`
+   The total number of queries on a replicate node since the :binary:`~bin.mongod`
    instance last started.
 
    .. include:: /includes/extracts/4.2-changes-opcountersRepl-type.rst
 
 .. serverstatus:: opcountersRepl.update
 
-   The total number of replicated update operations since the
+   The total number of update operations on a replicate node since the
    :binary:`~bin.mongod` instance last started.
 
    .. include:: /includes/extracts/4.2-changes-opcountersRepl-type.rst
 
 .. serverstatus:: opcountersRepl.delete
 
-   The total number of replicated delete operations since the
+   The total number of delete operations on a replicate node since the
    :binary:`~bin.mongod` instance last started.
 
    .. include:: /includes/extracts/4.2-changes-opcountersRepl-type.rst
 
 .. serverstatus:: opcountersRepl.getmore
 
-   The total number of "getmore" operations since the :binary:`~bin.mongod`
+   The total number of "getmore" operations on a replicate node since the :binary:`~bin.mongod`
    instance last started. This counter can be high even if the query
    count is low. Secondary nodes send ``getMore`` operations as part of
    the replication process.
@@ -1440,7 +1442,7 @@ opcountersRepl
 
 .. serverstatus:: opcountersRepl.command
 
-   The total number of replicated commands issued to the database since
+   The total number of commands on a replicate node issued to the database since
    the :binary:`~bin.mongod` instance last started.
 
    .. include:: /includes/extracts/4.2-changes-opcountersRepl-type.rst


### PR DESCRIPTION
Updated text to indicate that opcounters are only for the primary node, and opcountersRepl are only for secondary nodes.  Based on a discussion with Doug Duncan in:
https://developer.mongodb.com/community/forums/t/how-are-opcountersrepl-different-from-opcounters/4079