### PR TITLE
update link and description to drivers landing page

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -14,7 +14,7 @@ The MongoDB |version|  Manual
    To download MongoDB 4.4, go to the `MongoDB Download Center
    <https://www.mongodb.com/try/download?tck=docs_server>`_.
 
-Welcome to the MongoDB |version| Manual! MongoDB is a 
+Welcome to the MongoDB |version| Manual! MongoDB is a
 document database designed for ease of development
 and scaling. The Manual introduces key concepts in MongoDB, presents the
 query language, and provides operational and administrative
@@ -30,7 +30,7 @@ database:
 - MongoDB Enterprise is available as part of the MongoDB Enterprise
   Advanced subscription and includes comprehensive support for your
   MongoDB deployment. MongoDB Enterprise also adds enterprise-focused
-  features such as LDAP and Kerberos support, on-disk encryption, 
+  features such as LDAP and Kerberos support, on-disk encryption,
   and auditing.
 
 MongoDB also offers
@@ -51,11 +51,11 @@ following editions.
    :class: index-table
 
    * - :doc:`mongo Shell Edition </tutorial/getting-started>`
-       
+
        `Node.JS Edition <http://mongodb.github.io/node-mongodb-native/3.4/quick-start/quick-start/>`_
 
      - :api:`Python Edition <pymongo>`
-       
+
        `C++ Edition <https://mongodb.github.io/mongo-cxx-driver/mongocxx-v3/tutorial/>`_
 
      - `Java Edition <https://mongodb.github.io/mongo-java-driver/>`_
@@ -184,9 +184,8 @@ Additional Resources
       Enterprise operations management solution for MongoDB: includes
       Automation, Backup, and Monitoring.
 
-   `MongoDB Ecosystem <https://docs.mongodb.com/ecosystem/?tck=docs_server>`_
-      The documentation available for the drivers, frameworks, tools,
-      and services for use with MongoDB.
+   `MongoDB Drivers <https://docs.mongodb.com/drivers/?tck=docs_server>`_
+      The documentation available for the drivers for use with MongoDB.
 
 .. _`MongoDB, Inc.`: https://www.mongodb.com?tck=docs_server
 


### PR DESCRIPTION
In this PR, I updated the description of the drivers section to reflect its current purpose.
One question is whether you'd prefer to keep the link to "/ecosystem" which currently redirects to "/drivers" for analytics purposes or whether it is ok to update to the latter.