### PR TITLE
DOCS-14756: Update ensure-indexes-fit-ram.txt

### DIFF
--- a/source/tutorial/ensure-indexes-fit-ram.txt
+++ b/source/tutorial/ensure-indexes-fit-ram.txt
@@ -22,7 +22,7 @@ bytes:
 .. code-block:: javascript
 
    > db.collection.totalIndexSize()
-   4294976499
+   4617080000
 
 The above example shows an index size of almost 4.3 gigabytes. To ensure
 this index fits in RAM, you must not only have more than that much RAM


### PR DESCRIPTION
the calculation from Bytes to GB is wrong