### PR TITLE
Add missing words in Access Control text

### DIFF
--- a/source/reference/command/killAllSessionsByPattern.txt
+++ b/source/reference/command/killAllSessionsByPattern.txt
@@ -86,7 +86,7 @@ Access Control
 --------------
 
 If the deployment enforces authentication/authorization, you must have
-the :authaction:`killAnySession` to run the
+the :authaction:`killAnySession` privilege action to run the
 :dbcommand:`killAllSessionsByPattern` command.
 
 For patterns that include ``users`` or ``roles``, you must also have
@@ -95,7 +95,7 @@ resource.
 
 .. note::
 
-   Users can kill their own sessions even without
+   Users can kill their own sessions even without the
    :authaction:`killAnySession` privilege action.
 
 Examples


### PR DESCRIPTION
I came across this while looking into [DRIVERS-1577](https://jira.mongodb.org/browse/DRIVERS-1577).

Also, whoever merges this may want to also take a look at [SERVER-54216](https://jira.mongodb.org/browse/SERVER-54216). It seems there is an outstanding server bug that contradicts the message in this current documentation. I'm not sure if that's related to [DOCSP-14305](https://jira.mongodb.org/browse/DOCSP-14305), but if not I'd suggest opening a new DOCSP ticket (linked to SERVER-54216) so you don't lose track of that.