### PR TITLE
Spelling correction: then to than in source/reference/operator/aggregation/bucketAuto.txt

### DIFF
--- a/source/reference/operator/aggregation/bucketAuto.txt
+++ b/source/reference/operator/aggregation/bucketAuto.txt
@@ -172,7 +172,7 @@ There may be less than the specified number of buckets if:
 - The number of unique values of the ``groupBy`` expression is less
   than the specified number of ``buckets``.
 
-- The ``granularity`` has fewer intervals then the number of
+- The ``granularity`` has fewer intervals than the number of
   ``buckets``.  
   
 - The ``granularity`` is not fine enough to evenly distribute documents


### PR DESCRIPTION
Spelling correction: then to than in source/reference/operator/aggregation/bucketAuto.txt