### PR TITLE
correcting where merging happens

### DIFF
--- a/source/core/sharded-cluster-query-router.txt
+++ b/source/core/sharded-cluster-query-router.txt
@@ -46,8 +46,8 @@ cluster>` by:
 The :binary:`~bin.mongos` then merges the data from each of the
 targeted shards and returns the result document. Certain
 query modifiers, such as :ref:`sorting<sharding-mongos-sort>`,
-are performed on a shard such as the :term:`primary shard` before
-:binary:`~bin.mongos` retrieves the results.
+are performed on each shard before :binary:`~bin.mongos` 
+retrieves the results.
 
 .. versionchanged:: 3.6
 


### PR DESCRIPTION
Removed incorrect reference to primary shard

This should be fixed in master and 4.2 and 4.0