### PR TITLE
Move $in and $nin to the Array Operator Category

### DIFF
--- a/source/reference/operator/query.txt
+++ b/source/reference/operator/query.txt
@@ -43,10 +43,6 @@ Comparison
 
      - Matches values that are greater than or equal to a specified value.
 
-   * - :query:`$in`
-
-     - Matches any of the values specified in an array.
-
    * - :query:`$lt`
 
      - Matches values that are less than a specified value.
@@ -58,10 +54,6 @@ Comparison
    * - :query:`$ne`
 
      - Matches all values that are not equal to a specified value.
-
-   * - :query:`$nin`
-
-     - Matches none of the values specified in an array.
 
 
 .. toctree::
@@ -252,6 +244,14 @@ Array
 
      - Selects documents if element in the array field matches all the specified :query:`$elemMatch` conditions.
 
+   * - :query:`$in`
+
+     - Matches any of the values specified in an array.
+
+   * - :query:`$nin`
+
+     - Matches none of the values specified in an array.
+     
    * - :query:`$size`
 
      - Selects documents if the array field is a specified size.


### PR DESCRIPTION
`$in` and `$nin` should be located in the Array operators category.  `$all` is already in this category and all three of these strongly-related operators should be grouped together.