### PR TITLE
Backport DOCS-13475 to v4.2

### DIFF
--- a/source/core/security-client-side-encryption.txt
+++ b/source/core/security-client-side-encryption.txt
@@ -450,7 +450,7 @@ the following official 4.2-compatible driver versions:
      - `PHP Driver Quickstart <https://docs.mongodb.com/php-library/current/tutorial/client-side-encryption/>`__
 
    * - `Ruby <https://docs.mongodb.com/ruby-driver/current/>`__
-     - ``2.12.0+``
+     - ``2.12.1+``
      - `Ruby Driver Quickstart <https://docs.mongodb.com/ruby-driver/current/tutorials/client-side-encryption/>`__
 
 Please refer to the driver reference documentation for syntax and


### PR DESCRIPTION
DOCS-13475: update ruby driver version to 2.12.1 for CSFLE support