### PR TITLE
(DOCSP-13152): Improve Atlas Search callouts

### DIFF
--- a/source/core/index-text.txt
+++ b/source/core/index-text.txt
@@ -12,8 +12,6 @@ Text Indexes
    :depth: 1
    :class: singlecol
 
-.. include:: /includes/fact-atlas-search-banner.rst
-
 Overview
 --------
 

--- a/source/core/text-search-operators.txt
+++ b/source/core/text-search-operators.txt
@@ -53,6 +53,8 @@ For more information and examples of text search in the
 :doc:`/aggregation` framework, see
 :doc:`/tutorial/text-search-in-aggregation`.
 
+.. include:: /includes/fact-atlas-search-search-stage.rst
+
 .. [#meta-aggregation]
 
    .. include:: /includes/fact-meta-operator-disambiguation.rst

--- a/source/includes/fact-atlas-search-languages.rst
+++ b/source/includes/fact-atlas-search-languages.rst
@@ -1,0 +1,4 @@
+For data hosted on MongoDB Atlas, :atlas:`Atlas Search </atlas-search>`
+provides support for additional languages. To see the complete list of
+languages supported by Atlas Search, see the :atlas:`Atlas Search
+Language Analyzers </reference/atlas-search/analyzers/language/>`.

--- a/source/includes/fact-atlas-search-search-stage.rst
+++ b/source/includes/fact-atlas-search-search-stage.rst
@@ -1,0 +1,3 @@
+For data hosted on MongoDB Atlas, :atlas:`Atlas Search </atlas-search>`
+provides the :atlas:`$search </reference/atlas-search/query-syntax/>`
+aggregation stage to perform full-text search on your collections.

--- a/source/includes/fact-text-index-limit-one.rst
+++ b/source/includes/fact-text-index-limit-one.rst
@@ -1,1 +1,6 @@
 A collection can have at most **one** ``text`` index.
+
+Atlas Search (available in `MongoDB Atlas
+<https://www.mongodb.com/cloud/atlas?tck=docs_server>`__) supports
+multiple full-text search indexes on a single collection. To learn more,
+see the :atlas:`Atlas Search documentation </atlas-search>`.

--- a/source/reference/operator/query/text.txt
+++ b/source/reference/operator/query/text.txt
@@ -10,8 +10,6 @@ $text
    :depth: 1
    :class: singlecol
 
-.. include:: /includes/fact-atlas-search-banner.rst
-
 Definition
 ----------
 
@@ -164,6 +162,15 @@ In the ``$search`` field, specify a string of words that the
 The :query:`text` operator treats most punctuation
 in the string as delimiters, except a hyphen-minus (``-``) that negates term or
 an escaped double quotes ``\"`` that specifies a phrase.
+
+.. note::
+
+   The ``$search`` field for the :query:`$text` expression is different
+   than the the :atlas:`$search aggregation stage
+   </reference/atlas-search/query-syntax/>` provided by
+   :atlas:`Atlas Search </atlas-search>`. The ``$search`` aggregation
+   stage performs full-text search on specified fields and is only
+   available on MongoDB Atlas.
 
 .. _text-operator-phrases:
 

--- a/source/reference/text-search-languages.txt
+++ b/source/reference/text-search-languages.txt
@@ -74,5 +74,7 @@ language name:
 
    .. include:: /includes/fact-text-search-language-none.rst
 
+.. include:: /includes/fact-atlas-search-languages.rst
+
 .. seealso:: :doc:`/tutorial/specify-language-for-text-index`
 

--- a/source/text-search.txt
+++ b/source/text-search.txt
@@ -10,8 +10,6 @@ Text Search
    :depth: 1
    :class: singlecol
 
-.. include:: /includes/fact-atlas-search-banner.rst
-
 Overview
 --------
 
@@ -107,6 +105,8 @@ Language Support
 MongoDB supports text search for various languages. See
 :doc:`/reference/text-search-languages` for a list of supported
 languages.
+
+.. include:: /includes/fact-atlas-search-languages.rst
 
 .. toctree::
    :titlesonly:

--- a/source/tutorial/control-results-of-text-search.txt
+++ b/source/tutorial/control-results-of-text-search.txt
@@ -77,3 +77,10 @@ each other. For instance, a term match in the ``content`` field has:
 
 - ``10`` times (i.e. ``10:1``) the impact as a term match in the
   ``about`` field.
+
+.. note::
+
+   For data hosted on MongoDB Atlas,
+   :atlas:`Atlas Search </atlas-search>` provides more robust custom
+   scoring than ``text`` indexes. To learn more, see the Atlas Search
+   :atlas:`Scoring </reference/atlas-search/scoring/>` documentation.

--- a/source/tutorial/text-search-in-aggregation.txt
+++ b/source/tutorial/text-search-in-aggregation.txt
@@ -16,7 +16,7 @@ In the aggregation pipeline, text search is available via the use of
 the :query:`$text` query operator in the :pipeline:`$match` stage.
 
 Restrictions
-~~~~~~~~~~~~
+------------
 
 For general :query:`$text` operator restrictions, see :ref:`operator
 restrictions <text-query-operator-behavior>`.
@@ -36,7 +36,7 @@ restrictions:
 .. |sort-object| replace:: :pipeline:`$sort` pipeline
 
 Text Score
-~~~~~~~~~~
+----------
 
 .. include:: /includes/fact-text-search-score.rst
 
@@ -132,3 +132,8 @@ matching documents in the :pipeline:`$group` stage.
         { $group: { _id: null, views: { $sum: "$views" } } }
       ]
    )
+
+``$search`` Stage in Atlas Search
+---------------------------------
+
+.. include:: /includes/fact-atlas-search-search-stage.rst


### PR DESCRIPTION
This PR removes the top-level callouts for Atlas Search and replaces them with more contextual callouts in-line, which will hopefully result in a better experience for the user and drive awareness of Atlas Search.

Staged pages:

- Top level [Text Index Page](https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/DOCSP-13152/core/index-text.html#create-text-index)
- [Text Search Operators](https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/DOCSP-13152/core/text-search-operators.html#aggregation-framework)
- [Text Search in Aggregation Pipeline](https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/DOCSP-13152/tutorial/text-search-in-aggregation.html#search-stage-in-atlas-search)
- [Text Search Languages](https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/DOCSP-13152/reference/text-search-languages.html)
- [Control Search Results with Weights](https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/DOCSP-13152/tutorial/control-results-of-text-search.html)
- [$text - search field](https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/DOCSP-13152/reference/operator/query/text.html#search-field)