### PR TITLE
DOCS-13229 Correcting merging in sharded cluster statement

### DIFF
--- a/source/core/aggregation-pipeline-sharded-collections.txt
+++ b/source/core/aggregation-pipeline-sharded-collections.txt
@@ -30,9 +30,11 @@ to be done on the primary shard.
 .. versionchanged:: 3.6
 
 When aggregation operations run on multiple shards, the results are 
-routed to the :binary:`~bin.mongos` to be merged. However, :pipeline:`$out`
-and :pipeline:`$lookup` must run on the :ref:`primary shard <primary-shard>` 
-and are aggregated there.  
+routed to the :binary:`~bin.mongos` to be merged except when :pipeline:`$out`
+and :pipeline:`$lookup` are present, and must merge on the :ref:`primary 
+shard <primary-shard>` or when :ref:`allowDiskUse` is true and there is a
+sorting or grouping stage present in which case one of the shards will be
+randomly selected to perform the merge.  
 
 Optimization
 ------------


### PR DESCRIPTION
Missing the merge on random shard when there's a blocking stage and allowDiskUse:true is specified.