### PR TITLE
DOCS-13378 Change repair to only rebuild indexes on repaired collections

### DIFF
--- a/source/reference/program/mongod.txt
+++ b/source/reference/program/mongod.txt
@@ -1509,14 +1509,17 @@ Storage Options
 
 
 .. option:: --repair
-
-   
-   .. versionchanged:: 4.0.3
    
    Runs a repair routine on all databases for a :binary:`~bin.mongod`
-   instance. The operation attempts to salvage corrupt data as well as
-   rebuilds all the indexes. The operation discards any corrupt data
-   that cannot be salvaged.
+   instance. The operation attempts to: 
+   
+   - Salvage corrupt data. The operation discards any corrupt 
+     data that cannot be salvaged. 
+   - Rebuild indexes. The operation validates collections and rebuilds 
+     all indexes for collections with inconsistencies between the 
+     collection data and one or more indexes. The operation also 
+     rebuilds indexes for all salvaged and modified collections. 
+     (*Changed in version 4.4.*)
    
    .. tip::
    

--- a/source/release-notes/4.4.txt
+++ b/source/release-notes/4.4.txt
@@ -1428,6 +1428,19 @@ Validation Data Throughput Information
 
 .. seealso:: :ref:`4.4-validate-method-signature`
 
+``mongod --repair`` Behavior Change 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Starting in MongoDB 4.4, the :option:`mongod --repair` rebuilds all 
+indexes for the following: 
+
+- Collections with inconsistencies between the collection data and 
+  one or more indexes.
+- Salvaged and modified collections. 
+
+In earlier versions of MongoDB, the :option:`mongod --repair` option 
+rebuilt all indexes for all collections.
+
 ``serverStatus`` Output Change
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/tutorial/recover-data-following-unexpected-shutdown.txt
+++ b/source/tutorial/recover-data-following-unexpected-shutdown.txt
@@ -50,10 +50,11 @@ these cases:
    The operation removes and does not save any corrupt data during the
    repair process.
 
-Starting in MongoDB 4.0.3, for the WiredTiger storage engine,
+Starting in MongoDB 4.4, for the WiredTiger storage engine, 
 :option:`mongod --repair`:
 
-- Rebuilds all indexes.
+- Rebuilds all indexes for collections with one or more inconsistent 
+  indexes.
 
 - Discards corrupt data.
 


### PR DESCRIPTION
- [JIRA](https://jira.mongodb.org/browse/DOCS-13378)
- [CR](https://mongodbcr.appspot.com/607390004/)
- Stage:
  - [--repair](https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/DOCS-13378/reference/program/mongod.html#cmdoption-mongod-repair)
  - [Recover a Standalone after an Unexpected Shutdown](https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/DOCS-13378/tutorial/recover-data-following-unexpected-shutdown.html)
  - [Release Notes](https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/DOCS-13378/release-notes/4.4.html#mongod-repair-behavior-change)