### PR TITLE
must be fields intead of indexes

### DIFF
--- a/source/tutorial/sort-results-with-indexes.txt
+++ b/source/tutorial/sort-results-with-indexes.txt
@@ -15,8 +15,8 @@ Use Indexes to Sort Query Results
 
 Since indexes contain ordered records, MongoDB can obtain the results of
 a sort from an index with which includes the sort fields. MongoDB *may*
-use multiple indexes to support a sort operation *if* the sort uses the
-same indexes as the query predicate. 
+use multiple fields to support a sort operation *if* the sort uses the
+same fields as the query predicate. 
 
 If MongoDB cannot use an index or indexes to obtain the sort
 order, MongoDB must perform a blocking sort operation on the data.


### PR DESCRIPTION
I think that the idea that _mongoDB may use multiple indexes_ to support a sort operation is wrong.