### PR TITLE
(DOCSP-12786) ldapQueryPassword setParameter accepts an array of strings in 4.4

### DIFF
--- a/source/reference/program/mongod.txt
+++ b/source/reference/program/mongod.txt
@@ -980,7 +980,7 @@ LDAP Authentication or Authorization Options
    This setting can be configured on a running :program:`mongod` using
    :dbcommand:`setParameter`.
 
-   Starting in MongoDB 4.3, the ``ldapQueryPassword``
+   Starting in MongoDB 4.4, the ``ldapQueryPassword``
    :dbcommand:`setParameter` command accepts either a string or 
    an array of strings. If set to an array, each password is tried 
    until one succeeds. This can be used to perform a rollover of the 

--- a/source/reference/program/mongod.txt
+++ b/source/reference/program/mongod.txt
@@ -982,7 +982,7 @@ LDAP Authentication or Authorization Options
 
    Starting in MongoDB 4.3, the ``ldapQueryPassword``
    :dbcommand:`setParameter` command accepts either a string or 
-   an array of strings. If set to an array, it will try each password 
+   an array of strings. If set to an array, each password is tried 
    until one succeeds. This can be used to perform a rollover of the 
    LDAP account password without downtime for MongoDB.
    

--- a/source/reference/program/mongod.txt
+++ b/source/reference/program/mongod.txt
@@ -979,6 +979,12 @@ LDAP Authentication or Authorization Options
    
    This setting can be configured on a running :program:`mongod` using
    :dbcommand:`setParameter`.
+
+   Starting in MongoDB 4.3, the ``ldapQueryPassword``
+   :dbcommand:`setParameter` command accepts either a string or 
+   an array of strings. If set to an array, it will try each password 
+   until one succeeds. This can be used to perform a rollover of the 
+   LDAP account password without downtime for MongoDB.
    
    .. note::
    

--- a/source/release-notes/4.4.txt
+++ b/source/release-notes/4.4.txt
@@ -1094,6 +1094,15 @@ For more information on structured logging, including a detailed
 examination of log entry components as well as command-line parsing
 examples, see :doc:`Log Messages </reference/log-messages>`.
 
+Multiple LDAP Password Support
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Starting in MongoDB 4.4, the ``ldapQueryPassword``
+:dbcommand:`setParameter` command accepts either a string or 
+an array of strings. If set to an array, each password is tried 
+until one succeeds. This can be used to perform a rollover of the 
+LDAP account password without downtime for MongoDB.
+
 Platform Support
 ----------------
 


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DOCS-12786)
[appspot review](https://mongodbcr.appspot.com/646070002/)

Staged
[mongod option](https://docs-mongodbcom-staging.corp.mongodb.com/zach.carr/DOCSP-12786/reference/program/mongod.html#cmdoption-mongod-ldapquerypassword)
[Release note item](https://docs-mongodbcom-staging.corp.mongodb.com/zach.carr/DOCSP-12786/release-notes/4.4.html#multiple-ldap-password-support)