### PR TITLE
Remove incorrect TTL reference

### DIFF
--- a/source/administration/production-notes.txt
+++ b/source/administration/production-notes.txt
@@ -643,14 +643,6 @@ operations like the following:
 - Features which rely on timekeeping may have inconsistent or
   unpredictable behavior in clusters with clock drift between MongoDB
   components. 
-  
-  For example, :ref:`TTL indexes <index-feature-ttl>` rely
-  on the system clock to calculate when to delete a given document. If
-  two members have different system clock times, each member could
-  delete a given document covered by the TTL index at a different
-  time. Since :ref:`sessions` use TTL indexes to control their
-  lifespan, clock drift could result in inconsistent or unpredictable
-  session timeout behavior.
 
 NTP synchronization is required for deployments running MongoDB lower
 than ``3.4.6`` or ``3.2.17`` with the Wired Tiger storage engine, where


### PR DESCRIPTION
TTL uses replication not clock sync on members of a replica set.