### PR TITLE
Remove legacy shell tip from aggregate command

### DIFF
--- a/source/reference/command/aggregate.txt
+++ b/source/reference/command/aggregate.txt
@@ -50,8 +50,7 @@ The command has following syntax:
    Rather than run the :dbcommand:`aggregate` command directly, most
    users should use the :method:`db.collection.aggregate()` helper
    provided in :binary:`~bin.mongosh` or the equivalent helper in
-   their driver. In 2.6 and later, the
-   :method:`db.collection.aggregate()` helper always returns a cursor.
+   their driver.
 
 Command Fields
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
This sentence appears to only be applicable to the legacy shell.