### PR TITLE
Applied IEC 60027-2 standard

### DIFF
--- a/source/reference/command/dbStats.txt
+++ b/source/reference/command/dbStats.txt
@@ -47,7 +47,7 @@ Definition
         
           Optional. The scale factor for the various size data. The
           ``scale`` defaults to 1 to return size data in bytes. To
-          display kilobytes rather than bytes, specify a ``scale``
+          display kibibytes rather than bytes, specify a ``scale``
           value of ``1024``.
 
           If you specify a non-integer scale factor, MongoDB uses the

--- a/source/reference/method/db.collection.stats.txt
+++ b/source/reference/method/db.collection.stats.txt
@@ -54,7 +54,7 @@ Definition
         - number
    
         - Optional. The scale factor for the various size data. The ``scale`` defaults
-          to 1 to return size data in bytes. To display kilobytes rather than
+          to 1 to return size data in bytes. To display kibibytes rather than
           bytes, specify a ``scale`` value of ``1024``.
           
           If you specify a non-integer scale factor, MongoDB uses the integer
@@ -417,7 +417,7 @@ As stats was not give a scale parameter, all size values are in ``bytes``.
 Stats Lookup With Scale
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-The following operation changes the scale of data from ``bytes`` to ``kilobytes``
+The following operation changes the scale of data from ``bytes`` to ``kibibytes``
 by specifying a ``scale`` of ``1024``:
 
 .. code-block:: javascript

--- a/source/reference/method/db.stats.txt
+++ b/source/reference/method/db.stats.txt
@@ -43,7 +43,7 @@ The :method:`db.stats()` method has the following optional parameter:
 
        Optional. The scale factor for the various size data. The
        ``scale`` defaults to 1 to return size data in bytes. To
-       display kilobytes rather than bytes, specify a ``scale``
+       display kibibytes rather than bytes, specify a ``scale``
        value of ``1024``.
 
        If you specify a non-integer scale factor, MongoDB uses the
@@ -96,7 +96,7 @@ Accuracy after Unexpected Shutdown
 Example
 -------
 
-The following example returns various size values in kilobytes:
+The following example returns various size values in kibibytes:
 
 .. code-block:: javascript
 

--- a/source/reference/operator/aggregation/collStats.txt
+++ b/source/reference/operator/aggregation/collStats.txt
@@ -65,7 +65,7 @@ Definition
 
           - Specify the scale factor (i.e. ``storageStats: { scale:
             <number> }``) to use the specified scale factor for the
-            various size data. For example, to display kilobytes rather
+            various size data. For example, to display kibibytes rather
             than bytes, specify a scale value of 1024.
                         
             If you specify a non-integer scale factor, MongoDB uses the integer


### PR DESCRIPTION
Applied IEC 60027-2. (another possibility would be to put KiB instead of kibibytes).
But kilobytes is incorrect.