### PR TITLE
Update manage-indexes.txt

### DIFF
--- a/source/tutorial/manage-indexes.txt
+++ b/source/tutorial/manage-indexes.txt
@@ -57,6 +57,30 @@ Modify an Index
 
 .. _manage-indexes-find-inconsistent-indexes:
 
+Control Index Use with ``hint()``
+---------------------------------
+
+To *force* MongoDB to use a particular index for a
+:method:`db.collection.find()` operation, specify the index with the
+:method:`~cursor.hint()` method. Append the :method:`~cursor.hint()`
+method to the :method:`~db.collection.find()` method. Consider the
+following example:
+
+.. code-block:: javascript
+
+   db.people.find(
+      { name: "John Doe", zipcode: { $gt: "63000" } }
+   ).hint( { zipcode: 1 } )
+
+Specify the ``$natural`` operator to the :method:`~cursor.hint()`
+method to prevent MongoDB from using *any* index:
+
+.. code-block:: javascript
+
+   db.people.find(
+      { name: "John Doe", zipcode: { $gt: "63000" } }
+   ).hint( { $natural: 1 } )
+
 Find Inconsistent Indexes across Shards
 ---------------------------------------
 


### PR DESCRIPTION
Include information on how to force MongoDB to use a *particular* index. Examples were copied from https://docs.mongodb.com/manual/tutorial/measure-index-use/.