### PR TITLE
DOCSP-15489 update mongo shell banner for mongosh

### DIFF
--- a/source/includes/fact-mongo-shell-method-toc.rst
+++ b/source/includes/fact-mongo-shell-method-toc.rst
@@ -1,5 +1,0 @@
-The methods listed on this table of contents page refer to the
-:binary:`~bin.mongo` shell methods, and *not* to the MongoDB Node.js
-driver (or any other driver) methods. For corresponding MongoDB driver
-API, refer to your specific :driver:`MongoDB driver </>`
-documentation instead.

--- a/source/includes/fact-mongo-shell-method.rst
+++ b/source/includes/fact-mongo-shell-method.rst
@@ -1,7 +1,0 @@
-.. important:: ``mongo`` Shell Method
-
-
-   This page documents the :binary:`~bin.mongo` shell method, and does
-   *not* refer to the MongoDB Node.js driver (or any other driver)
-   method. For corresponding MongoDB driver API, refer to your specific
-   :driver:`MongoDB driver </>` documentation instead.

--- a/source/includes/fact-mongosh-shell-method-toc.rst
+++ b/source/includes/fact-mongosh-shell-method-toc.rst
@@ -1,0 +1,18 @@
+The methods listed on this table of contents page are
+:mongosh:`mongosh </>` methods.  This is *not* the documention for
+``Node.js`` or other programming language specific driver methods.
+
+In most cases :mongosh:`mongosh </>` methods work the same way as the
+legacy :binary:`~bin.mongo` shell methods. However, some legacy methods
+are unavailable in ``mongosh``.
+
+For legacy :binary:`~bin.mongo` shell documention, refer to the
+documentation for the corresponding ``MongoDB`` release.
+
+- :v4.4:`mongo shell v4.4 </mongo>`
+- :v4.2:`mongo shell v4.2 </mongo>`
+- :v4.0:`mongo shell v4.0 </mongo>`
+
+For MongoDB API drivers, refer to the language specific
+:driver:`MongoDB driver </>` documentation.
+

--- a/source/includes/fact-mongosh-shell-method.rst
+++ b/source/includes/fact-mongosh-shell-method.rst
@@ -1,0 +1,20 @@
+.. important:: ``mongosh`` Method
+
+   This is a :mongosh:`mongosh </>` method. This is *not* the
+   documention for ``Node.js`` or other programming language specific
+   driver methods.
+
+   In most cases :mongosh:`mongosh </>` methods work the same way as
+   the legacy :binary:`~bin.mongo` shell methods. However, some legacy
+   methods are unavailable in ``mongosh``.
+
+   For legacy :binary:`~bin.mongo` shell documention, refer to the
+   documentation for the corresponding ``MongoDB`` release.
+
+   - :v4.4:`mongo shell v4.4 </mongo>`
+   - :v4.2:`mongo shell v4.2 </mongo>`
+   - :v4.0:`mongo shell v4.0 </mongo>`
+
+   For MongoDB API drivers, refer to the language specific
+   :driver:`MongoDB driver </>` documentation.
+

--- a/source/reference/method.txt
+++ b/source/reference/method.txt
@@ -1,8 +1,8 @@
 .. _js-administrative-methods:
 
-=======================
-``mongo`` Shell Methods
-=======================
+===================
+``mongosh`` Methods
+===================
 
 .. default-domain:: mongodb
 

--- a/source/reference/method/cursor.addOption.txt
+++ b/source/reference/method/cursor.addOption.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: cursor.addOption(flag)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    .. include:: /includes/extracts/mongo-shell-deprecated-meta-operator-cursor-addOption.rst

--- a/source/reference/method/cursor.allowDiskUse.txt
+++ b/source/reference/method/cursor.allowDiskUse.txt
@@ -18,7 +18,7 @@ Definition
 .. method:: cursor.allowDiskUse()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
    :method:`~cursor.allowDiskUse()` allows MongoDB to use temporary
    files on disk to store data exceeding the 100 megabyte system memory

