### PR TITLE
(DOCSP-10116): Add Online Archive callout to mongodump/export

### DIFF
--- a/source/includes/fact-online-archive-callout.rst
+++ b/source/includes/fact-online-archive-callout.rst
@@ -1,0 +1,5 @@
+If you are archiving stale data to save on storage costs, consider
+:atlas:`Online Archive </online-archive/manage-online-archive>` in
+`MongoDB Atlas <https://www.mongodb.com/cloud?jmp=docs>`__. Online
+Archive automatically archives infrequently accessed data to
+fully-managed S3 buckets for cost-effective data tiering.

--- a/source/reference/program/mongodump.txt
+++ b/source/reference/program/mongodump.txt
@@ -30,6 +30,10 @@ from either :binary:`~bin.mongod` or :binary:`~bin.mongos` instances;
 i.e. can export data from standalone, replica set, and sharded cluster
 deployments.
 
+.. note::
+
+   .. include:: /includes/fact-online-archive-callout.rst
+
 .. _mongodump-availability:
 
 Availability
@@ -1002,5 +1006,3 @@ As an alternative, users can use :binary:`~bin.mongodump` and
 <mongorestore --nsFrom>`).
 
 .. include:: /includes/extracts/clone-copy-db-same-instance.rst
-
-

--- a/source/reference/program/mongoexport.txt
+++ b/source/reference/program/mongoexport.txt
@@ -34,6 +34,10 @@ or CSV export of data stored in a MongoDB instance.
    :binary:`~bin.mongoimport` which provides the corresponding "import"
    capability.
 
+.. note::
+
+   .. include:: /includes/fact-online-archive-callout.rst
+
 .. _mongoexport-availability:
 
 Availability


### PR DESCRIPTION
Using same copy from https://github.com/mongodb/docs-commandline-tools/pull/16

Staged: [mongodump](https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/DOCSP-10116-new/reference/program/mongodump.html)

[mongoexport](https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/DOCSP-10116-new/reference/program/mongoexport.html)