### PR TITLE
(DOCSP-17931): Added Atlas connection string note.

### DIFF
--- a/source/reference/connection-string.txt
+++ b/source/reference/connection-string.txt
@@ -19,6 +19,14 @@ between applications and MongoDB instances in the official MongoDB
 :driver:`Drivers </>`. For a list of drivers and links to
 driver documentation, see :driver:`Drivers </>`.
 
+.. note::
+
+   The MongoDB Atlas UI provides the connection strings for you 
+   when you :atlas:`connect to a database deployment 
+   </connect-to-database-deployment/>`. To register a new Atlas 
+   account, start at the :mdbacct:`MongoDB Atlas registration page 
+   </register?tck=docs_atlas>`.
+
 Connection String Formats
 -------------------------
 

--- a/source/reference/connection-string.txt
+++ b/source/reference/connection-string.txt
@@ -126,14 +126,15 @@ Examples
         name: Atlas Deployment
         content: |
 
-           .. note::
+           MongoDB Atlas provides the connection strings for 
+           your deployment when you click the :atlas:`Connect
+           </connect-to-database-deployment/>` button in the Atlas UI. 
+           To register a new Atlas account, start at the 
+           :mdbacct:`MongoDB Atlas registration page 
+           </register?tck=docs_atlas>`.
 
-              The MongoDB Atlas UI provides the connection strings for 
-              you when you :atlas:`connect to a database deployment 
-              </connect-to-database-deployment/>`. To register a new 
-              Atlas account, start at the 
-              :mdbacct:`MongoDB Atlas registration page 
-              </register?tck=docs_atlas>`.
+           Your Atlas connection string might resemble the following 
+           example:
 
            .. code-block:: bash
 

--- a/source/reference/connection-string.txt
+++ b/source/reference/connection-string.txt
@@ -19,14 +19,6 @@ between applications and MongoDB instances in the official MongoDB
 :driver:`Drivers </>`. For a list of drivers and links to
 driver documentation, see :driver:`Drivers </>`.
 
-.. note::
-
-   The MongoDB Atlas UI provides the connection strings for you 
-   when you :atlas:`connect to a database deployment 
-   </connect-to-database-deployment/>`. To register a new Atlas 
-   account, start at the :mdbacct:`MongoDB Atlas registration page 
-   </register?tck=docs_atlas>`.
-
 Connection String Formats
 -------------------------
 
@@ -129,6 +121,23 @@ Examples
                 mongodb://myDBReader:D1fficultP%40ssw0rd@mongos0.example.com:27017,mongos1.example.com:27017,mongos2.example.com:27017/?authSource=admin
 
              .. include:: /includes/fact-pct-encode-uri.rst
+
+      - id: atlas
+        name: Atlas Deployment
+        content: |
+
+           .. note::
+
+              The MongoDB Atlas UI provides the connection strings for 
+              you when you :atlas:`connect to a database deployment 
+              </connect-to-database-deployment/>`. To register a new 
+              Atlas account, start at the 
+              :mdbacct:`MongoDB Atlas registration page 
+              </register?tck=docs_atlas>`.
+
+           .. code-block:: bash
+
+              mongosh "mongodb+srv://cluster0.example.mongodb.net myFirstDatabase" --username JohnDoe
 
 For more examples, see :ref:`connections-connection-examples`.
 

--- a/source/reference/connection-string.txt
+++ b/source/reference/connection-string.txt
@@ -131,7 +131,8 @@ Examples
            </connect-to-database-deployment/>` button in the Atlas UI. 
            To register a new Atlas account, start at the 
            :mdbacct:`MongoDB Atlas registration page 
-           </register?tck=docs_atlas>`.
+           </register?tck=docs_server>`. To learn more, see
+           :atlas:`Get Started with Atlas </getting-started/>`.
 
            Your Atlas connection string might resemble the following 
            example:


### PR DESCRIPTION
@jdestefano-mongo, I added details to the following page about the Atlas UI providing the connection strings.

[STAGE](https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/DOCSP-17921/reference/connection-string/)

[JIRA](https://jira.mongodb.org/browse/DOCSP-17931)

[BUILD](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=6127ecc67dcf01293000e24c)