### PR TITLE
Changed log message ID type from String to Integer

### DIFF
--- a/source/reference/log-messages.txt
+++ b/source/reference/log-messages.txt
@@ -98,7 +98,7 @@ specification, and has the following layout and field order:
      "s": <String>, // severity
      "c": <String>, // component
      "ctx": <String>, // context
-     "id": <String>, // unique identifier
+     "id": <Integer>, // unique identifier
      "msg": <String>, // message body
      "attr": <Object> // additional attributes (optional)
      "tags": <Array of strings> // tags (optional)
@@ -118,7 +118,7 @@ specification, and has the following layout and field order:
 - **Context** - String representing the name of the thread issuing the
   log statement.
 
-- **id** - String representing the unique identifier of the log
+- **id** - Integer representing the unique identifier of the log
   statement. See :ref:`log-message-parsing-example-filter-id` for an
   example.
 


### PR DESCRIPTION
I noticed an error in the log message documentation with mongo v4.4.
I was receiving log message with an `"id"` being an `Integer`, and not a `String`. Example:

```json
{
  ...
  "id": 123456,
  ...
}
```

So I offer to update documentation.

### Porting to other branches?
I have not tested any other version of mongo, nor compared with the doc for other branches. I would expect this change should be ported to other branches but I couldn't evaluate which ones.

Related work where the inconsistency was noticed: https://github.com/Mongo2Go/Mongo2Go/pull/114