### PR TITLE
Add another example for sorting with indexes

### DIFF
--- a/source/tutorial/sort-results-with-indexes.txt
+++ b/source/tutorial/sort-results-with-indexes.txt
@@ -184,9 +184,13 @@ The following operations can use the index to get the sort order:
 
    * - ``db.data.find( { a: 5 } ).sort( { b: 1, c: 1 } )``
 
-     - ``{ a: 1 , b: 1, c: 1 }``
+     - ``{ a: 1, b: 1, c: 1 }``
 
    * - ``db.data.find( { b: 3, a: 4 } ).sort( { c: 1 } )``
+
+     - ``{ a: 1, b: 1, c: 1 }``
+
+   * - ``db.data.find( { a: 5, c: 2 } ).sort( { b: 1 } )``
 
      - ``{ a: 1, b: 1, c: 1 }``
 


### PR DESCRIPTION
While reading the documentation to find an optimal index for a query with sort, I found that the documentation didn't cover a case where `find()` contains a field that's defined in the index after the field used by `sort()`. This PR adds an example for it.