### PR TITLE
Prevent Warning on multiarch system

### DIFF
--- a/source/includes/steps-install-mongodb-enterprise-on-debian.yaml
+++ b/source/includes/steps-install-mongodb-enterprise-on-debian.yaml
@@ -20,14 +20,14 @@ content: |
 
         .. code-block:: sh
 
-           echo "deb http://repo.mongodb.com/apt/debian buster/mongodb-enterprise/{+version+} main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+           echo "deb [ arch=amd64 ] http://repo.mongodb.com/apt/debian buster/mongodb-enterprise/{+version+} main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
      .. tab:: Debian 9 "Stretch"
         :tabid: debian-9-stretch
 
         .. code-block:: sh
 
-           echo "deb http://repo.mongodb.com/apt/debian stretch/mongodb-enterprise/{+version+} main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+           echo "deb [ arch=amd64 ] http://repo.mongodb.com/apt/debian stretch/mongodb-enterprise/{+version+} main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
   If you'd like to install MongoDB Enterprise packages from a
   particular :ref:`release series <release-version-numbers>`, you can


### PR DESCRIPTION
When the system amd64 and i386 coexist must be modified sources.list to indicate that use only amd64.

```
n: the use of the file omitting set "main / binary-i386 / packages" since the repository "http://repo.mongodb.org/apt/debian buster / mongodb-org / 4.4 inrelease" does not support architecture "i386"
```