--- a/source/reference/method/cursor.allowPartialResults.txt
+++ b/source/reference/method/cursor.allowPartialResults.txt
@@ -15,7 +15,7 @@ Definition
 
 .. method:: cursor.allowPartialResults()
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
    When used with :method:`db.collection.find()` operations against a
    sharded collection, returns partial results, rather than an error,

--- a/source/reference/method/cursor.batchSize.txt
+++ b/source/reference/method/cursor.batchSize.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: cursor.batchSize(size)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Specifies the

--- a/source/reference/method/cursor.close.txt
+++ b/source/reference/method/cursor.close.txt
@@ -10,7 +10,7 @@ Definition
 .. method:: cursor.close()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Instructs the server to close a :ref:`cursor <read-operations-cursors>`

--- a/source/reference/method/cursor.collation.txt
+++ b/source/reference/method/cursor.collation.txt
@@ -18,7 +18,7 @@ Definition
 .. method:: cursor.collation(<collation document>)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    .. versionadded:: 3.4

--- a/source/reference/method/cursor.comment.txt
+++ b/source/reference/method/cursor.comment.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: cursor.comment()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    .. versionadded:: 3.2

--- a/source/reference/method/cursor.count.txt
+++ b/source/reference/method/cursor.count.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: cursor.count()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    .. note::

--- a/source/reference/method/cursor.explain.txt
+++ b/source/reference/method/cursor.explain.txt
@@ -15,7 +15,7 @@ Definition
 
 .. method:: cursor.explain(verbosity)
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
    Provides information on the query plan for the
    :method:`db.collection.find()` method.

--- a/source/reference/method/cursor.forEach.txt
+++ b/source/reference/method/cursor.forEach.txt
@@ -16,7 +16,7 @@ Description
 .. method:: cursor.forEach(function)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Iterates the cursor to apply a JavaScript ``function`` to each

--- a/source/reference/method/cursor.hasNext.txt
+++ b/source/reference/method/cursor.hasNext.txt
@@ -13,7 +13,7 @@ cursor.hasNext()
 .. method:: cursor.hasNext()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    :returns: Boolean.

--- a/source/reference/method/cursor.hint.txt
+++ b/source/reference/method/cursor.hint.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: cursor.hint(index)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Call this method on a query to override MongoDB's default index

--- a/source/reference/method/cursor.isClosed.txt
+++ b/source/reference/method/cursor.isClosed.txt
@@ -13,7 +13,7 @@ cursor.isClosed()
 .. method:: cursor.isClosed()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    :returns: Boolean.

--- a/source/reference/method/cursor.isExhausted.txt
+++ b/source/reference/method/cursor.isExhausted.txt
@@ -13,7 +13,7 @@ cursor.isExhausted()
 .. method:: cursor.isExhausted()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    :returns: Boolean.

--- a/source/reference/method/cursor.itcount.txt
+++ b/source/reference/method/cursor.itcount.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: cursor.itcount()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Counts the number of documents remaining in a cursor.

--- a/source/reference/method/cursor.limit.txt
+++ b/source/reference/method/cursor.limit.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: cursor.limit()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Use the :method:`~cursor.limit()` method on a cursor to specify the maximum

--- a/source/reference/method/cursor.map.txt
+++ b/source/reference/method/cursor.map.txt
@@ -13,7 +13,7 @@ cursor.map()
 .. method:: cursor.map(function)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Applies ``function`` to each document visited by the cursor and

--- a/source/reference/method/cursor.max.txt
+++ b/source/reference/method/cursor.max.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: cursor.max()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Specifies the *exclusive* upper bound for a specific index in order

--- a/source/reference/method/cursor.maxTimeMS.txt
+++ b/source/reference/method/cursor.maxTimeMS.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: cursor.maxTimeMS(<time limit>)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Specifies a cumulative time limit in milliseconds for processing

