### PR TITLE
Note the limitation on $lookup in sharding-unavailable-operations

### DIFF
--- a/source/includes/limits-sharding-unavailable-operations.rst
+++ b/source/includes/limits-sharding-unavailable-operations.rst
@@ -4,3 +4,6 @@ un-sharded collections.
 
 The :dbcommand:`geoSearch` command is not supported in sharded
 environments.
+
+The  :pipeline:`$lookup` aggregation pipeline stage cannot read
+from a sharded collection.


### PR DESCRIPTION
It's nice to have all the restrictions in one place.