### PR TITLE
DOP-2048: Drop .tar.gz and .epub files from the sitemap

### DIFF
--- a/conf-sitemap.xml
+++ b/conf-sitemap.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site
-  base_url="http://docs.mongodb.com/manual/"
+  base_url="https://docs.mongodb.com/manual/"
   store_into="build/master/sitemap.xml.gz"
   verbose="1"
   >
 
 <directory
         path="build/public/master/"
-        url="http://docs.mongodb.com/manual/"
+        url="https://docs.mongodb.com/manual/"
         default_file="index.html"
         />
 <filter  action="drop"  type="wildcard"  pattern="*~" />
@@ -18,6 +18,8 @@
 <filter  action="drop"  type="wildcard"  pattern="*.js" />
 <filter  action="drop"  type="wildcard"  pattern="*.gif" />
 <filter  action="drop"  type="wildcard"  pattern="*.png" />
+<filter  action="drop"  type="wildcard"  pattern="*.tar.gz" />
+<filter  action="drop"  type="wildcard"  pattern="*.epub" />
 <filter  action="drop"  type="regexp"  pattern="/\.[^/]*" />
 <filter  action="drop"  type="wildcard"  pattern="*/master/single*"/>
 <filter  action="drop"  type="wildcard"  pattern="*/meta/*"/>


### PR DESCRIPTION
During the Croud SEO audit, they found that non-HTML files were included in the sitemap.