--- a/source/reference/method/cursor.min.txt
+++ b/source/reference/method/cursor.min.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: cursor.min()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Specifies the *inclusive* lower bound for a specific index in order

--- a/source/reference/method/cursor.next.txt
+++ b/source/reference/method/cursor.next.txt
@@ -13,7 +13,7 @@ cursor.next()
 .. method:: cursor.next()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    :returns: The next document in the cursor returned by the

--- a/source/reference/method/cursor.noCursorTimeout.txt
+++ b/source/reference/method/cursor.noCursorTimeout.txt
@@ -10,7 +10,7 @@ Definition
 .. method:: cursor.noCursorTimeout()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Instructs the server to avoid closing a cursor automatically after a period

--- a/source/reference/method/cursor.objsLeftInBatch.txt
+++ b/source/reference/method/cursor.objsLeftInBatch.txt
@@ -13,7 +13,7 @@ cursor.objsLeftInBatch()
 .. method:: cursor.objsLeftInBatch()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    :method:`cursor.objsLeftInBatch()` returns the number of

--- a/source/reference/method/cursor.pretty.txt
+++ b/source/reference/method/cursor.pretty.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: cursor.pretty()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Configures the cursor to display results in an easy-to-read format.

--- a/source/reference/method/cursor.readConcern.txt
+++ b/source/reference/method/cursor.readConcern.txt
@@ -17,7 +17,7 @@ Definition
 .. method:: cursor.readConcern(level)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    .. versionadded:: 3.2

--- a/source/reference/method/cursor.readPref.txt
+++ b/source/reference/method/cursor.readPref.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: cursor.readPref(mode, tagSet, hedgeOptions)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Append :method:`~cursor.readPref()` to a cursor to

--- a/source/reference/method/cursor.returnKey.txt
+++ b/source/reference/method/cursor.returnKey.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: cursor.returnKey()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
    .. tip::
 

--- a/source/reference/method/cursor.showRecordId.txt
+++ b/source/reference/method/cursor.showRecordId.txt
@@ -13,7 +13,7 @@ cursor.showRecordId()
 .. method:: cursor.showRecordId()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    .. versionchanged:: 3.2

--- a/source/reference/method/cursor.size.txt
+++ b/source/reference/method/cursor.size.txt
@@ -13,7 +13,7 @@ cursor.size()
 .. method:: cursor.size()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    :returns: A count of the number of documents that match the

--- a/source/reference/method/cursor.skip.txt
+++ b/source/reference/method/cursor.skip.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: cursor.skip(<offset>)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Call the :method:`~cursor.skip()` method on a cursor to control where

--- a/source/reference/method/cursor.sort.txt
+++ b/source/reference/method/cursor.sort.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: cursor.sort(sort)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Specifies the order in which the query returns matching documents.

--- a/source/reference/method/cursor.tailable.txt
+++ b/source/reference/method/cursor.tailable.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: cursor.tailable()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    .. versionadded:: 3.2

--- a/source/reference/method/cursor.toArray.txt
+++ b/source/reference/method/cursor.toArray.txt
@@ -13,7 +13,7 @@ cursor.toArray()
 .. method:: cursor.toArray()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    The :method:`~cursor.toArray()` method returns an array that

--- a/source/reference/method/db.adminCommand.txt
+++ b/source/reference/method/db.adminCommand.txt
@@ -10,6 +10,8 @@ db.adminCommand()
    :depth: 1
    :class: singlecol
 
+.. include:: /includes/fact-mongosh-shell-method.rst
+
 Definition
 ----------
 

--- a/source/reference/method/db.collection.aggregate.txt
+++ b/source/reference/method/db.collection.aggregate.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: db.collection.aggregate(pipeline, options)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Calculates aggregate values for the data in a collection or a :doc:`view </core/views>`.

--- a/source/reference/method/db.collection.bulkWrite.txt
+++ b/source/reference/method/db.collection.bulkWrite.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: db.collection.bulkWrite()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    .. versionadded:: 3.2

