### PR TITLE
create .pem file in correct way

### DIFF
--- a/source/appendix/security/appendixA-openssl-ca.txt
+++ b/source/appendix/security/appendixA-openssl-ca.txt
@@ -159,7 +159,7 @@ B. Generate the Test CA PEM File
 
    .. code-block:: sh
 
-      cat mongodb-test-ca.crt mongodb-test-ia.crt  > test-ca.pem
+      cat mongodb-test-ia.crt mongodb-test-ca.crt > test-ca.pem
 
 You can use the :red:`test` PEM file when configuring :binary:`~bin.mongod`,
 :binary:`~bin.mongos`, or :binary:`~bin.mongo` for TLS/SSL :red:`testing`.


### PR DESCRIPTION
I was trying this document and faced a lot of issues while running mongo with TLS, it was giving me certificate signature failure, as per https://nonspecific.org/error-7-at-0-depth-lookupcertificate-signature-failure/ the order in which I am passing the file to generate .pem was wrong so I changed the order and that fixed the bug for me so changing to document for others to not face the same bug, as seen in many other StackOverflow topics many people are facing this issue.