### PR TITLE
Revert "DOCSP-9411 add warning re dropped indexes during replication"

### DIFF
--- a/source/core/index-creation.txt
+++ b/source/core/index-creation.txt
@@ -190,21 +190,6 @@ The build process is summarized as follows:
 For sharded clusters, the index build occurs only on shards
 containing data for the collection being indexed.
 
-.. warning::
- 
-  Avoid dropping any index on a collection while an index is being 
-  replicated on the secondaries.
-  
-  If you attempt to drop an index from a collection on a :term:`primary` 
-  node while the collection has a background index building on the 
-  :term:`secondary` nodes, the two indexing operations will conflict 
-  with each other. 
-  
-  As a result, reads will be halted across all namespaces and
-  replication will halt until the background index build completes. 
-  When the build finishes the dropIndex action will execute, then 
-  reads and replication will resume. 
-
 For a more detailed description of the index build process, 
 see :ref:`index-build-process`.
 


### PR DESCRIPTION
This reverts commit 058fe9f5d32a8e886afdb8a073e5b665a32728d8.