### PR TITLE
DOCSP-9411 warn about dropping indexes

### DIFF
--- a/source/core/index-creation.txt
+++ b/source/core/index-creation.txt
@@ -246,12 +246,18 @@ Secondary Index Builds May Stall Read and Write Operations
   build releases that lock.
 
 Secondaries Process Index Drops After Index Build Completes
-  Dropping the index on the primary before secondaries
-  complete the replicated index build does not kill the secondary index
-  builds. When the secondary replicates the index drop, it must wait
-  until *after* the index build completes to apply the drop.
-  Furthermore, since index drops are a metadata operation on the
-  collection, the index drop stalls replication on that secondary.
+  Avoid dropping an index on a collection while any index is being
+  replicated on a secondary.
+
+  If you attempt to drop an index from a collection on a :term:`primary`
+  while the collection has a background index building on the
+  :term:`secondary`, the two indexing operations will conflict with each
+  other.
+
+  As a result, reads will be halted across all namespaces and
+  replication will halt until the background index build completes.
+  When the build finishes the ``dropIndex`` action will execute, then
+  reads and replication will resume.
 
 Build Failure and Recovery
 --------------------------

--- a/source/reference/command/dropIndexes.txt
+++ b/source/reference/command/dropIndexes.txt
@@ -77,6 +77,16 @@ Resource Locking
 
 .. include:: /includes/extracts/dropIndexes-resource-lock.rst
 
+Dropping an Index during Index Replication
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Avoid dropping an index on a collection while any index is being
+replicated on a secondary. If you attempt to drop an index from a
+collection on a :term:`primary` while the collection has a background
+index building on a :term:`secondary`, reads will be halted across all
+namespaces and replication will halt until the background index build
+completes.
+ 
 Index Names
 ~~~~~~~~~~~
 

--- a/source/reference/method/db.collection.dropIndex.txt
+++ b/source/reference/method/db.collection.dropIndex.txt
@@ -76,6 +76,16 @@ Resource Locking
 
 .. include:: /includes/extracts/dropIndex-method-resource-lock.rst
 
+Dropping an Index during Index Replication
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Avoid dropping an index on a collection while any index is being
+replicated on a secondary. If you attempt to drop an index from a
+collection on a :term:`primary` while the collection has a background
+index building on a :term:`secondary`, reads will be halted across all
+namespaces and replication will halt until the background index build
+completes.
+
 Example
 -------
 

--- a/source/reference/method/db.collection.dropIndexes.txt
+++ b/source/reference/method/db.collection.dropIndexes.txt
@@ -120,6 +120,16 @@ Resource Locking
 
 .. include:: /includes/extracts/dropIndexes-method-resource-lock.rst
 
+Dropping an Index during Index Replication
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Avoid dropping an index on a collection while any index is being
+replicated on a secondary. If you attempt to drop an index from a
+collection on a :term:`primary` while the collection has a background
+index building on a :term:`secondary`, reads will be halted across all
+namespaces and replication will halt until the background index build
+completes.
+
 Index Names
 ~~~~~~~~~~~
 


### PR DESCRIPTION
This is now in 4 places: 

# STAGING URLS
https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/DOCSP-9411-warning-for-dropping-indexes-in-some-cases-v4.2/core/index-creation.html

https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/DOCSP-9411-warning-for-dropping-indexes-in-some-cases-v4.2/reference/command/dropIndexes.html

https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/DOCSP-9411-warning-for-dropping-indexes-in-some-cases-v4.2/reference/method/db.collection.dropIndex.html

https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/DOCSP-9411-warning-for-dropping-indexes-in-some-cases-v4.2/reference/method/db.collection.dropIndexes.html
