### PR TITLE
Update parameters.txt about parameters reverting to default after reboot unless set in config file or cmd line opt

### DIFF
--- a/source/reference/parameters.txt
+++ b/source/reference/parameters.txt
@@ -22,7 +22,7 @@ using:
 
      db.adminCommand( { setParameter: 1, <parameter>: <value>  } )
 
-- the :setting:`setParameter` configuration setting:
+- the :setting:`setParameter` configuration setting in the boot time configuration file:
 
   .. code-block:: yaml
 
@@ -41,6 +41,8 @@ using:
 For additional configuration options, see
 :doc:`/reference/configuration-options`, :binary:`~bin.mongod` and
 :binary:`~bin.mongos`.
+
+Changes made via the :dbcommand:`setParameter` will revert to defaults after reboot unless they're included in either the boot time configuration file or the ``--setParameter`` command-line option.
 
 Parameters
 ----------


### PR DESCRIPTION
Added a note saying parameters set via the :dbcommand:`setParameter` option will revert to default after reboot unless set in the config file or command line options.

This may seem obvious once you know it, but it's different from a lot of other database systems.

Ben Slade
DBA @ NCBI.NLM.NIH.gov