### PR TITLE
Fix transctions typo in extracts-transactions file

### DIFF
--- a/source/includes/extracts-transactions.yaml
+++ b/source/includes/extracts-transactions.yaml
@@ -574,7 +574,7 @@ content: |
         <transactions-read-preference>`.
 
       - In MongoDB 4.2 and earlier, you cannot create collections in
-        transctions. Write operations that result in document inserts
+        transactions. Write operations that result in document inserts
         (e.g. ``insert`` or update operations with ``upsert: true``)
         must be on **existing** collections if run inside transactions.
 


### PR DESCRIPTION
I fixed a small typo (missing `a`) in the extract-transactions.yaml file `transctions` -> `transactions`

BTW I hope the PR format follow the standards, I wanted to read https://github.com/mongodb/docs/blob/master/CONTRIBUTING.rst but all links redirect to a 404)