### PR TITLE
DOCS-14134: remove incorrect statement about no query

### DIFF
--- a/source/reference/operator/projection/positional.txt
+++ b/source/reference/operator/projection/positional.txt
@@ -17,11 +17,9 @@ Definition
 
 
    The positional :projection:`$` operator limits the contents of an
-   ``<array>`` to return either:
+   ``<array>`` to return:
 
    - The first element that matches the query condition on the array.
-   - The first element if no query condition is specified for the
-     array (Starting in MongoDB 4.4).
 
    Use :projection:`$` in the :term:`projection` document of the
    :method:`~db.collection.find()` method or the


### PR DESCRIPTION
No query is allowed on *the projected* array, not on no array.  See SERVER-53576 (aka DOCS-14134)