### PR TITLE
(DOCSP-10774): Fix bad refs in Compass index instructions

### DIFF
--- a/source/includes/steps-create-index-compass.yaml
+++ b/source/includes/steps-create-index-compass.yaml
@@ -50,51 +50,49 @@ content: |
         - If checked, ensure that the MongoDB deployment remains
           available during the index build operation.
 
-        - :manual:`Background Construction </core/index-creation/index.html#background-construction>`
+        - :ref:`Background Construction <index-creation-background>`
 
       * - Create unique index
 
         - If checked, ensure that the indexed fields do not
           store duplicate values.
 
-        - :manual:`Unique Indexes </core/index-unique>`
+        - :ref:`Unique Indexes <index-type-unique>`
 
       * - Create :abbr:`TTL (Time to Live)`
 
         - If checked, automatically delete documents after a
           specified number of seconds since the indexed field value.
 
-        - :manual:`TTL Indexes </core/index-ttl>`
+        - :ref:`TTL Indexes <index-feature-ttl>`
 
       * - Partial filter expression
       
         - If checked, only index documents which match the specified
           filter expression.
 
-          .. example::
+          For example, the following partial filter expression only
+          indexes documents where the ``timezone`` field exists:
 
-             The following partial filter expression only indexes
-             documents where the ``timezone`` field exists:
+          .. code-block:: js
 
-             .. code-block:: js
-
-                { "timezone": { "$exists": true } } 
+            { "timezone": { "$exists": true } } 
       
-        - :manual:`Partial Indexes </core/index-partial/>`
+        - :ref:`Partial Indexes <index-type-partial>`
 
       * - Use custom collation
 
         - If checked, create a custom collation for the index
           using the options provided in Compass.
 
-        - :manual:`Collation Document </reference/collation/#collation-document>`
+        - :ref:`Collation Document <collation-document-fields>`
 
       * - Wildcard projection (*New in MongoDB 4.2*)
         
         - If checked, support unknown or arbitrary fields
           which match the specified projection in the index.
 
-        - :manual-next:`Wildcard Indexes </core/index-wildcard/>`
+        - :ref:`wildcard-index-core`
 ---
 title: Click :guilabel:`Create` to create the index.
 level: 4


### PR DESCRIPTION
Hey @kay-kim, opening this PR to fix the comments you pointed out in https://github.com/mongodb/docs/commit/559f6da74008d07c1b79c2aeaf42649ef27aa46c. Would you mind taking a quick look at this before merge, then I'll backport?

Thanks and sorry for the mixups in the last merge!

