### PR TITLE
DOP-1882: redirect genindex to homepage

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1786,3 +1786,5 @@ raw: /manual/core/wildcard -> ${base}/manual/core/index-wildcard/
 [v3.4-v4.0]: /${version}/reference/mongodb-defaults -> ${base}/${version}/reference/
 
 [v3.6-*]: /${version}/reference/command/clean -> ${base}/${version}/reference/command/nav-administration/
+
+[4.4-*]: /${version}/genindex -> ${base}/${version}/


### PR DESCRIPTION
Adds redirect to… redirect the genindex page that we are no longer building as of Snooty to the main landing page. Redirect file should be updated to include the earlier versions as they move onto being built with Snooty as well.