### PR TITLE
Update snooty.toml

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -166,7 +166,7 @@ toc_landing_pages = [
    "/tutorial/install-mongodb-enterprise-on-windows",
    "/tutorial/install-mongodb-on-amazon",
    "/tutorial/install-mongodb-on-debian",
-   "/tutorial/install-mongodb-on-macos",
+   "/tutorial/install-mongodb-on-os-x",
    "/tutorial/install-mongodb-on-red-hat",
    "/tutorial/install-mongodb-on-suse",
    "/tutorial/install-mongodb-on-ubuntu",


### PR DESCRIPTION
[[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/a77a06488/docs/docsworker-xlarge/patch-1/tutorial/install-mongodb-on-os-x/)] `snooty.toml` refers to a page called `tutorial/install-mongodb-on-macos`, but the page [here](https://github.com/mongodb/docs/blob/master/source/tutorial/install-mongodb-on-os-x.txt) is still named `tutorial/install-mongodb-on-os-x`. As a result, I wasn't able to click on the page with the `brew` install instructions; it only worked as a dropdown.

Probably the better solution would be to rename the page since OS X is deprecated 😁 so feel free to close this PR if you'd rather do that!