### PR TITLE
Fix database profiler collection location

### DIFF
--- a/source/tutorial/manage-the-database-profiler.txt
+++ b/source/tutorial/manage-the-database-profiler.txt
@@ -16,9 +16,9 @@ The database profiler collects detailed information about
 :ref:`database-commands` executed against a running :binary:`~bin.mongod`
 instance. This includes CRUD operations as well as configuration and
 administration commands.
-The profiler writes all the data it collects to the
+The profiler writes all the data it collects to a
 :data:`system.profile <<database>.system.profile>` collection, a
-:doc:`capped collection </core/capped-collections>` in the ``admin``
+:doc:`capped collection </core/capped-collections>` in each profiled
 database. See :doc:`/reference/database-profiler` for an overview of the
 :data:`system.profile <<database>.system.profile>` documents created by
 the profiler.


### PR DESCRIPTION
I don't think we ever put everything in admin.system.profile, and the text already conflicts with itself later on when we do state that system.profile goes in every profiled database.