### PR TITLE
DOP-1883: address legacy links to ecosystem docs

### DIFF
--- a/source/core/read-preference-hedge-option.txt
+++ b/source/core/read-preference-hedge-option.txt
@@ -26,8 +26,8 @@ To use hedged reads, enable the hedge read option for non-``primary``
 read preferences. Read preference :readmode:`nearest` specifies hedged
 read by default.
 
-- When using the drivers, refer to the `drivers' read preference API
-  <https://docs.mongodb.com/drivers/drivers>`__.
+- When using the drivers, refer to the :driver:`drivers' read preference API
+  </>`.
 
 - When using the :binary:`~bin.mongo` shell, you can use the helper
   methods :method:`cursor.readPref()` and :method:`Mongo.setReadPref()`.

--- a/source/reference/connection-string.txt
+++ b/source/reference/connection-string.txt
@@ -842,8 +842,7 @@ on a per-connection basis in the connection string.
 .. note::
 
    To specify the hedged reads option using the drivers, refer to the
-   `drivers' read preference API
-   <https://docs.mongodb.com/drivers/drivers>`__.
+   :driver:`drivers' read preference API </>`.
 
 For example:
 

--- a/source/tutorial/upgrade-revision.txt
+++ b/source/tutorial/upgrade-revision.txt
@@ -37,9 +37,7 @@ Compatibility Considerations
 
   - The release notes, located at :doc:`/release-notes`.
 
-  - The documentation for your driver. See :driver:`Drivers
-    </>` and :driver:`Driver Compatibility
-    </drivers/driver-compatibility-reference>` pages for more information.
+  - The :driver:`documentation for your driver </>`.
 
 .. important::
 
@@ -110,9 +108,8 @@ use the procedure :ref:`upgrade-mongodb-instance`.
 Follow this upgrade procedure:
 
 1. For deployments that use authentication, first upgrade all of your
-   MongoDB :driver:`Drivers </>`. To upgrade, see the
-   documentation for your driver as well as the :driver:`Driver
-   Compatibility </drivers/driver-compatibility-reference>` page.
+   MongoDB Drivers. To upgrade, see the
+   :driver:`documentation for your driver </>`.
 
 #. Upgrade sharded clusters, as described in
    :ref:`upgrade-sharded-cluster`.


### PR DESCRIPTION
Updates links to point to actual driver documentation. This cherry-picks the changes from #5349 to master.