### PR TITLE
fixing wording

### DIFF
--- a/source/core/zone-sharding.txt
+++ b/source/core/zone-sharding.txt
@@ -173,15 +173,15 @@ You must use fields contained in the :term:`shard key` when defining a new
 range for a zone to cover. If using a :term:`compound <compound index>` shard
 key, the range must include the prefix of the shard key.
 
-For example, given a shard key ``{ a : 1, b : 2, c : 3 }``, creating or
-updating a zone to cover values of ``b`` requires including ``a`` as the
-prefix. Creating or updating a zone to covers values of ``c`` requires
+For example, given a shard key ``{ a : 1, b : 1, c : 1 }``, creating or
+updating a range to cover values of ``b`` requires including ``a`` as the
+prefix. Creating or updating a range to covers values of ``c`` requires
 including ``a`` and ``b`` as the prefix.
 
-You cannot create zones using fields not included in the shard key. For
+You cannot create ranges using fields not included in the shard key. For
 example, if you wanted to use zones to partition data based on
-geographic location, the shard key would need at least one field that
-contained geographic data.
+geographic location, the shard key would need the first field to
+contain geographic data.
 
 When choosing a shard key for a collection, consider what fields you might
 want to use for configuring zones. See :ref:`sharding-internals-choose-shard-key` 


### PR DESCRIPTION
shard keys don't have values 1, 2, 3...   and you define ranges using shard key, not zones, and to use location it has to be first field (not any one field) in the shard key