### PR TITLE
Update setIntersection.txt

### DIFF
--- a/source/reference/operator/aggregation/setIntersection.txt
+++ b/source/reference/operator/aggregation/setIntersection.txt
@@ -68,7 +68,7 @@ elements), :expression:`$setIntersection` returns an empty array.
      - .. code-block:: javascript
           :copyable: false
 
-          [ ]
+          [ "a","b"]
 
 Example
 -------


### PR DESCRIPTION
the second example of $setintersection should have resulted ["a","b"]. Instead in the docs it was shown as to be resulting an empty array