--- a/source/reference/method/db.collection.copyTo.txt
+++ b/source/reference/method/db.collection.copyTo.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: db.collection.copyTo(newCollection)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    .. deprecated:: 3.0

--- a/source/reference/method/db.collection.count.txt
+++ b/source/reference/method/db.collection.count.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: db.collection.count(query, options)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    .. note::

--- a/source/reference/method/db.collection.countDocuments.txt
+++ b/source/reference/method/db.collection.countDocuments.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: db.collection.countDocuments(query, options)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    .. versionadded:: 4.0.3

--- a/source/reference/method/db.collection.createIndex.txt
+++ b/source/reference/method/db.collection.createIndex.txt
@@ -18,7 +18,7 @@ Definition
 .. method:: db.collection.createIndex(keys, options, commitQuorum)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Creates indexes on collections.

--- a/source/reference/method/db.collection.createIndexes.txt
+++ b/source/reference/method/db.collection.createIndexes.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: db.collection.createIndexes( [ keyPatterns ], options, commitQuorum )
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Creates one or more indexes on a collection.

--- a/source/reference/method/db.collection.dataSize.txt
+++ b/source/reference/method/db.collection.dataSize.txt
@@ -13,7 +13,7 @@ db.collection.dataSize()
 .. method:: db.collection.dataSize()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    :returns: The size in bytes of the collection.

--- a/source/reference/method/db.collection.deleteMany.txt
+++ b/source/reference/method/db.collection.deleteMany.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: db.collection.deleteMany()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Removes all documents that match the ``filter`` from a collection.

--- a/source/reference/method/db.collection.deleteOne.txt
+++ b/source/reference/method/db.collection.deleteOne.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: db.collection.deleteOne()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Removes a single document from a collection.

--- a/source/reference/method/db.collection.distinct.txt
+++ b/source/reference/method/db.collection.distinct.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: db.collection.distinct(field, query, options)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Finds the distinct

--- a/source/reference/method/db.collection.drop.txt
+++ b/source/reference/method/db.collection.drop.txt
@@ -18,7 +18,7 @@ Definition
 .. method:: db.collection.drop(<options>)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Removes a collection or :doc:`view </core/views>` from the database.

--- a/source/reference/method/db.collection.dropIndex.txt
+++ b/source/reference/method/db.collection.dropIndex.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: db.collection.dropIndex(index)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Drops or removes the specified index from a collection. The

