### PR TITLE
(DOCSP-15627) Fixed typo in text

### DIFF
--- a/source/tutorial/rotate-x509-membership-certificates.txt
+++ b/source/tutorial/rotate-x509-membership-certificates.txt
@@ -110,7 +110,7 @@ member (see next step).
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Once you have modified the configuration for all the members,
-restart each secondaries and then the primary.
+restart each secondary and then the primary.
 
 **For each secondary member**, connect a :binary:`~bin.mongo` shell to the
 member and:


### PR DESCRIPTION
[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=607ed24009293ae626651bd2) link
[JIRA ticket](https://jira.mongodb.org/browse/DOCSP-15627)
[Staging 1](https://docs-mongodbcom-staging.corp.mongodb.com/ca5729b36/docs/docsworker-xlarge/DOCSP-15627/tutorial/rotate-x509-membership-certificates/)

What was fixed: changed "...restart each **secondaries** and then the primary" to "...restart each **secondary** and then the primary"