### PR TITLE
remove reference to natural

### DIFF
--- a/source/reference/method/cursor.skip.txt
+++ b/source/reference/method/cursor.skip.txt
@@ -65,7 +65,7 @@ paginate a collection in ``_id`` order:
    function printStudents(pageNumber, nPerPage) {
      print( "Page: " + pageNumber );
      db.students.find()
-                .sort( { _id: -1 } )
+                .sort( { _id: 1 } )
                 .skip( pageNumber > 0 ? ( ( pageNumber - 1 ) * nPerPage ) : 0 )
                 .limit( nPerPage )
                 .forEach( student => {

--- a/source/reference/method/cursor.skip.txt
+++ b/source/reference/method/cursor.skip.txt
@@ -58,13 +58,14 @@ Using :method:`cursor.skip()`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following JavaScript function uses :method:`cursor.skip()` to
-paginate a collection in :term:`natural order`:
+paginate a collection in ``_id``:
 
 .. code-block:: javascript
 
    function printStudents(pageNumber, nPerPage) {
      print( "Page: " + pageNumber );
      db.students.find()
+                .sort( { _id: -1 } )
                 .skip( pageNumber > 0 ? ( ( pageNumber - 1 ) * nPerPage ) : 0 )
                 .limit( nPerPage )
                 .forEach( student => {

--- a/source/reference/method/cursor.skip.txt
+++ b/source/reference/method/cursor.skip.txt
@@ -58,7 +58,7 @@ Using :method:`cursor.skip()`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following JavaScript function uses :method:`cursor.skip()` to
-paginate a collection in ``_id``:
+paginate a collection in ``_id`` order:
 
 .. code-block:: javascript
 


### PR DESCRIPTION
Natural sort order is unstable so shouldn't be used in an example