--- a/source/reference/method/db.collection.dropIndexes.txt
+++ b/source/reference/method/db.collection.dropIndexes.txt
@@ -17,7 +17,7 @@ Definition
 .. method:: db.collection.dropIndexes()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Drops the specified index or indexes (except the index on the

--- a/source/reference/method/db.collection.estimatedDocumentCount.txt
+++ b/source/reference/method/db.collection.estimatedDocumentCount.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: db.collection.estimatedDocumentCount(options)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    .. versionadded:: 4.0.3

--- a/source/reference/method/db.collection.explain.txt
+++ b/source/reference/method/db.collection.explain.txt
@@ -16,7 +16,7 @@ Description
 .. method:: db.collection.explain()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Returns information on the query plan for the following methods:

--- a/source/reference/method/db.collection.find.txt
+++ b/source/reference/method/db.collection.find.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: db.collection.find(query, projection)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Selects documents in a collection or view and returns a

--- a/source/reference/method/db.collection.findAndModify.txt
+++ b/source/reference/method/db.collection.findAndModify.txt
@@ -22,7 +22,7 @@ Definition
 .. method:: db.collection.findAndModify(document)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
 

--- a/source/reference/method/db.collection.findOne.txt
+++ b/source/reference/method/db.collection.findOne.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: db.collection.findOne(query, projection)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Returns one document that satisfies the specified query criteria on

--- a/source/reference/method/db.collection.findOneAndDelete.txt
+++ b/source/reference/method/db.collection.findOneAndDelete.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: db.collection.findOneAndDelete( filter, options )
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    .. versionadded:: 3.2

--- a/source/reference/method/db.collection.findOneAndReplace.txt
+++ b/source/reference/method/db.collection.findOneAndReplace.txt
@@ -18,7 +18,7 @@ Definition
 .. method:: db.collection.findOneAndReplace( filter, replacement, options )
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    .. versionadded:: 3.2

--- a/source/reference/method/db.collection.findOneAndUpdate.txt
+++ b/source/reference/method/db.collection.findOneAndUpdate.txt
@@ -18,7 +18,7 @@ Definition
 .. method:: db.collection.findOneAndUpdate( filter, update, options )
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    .. versionadded:: 3.2

--- a/source/reference/method/db.collection.getIndexes.txt
+++ b/source/reference/method/db.collection.getIndexes.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: db.collection.getIndexes()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Returns an array that holds a list of documents that identify and

--- a/source/reference/method/db.collection.getPlanCache.txt
+++ b/source/reference/method/db.collection.getPlanCache.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: db.collection.getPlanCache()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Returns an interface to access the query plan cache for a

--- a/source/reference/method/db.collection.getShardDistribution.txt
+++ b/source/reference/method/db.collection.getShardDistribution.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: db.collection.getShardDistribution()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Prints the data distribution statistics for a :term:`sharded

--- a/source/reference/method/db.collection.getShardVersion.txt
+++ b/source/reference/method/db.collection.getShardVersion.txt
@@ -13,7 +13,7 @@ db.collection.getShardVersion()
 .. method:: db.collection.getShardVersion()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    This method returns information regarding the state of data in a

--- a/source/reference/method/db.collection.hideIndex.txt
+++ b/source/reference/method/db.collection.hideIndex.txt
@@ -17,7 +17,7 @@ Definition
 
    .. versionadded:: 4.4
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
    Hides an existing index from the query planner. An :doc:`index
    hidden from the query planner </core/index-hidden>` is not evaluated

--- a/source/reference/method/db.collection.initializeOrderedBulkOp.txt
+++ b/source/reference/method/db.collection.initializeOrderedBulkOp.txt
@@ -18,7 +18,7 @@ Definition
 .. method:: db.collection.initializeOrderedBulkOp()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Initializes and returns a new :method:`Bulk()` operations builder

--- a/source/reference/method/db.collection.initializeUnorderedBulkOp.txt
+++ b/source/reference/method/db.collection.initializeUnorderedBulkOp.txt
@@ -18,7 +18,7 @@ Definition
 .. method:: db.collection.initializeUnorderedBulkOp()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
    Initializes and returns a new :method:`Bulk()` operations builder
    for a collection. The builder constructs an *unordered* list of

--- a/source/reference/method/db.collection.insert.txt
+++ b/source/reference/method/db.collection.insert.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: db.collection.insert()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Inserts a document or documents into a collection.

--- a/source/reference/method/db.collection.insertMany.txt
+++ b/source/reference/method/db.collection.insertMany.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: db.collection.insertMany()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    .. versionadded:: 3.2

--- a/source/reference/method/db.collection.insertOne.txt
+++ b/source/reference/method/db.collection.insertOne.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: db.collection.insertOne()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    .. versionadded:: 3.2

--- a/source/reference/method/db.collection.isCapped.txt
+++ b/source/reference/method/db.collection.isCapped.txt
@@ -13,7 +13,7 @@ db.collection.isCapped()
 .. method:: db.collection.isCapped()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    :returns: Returns ``true`` if the collection is a :term:`capped

--- a/source/reference/method/db.collection.latencyStats.txt
+++ b/source/reference/method/db.collection.latencyStats.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: db.collection.latencyStats(options)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    :method:`db.collection.latencyStats()` returns latency

--- a/source/reference/method/db.collection.mapReduce.txt
+++ b/source/reference/method/db.collection.mapReduce.txt
@@ -16,7 +16,7 @@ db.collection.mapReduce()
 
 .. method:: db.collection.mapReduce(map,reduce, { <options> })
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
    The :method:`db.collection.mapReduce()` method provides a wrapper
    around the :dbcommand:`mapReduce` command.

--- a/source/reference/method/db.collection.reIndex.txt
+++ b/source/reference/method/db.collection.reIndex.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: db.collection.reIndex()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    The :method:`db.collection.reIndex()` drops all indexes on a

--- a/source/reference/method/db.collection.remove.txt
+++ b/source/reference/method/db.collection.remove.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: db.collection.remove()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Removes documents from a collection.

--- a/source/reference/method/db.collection.renameCollection.txt
+++ b/source/reference/method/db.collection.renameCollection.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: db.collection.renameCollection(target, dropTarget)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Renames a collection. Provides a wrapper for the

--- a/source/reference/method/db.collection.replaceOne.txt
+++ b/source/reference/method/db.collection.replaceOne.txt
@@ -18,7 +18,7 @@ Definition
 .. method:: db.collection.replaceOne(filter, replacement, options)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    .. versionadded:: 3.2

--- a/source/reference/method/db.collection.save.txt
+++ b/source/reference/method/db.collection.save.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: db.collection.save()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Updates an existing :doc:`document </core/document>` or inserts a

--- a/source/reference/method/db.collection.stats.txt
+++ b/source/reference/method/db.collection.stats.txt
@@ -22,7 +22,7 @@ Definition
 .. method:: db.collection.stats(<option>)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    Returns statistics about the collection.

--- a/source/reference/method/db.collection.storageSize.txt
+++ b/source/reference/method/db.collection.storageSize.txt
@@ -13,7 +13,7 @@ db.collection.storageSize()
 .. method:: db.collection.storageSize()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    :returns: The total amount of storage allocated to this collection

--- a/source/reference/method/db.collection.totalIndexSize.txt
+++ b/source/reference/method/db.collection.totalIndexSize.txt
@@ -13,7 +13,7 @@ db.collection.totalIndexSize()
 .. method:: db.collection.totalIndexSize()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    :returns: The total size of all indexes for the collection.  

--- a/source/reference/method/db.collection.totalSize.txt
+++ b/source/reference/method/db.collection.totalSize.txt
@@ -13,7 +13,7 @@ db.collection.totalSize()
 .. method:: db.collection.totalSize()
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    :returns: The total size in bytes of the data in the collection plus

--- a/source/reference/method/db.collection.unhideIndex.txt
+++ b/source/reference/method/db.collection.unhideIndex.txt
@@ -15,7 +15,7 @@ Definition
 
 .. method:: db.collection.unhideIndex()
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
    Unhides an existing index from the query planner. Once unhidden, the
    indexes are immediately available for use.

--- a/source/reference/method/db.collection.update.txt
+++ b/source/reference/method/db.collection.update.txt
@@ -17,7 +17,7 @@ Definition
 
 .. method:: db.collection.update(query, update, options)
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
    Modifies an existing document or documents in a collection. The
    method can modify specific fields of an existing document or documents

--- a/source/reference/method/db.collection.updateMany.txt
+++ b/source/reference/method/db.collection.updateMany.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: db.collection.updateMany(filter, update, options)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    .. versionadded:: 3.2

--- a/source/reference/method/db.collection.updateOne.txt
+++ b/source/reference/method/db.collection.updateOne.txt
@@ -18,7 +18,7 @@ Definition
 .. method:: db.collection.updateOne(filter, update, options)
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    .. versionadded:: 3.2

--- a/source/reference/method/db.collection.validate.txt
+++ b/source/reference/method/db.collection.validate.txt
@@ -15,7 +15,7 @@ Description
 
 .. method:: db.collection.validate(<documents>)
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
    Validates a collection. The method scans a collection data and
    indexes for correctness and returns the result. For details of the

--- a/source/reference/method/db.collection.watch.txt
+++ b/source/reference/method/db.collection.watch.txt
@@ -16,7 +16,7 @@ Definition
 .. method:: db.collection.watch( pipeline, options )
 
 
-   .. include:: /includes/fact-mongo-shell-method.rst
+   .. include:: /includes/fact-mongosh-shell-method.rst
 
 
    *For replica sets and sharded clusters only*

--- a/source/reference/method/db.getMongo.txt
+++ b/source/reference/method/db.getMongo.txt
@@ -10,6 +10,8 @@ db.getMongo()
    :depth: 1
    :class: singlecol
 
+.. include:: /includes/fact-mongosh-shell-method.rst
+
 .. method:: db.getMongo()
 
    :returns: The current database connection.
@@ -17,3 +19,10 @@ db.getMongo()
    :method:`db.getMongo()` runs when the shell initiates. Use this
    command to test that the :binary:`~bin.mongo` shell has a connection to
    the proper database instance.
+
+.. note::
+
+   The :binary:`~bin.mongo` shell has a sub-command,
+   ``db.getMongo().setSecondaryOk()`` which is not available in
+   ``mongosh``. Use :method:`Mongo.setReadPref()` instead.
+

--- a/source/reference/method/js-collection.txt
+++ b/source/reference/method/js-collection.txt
@@ -10,9 +10,9 @@ Collection Methods
    :depth: 1
    :class: singlecol
 
-.. note:: ``mongo`` Shell Methods
+.. note:: ``mongosh`` Methods
 
-   .. include:: /includes/fact-mongo-shell-method-toc.rst
+   .. include:: /includes/fact-mongosh-shell-method-toc.rst
 
 .. include:: /includes/extracts/methods-toc-explanation.rst
 

--- a/source/reference/method/js-cursor.txt
+++ b/source/reference/method/js-cursor.txt
@@ -10,9 +10,9 @@ Cursor Methods
    :depth: 1
    :class: singlecol
 
-.. note:: ``mongo`` Shell Methods
+.. note:: ``mongosh`` Methods
 
-   .. include:: /includes/fact-mongo-shell-method-toc.rst
+   .. include:: /includes/fact-mongosh-shell-method-toc.rst
 
 These methods modify the way that the underlying query is executed.
 


### PR DESCRIPTION
There are a large number of files in this change set. Most of them have only superficial changes. Here is a short summary of the changes made:

The substantive changes are found in the following files: 
source/includes/fact-mongosh-shell-method.rst
source/includes/fact-mongosh-shell-method-toc.rst



Two index pages had updates:
source/reference/method/js-collection.txt
source/reference/method/js-cursor.txt

One method was only partially migrated to mongosh
source/reference/method/db.getMongo.txt

There was a small, title change in:
source/reference/method.txt

The remaining files in the change set were updated to reflect filenames for the include files. 
source/includes/fact-mongo-shell-method.rst  was renamed: 
source/includes/fact-mongosh-shell-method.rst

source/includes/fact-mongo-shell-method-toc.rst was renamed:
source/includes/fact-mongosh-shell-method-toc.rst

### STAGING LINKS ###
### This is a sample page using the updated banner
https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/DOCSP-15489-update-mongo-shell-banner-for-mongosh-v5.0/reference/method/db.collection.distinct/

### These pages use the updated index files:
https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/DOCSP-15489-update-mongo-shell-banner-for-mongosh-v5.0/reference/method/js-cursor/
https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/DOCSP-15489-update-mongo-shell-banner-for-mongosh-v5.0/reference/method/js-collection/

### This page references a method which was not ported to mongosh
https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/DOCSP-15489-update-mongo-shell-banner-for-mongosh-v5.0/reference/method/db.getMongo/

### JIRA TICKET LINK ###
https://jira.mongodb.org/browse/DOCSP-15489
