### PR TITLE
DOCS-15883 update left-nav for mongo mongosh

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -117,6 +117,7 @@ toc_landing_pages = [
    "/reference/method/js-role-management",
    "/reference/method/js-sharding",
    "/reference/method/js-user-management",
+   "/reference/mongo",   
    "/reference/operator/aggregation-pipeline",
    "/reference/operator/aggregation",
    "/reference/operator/query-array",

--- a/source/contents.txt
+++ b/source/contents.txt
@@ -11,7 +11,6 @@ project, this Manual and additional editions of this text.
 
 - :doc:`/introduction`
 - :doc:`/installation`
-- :doc:`/mongo`
 - :doc:`/crud`
 - :doc:`/aggregation`
 - :doc:`/data-modeling`
@@ -35,7 +34,7 @@ project, this Manual and additional editions of this text.
 
    Introduction </introduction>
    Installation </installation>
-   /mongo
+   MongoDB Shell (mongosh) <https://docs.mongodb.com/mongodb-shell/>
    /crud
    /aggregation
    /data-modeling

--- a/source/includes/driver-examples/driver-example-indexes-2.rst
+++ b/source/includes/driver-examples/driver-example-indexes-2.rst
@@ -11,7 +11,7 @@
          .. note::
 
             The following examples illustrate indexes and collation in
-            the :doc:`Mongo Shell </mongo/>`.
+            :mongosh:`mongosh </>`.
 
             Refer to the
             :compass:`MongoDB Compass Documentation

--- a/source/includes/fact-collation-driver.rst
+++ b/source/includes/fact-collation-driver.rst
@@ -1,7 +1,7 @@
 .. note::
 
    The following examples illustrate indexes and collation in
-   the :doc:`Mongo Shell </mongo/>`.
+   the :mongosh:`mongosh </>`.
 
    Refer to your :api:`driver documentation <>` for
    instructions on creating indexes with collation in your specific

--- a/source/includes/footnote-set-shell-batch-size.rst
+++ b/source/includes/footnote-set-shell-batch-size.rst
@@ -1,3 +1,4 @@
 .. [#set-shell-batch-size] You can set the ``DBQuery.shellBatchSize``
    attribute to change the number of documents from the default value of
    ``20``.
+

--- a/source/includes/steps-run-mongodb-on-linux-tarball.yaml
+++ b/source/includes/steps-run-mongodb-on-linux-tarball.yaml
@@ -75,7 +75,7 @@ post: |
 
   For more information on connecting using the :binary:`~bin.mongo`
   shell, such as to connect to a :binary:`~bin.mongod` instance running
-  on a different host and/or port, see :doc:`/mongo`.
+  on a different host and/or port, see :doc:`/reference/mongo`.
 
   To help you start using MongoDB, MongoDB provides :ref:`Getting
   Started Guides <getting-started>` in various driver editions. For the

--- a/source/includes/steps-run-mongodb-on-linux.yaml
+++ b/source/includes/steps-run-mongodb-on-linux.yaml
@@ -97,7 +97,7 @@ post: |
 
   For more information on connecting using the :binary:`~bin.mongo`
   shell, such as to connect to a :binary:`~bin.mongod` instance running
-  on a different host and/or port, see :doc:`/mongo`.
+  on a different host and/or port, see :doc:`/reference/mongo`.
 
   To help you start using MongoDB, MongoDB provides :ref:`Getting
   Started Guides <getting-started>` in various driver editions. For the

--- a/source/includes/steps-run-mongodb-on-osx.yaml
+++ b/source/includes/steps-run-mongodb-on-osx.yaml
@@ -118,7 +118,7 @@ post: |
 
   For more information on connecting using the :binary:`~bin.mongo`
   shell, such as to connect to a :binary:`~bin.mongod` instance running
-  on a different host and/or port, see :doc:`/mongo`.
+  on a different host and/or port, see :doc:`/reference/mongo`.
 
   To help you start using MongoDB, MongoDB provides :ref:`Getting
   Started Guides <getting-started>` in various driver editions. See

--- a/source/includes/steps-run-mongodb-on-windows.yaml
+++ b/source/includes/steps-run-mongodb-on-windows.yaml
@@ -66,7 +66,7 @@ content: |
 
   For more information on connecting a :binary:`mongo.exe <bin.mongo>`
   shell, such as to connect to a MongoDB instance running on a different
-  host and/or port, see :doc:`/mongo`. For information on CRUD
+  host and/or port, see :doc:`/reference/mongo`. For information on CRUD
   (Create,Read,Update,Delete) operations, see:
      
   - :doc:`/tutorial/insert-documents`

--- a/source/reference.txt
+++ b/source/reference.txt
@@ -19,8 +19,12 @@ Reference
    command>` operations, syntax, and use.
 
 :doc:`/reference/method`
-   Documentation of all JavaScript methods and helpers in the
-   :binary:`~bin.mongo` shell.
+   Documentation of JavaScript methods and helpers in
+   :mongosh:`mongosh </>`.
+
+:doc:`/reference/mongo`
+   Documentation of JavaScript methods and helpers in
+   the legacy :binary:`~bin.mongo` shell.
 
 :doc:`/reference/program`
    Documentation of :binary:`~bin.mongod` and :binary:`~bin.mongos`
@@ -95,6 +99,7 @@ Reference
    /reference/operator
    /reference/command
    /reference/method
+   /reference/mongo
    /reference/program
    /reference/configuration-options
    /reference/parameters

--- a/source/reference/mongo.txt
+++ b/source/reference/mongo.txt
@@ -1,8 +1,14 @@
-===================
-The ``mongo`` Shell
-===================
+======================
+Legacy ``mongo`` Shell
+======================
 
 .. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
 
 .. note::
 
@@ -44,8 +50,15 @@ The list of methods supported by ``mongosh`` is here:
 
 .. seealso::
 
-   - :doc:`Getting Started Guide for the mongo Shell
-     </tutorial/getting-started>`
    - :binary:`~bin.mongo` Reference Page
    - :mongosh:`mongosh Documentation </>`
+
+.. toctree::
+   :titlesonly:
+
+   /tutorial/configure-mongo-shell
+   /tutorial/access-mongo-shell-help
+   /tutorial/write-scripts-for-the-mongo-shell
+   /core/shell-types
+   /reference/mongo-shell
 

--- a/source/reference/program/mongo.txt
+++ b/source/reference/program/mongo.txt
@@ -1420,7 +1420,7 @@ to enclose the JavaScript, using the following form:
 
    - :doc:`/reference/mongo-shell`
    - :doc:`/reference/method`
-   - :doc:`/mongo`
+   - :doc:`/reference/mongo`
    - :method:`isInteractive()`
 
 

--- a/source/tutorial/install-mongodb-enterprise-on-windows.txt
+++ b/source/tutorial/install-mongodb-enterprise-on-windows.txt
@@ -144,7 +144,7 @@ Interpreter` with Administrative privileges and run:
 
 For more information on connecting a :binary:`mongo.exe <bin.mongo>`
 shell, such as to connect to a MongoDB instance running on a different
-host and/or port, see :doc:`/mongo`. For information on CRUD
+host and/or port, see :doc:`/reference/mongo`. For information on CRUD
 (Create,Read,Update,Delete) operations, see:
      
 - :doc:`/tutorial/insert-documents`

--- a/source/tutorial/install-mongodb-on-windows.txt
+++ b/source/tutorial/install-mongodb-on-windows.txt
@@ -133,7 +133,7 @@ Interpreter` with Administrative privileges and run:
 
 For more information on connecting a :binary:`mongo.exe <bin.mongo>`
 shell, such as to connect to a MongoDB instance running on a different
-host and/or port, see :doc:`/mongo`. For information on CRUD
+host and/or port, see :doc:`/reference/mongo`. For information on CRUD
 (Create,Read,Update,Delete) operations, see:
      
 - :doc:`/tutorial/insert-documents`


### PR DESCRIPTION
This ticket:
- replaces mongo shell with a link to the new mongosh in the left nav
- moves the old mongo link to Reference section
- renames the link to 'Legacy mongo Shell' 
- returns a TOC to the legacy page that had been dropped 

Most of the updated files are included because of path updates in links to the old mongo shell. 

source/reference/mongo.txt is a stripped down version of the older source/mongo.txt landing page

The other changes are to link up the indices and TOCs properly.

### JIRA
https://jira.mongodb.org/browse/DOCSP-15883

### STAGING
# Main landing page
https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/DOCSP-15883-left-nav-updates-for-mongo-mongosh-v5.0/

# Legacy mongo shell pages
https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/DOCSP-15883-left-nav-updates-for-mongo-mongosh-v5.0/reference/mongo/
