### PR TITLE
Update to "Use $lookup with an array" section

### DIFF
--- a/source/reference/operator/aggregation/lookup.txt
+++ b/source/reference/operator/aggregation/lookup.txt
@@ -414,7 +414,7 @@ Create another collection ``members`` with the following documents:
    ])
 
 The following aggregation operation joins documents in the ``classes``
-collection with the ``members`` collection, matching on the ``members``
+collection with the ``members`` collection, matching on the ``enrollmentList``
 field to the ``name`` field:
 
 .. code-block:: javascript


### PR DESCRIPTION
Correct field name referenced in the 'Use $lookup with an array' section from 'members' to 'enrollmentList', as members is a collection and not a field and enrollmentList is the appropriate to mention here.