### PR TITLE
Correct typo with grep command.

### DIFF
--- a/source/tutorial/install-mongodb-on-os-x.txt
+++ b/source/tutorial/install-mongodb-on-os-x.txt
@@ -184,7 +184,7 @@ assume that you are using the default settings.
 
    .. code-block:: sh
 
-      ps aux | grep -v grep | grep mongod
+      ps aux | grep mongod
 
    You can also view the log file to see the current status of your
    ``mongod`` process: ``/usr/local/var/log/mongodb/mongo.log``.


### PR DESCRIPTION
I think this was a typo, the command works fine without the extra `grep -v grep`. Please ignore if it was not.