### PR TITLE
Fix typo

### DIFF
--- a/source/core/security-explicit-client-side-encryption.txt
+++ b/source/core/security-explicit-client-side-encryption.txt
@@ -61,7 +61,7 @@ explicitly encrypts the ``taxid`` field as part of a read operation:
 .. code-block:: javascript
    :copyable: false
 
-   encrypt = encryptedClient.getClientEncryption()
+   clientEncryption = encryptedClient.getClientEncryption()
 
    db.getSiblingDB("hr").getCollection("employees").findOne({
      "taxid" : clientEncryption.encrypt(


### PR DESCRIPTION
rename unreferenced "encrypt" var to "clientEncryption" var/