### PR TITLE
Added a 'snapshot' option to readConcernLevel in connection string

### DIFF
--- a/source/reference/connection-string.txt
+++ b/source/reference/connection-string.txt
@@ -825,6 +825,7 @@ The following connection string to a replica set specifies
        - :readconcern:`majority <"majority">`
        - :readconcern:`linearizable <"linearizable">`
        - :readconcern:`available <"available">`
+       - :readconcern:`snapshot <"snapshot">`
 
        This connection string option is not available for the
        :binary:`~bin.mongo` shell. Specify the read concern as an


### PR DESCRIPTION
It seems that a `snapshot` option of `readConcernLevel` has been missed in the document.