### PR TITLE
DOCS-13479 Add note for out and merge behavior on RS

### DIFF
--- a/source/reference/operator/aggregation/merge.txt
+++ b/source/reference/operator/aggregation/merge.txt
@@ -39,9 +39,27 @@ Definition
 
    - Can output to a collection in the same or different database.
 
-     - Starting in MongoDB 4.4, :pipeline:`$merge` can output to the
+   - Starting in MongoDB 4.4:
+
+     - :pipeline:`$merge` can output to the
        same collection that is being aggregated. For more
        information, see :ref:`merge-behavior-same-collection`.
+
+     - Pipelines with the :pipeline:`$merge` stage can run on 
+       replica set secondary nodes if all the nodes in cluster have 
+       :ref:`featureCompatibilityVersion <view-fcv>` set 
+       to ``4.4`` or higher and the :doc:`/core/read-preference`
+       allows secondary reads. 
+
+       - Read operations of the :pipeline:`$merge` statement are sent to 
+         secondary nodes, while the write operations occur only on the 
+         primary node.
+
+       - Not all driver versions support targeting of :pipeline:`$merge` 
+         operations to replica set secondary nodes. Check your 
+         :driver:`driver </>` documentation to see when your driver added
+         support for :pipeline:`$merge` read operations running on 
+         secondary nodes.
 
    - Creates a new collection if the output collection does not already
      exist.

--- a/source/reference/operator/aggregation/out.txt
+++ b/source/reference/operator/aggregation/out.txt
@@ -151,6 +151,24 @@ Comparison with ``$merge``
 Behaviors
 ---------
 
+$out Read Operations Run on Secondary Replica Set Members
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Starting in MongoDB 4.4, :pipeline:`$out` can run on 
+replica set secondary nodes if all the nodes in
+cluster have :ref:`featureCompatibilityVersion <view-fcv>` set 
+to ``4.4`` or higher and the :doc:`/core/read-preference` is set to 
+secondary.
+
+Read operations of the :pipeline:`$out` statement occur on the 
+secondary nodes, while the write operations occur only on the 
+primary nodes.
+
+Not all driver versions support targeting of :pipeline:`$out` 
+operations to replica set secondary nodes. Check your 
+:driver:`driver </>` documentation to see when your driver added
+support for :pipeline:`$out` running on a secondary.
+
 Create New Collection
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/release-notes/4.4.txt
+++ b/source/release-notes/4.4.txt
@@ -387,9 +387,19 @@ General Aggregation Improvements
 ``$out``
 ````````
 
-Starting in MongoDB 4.4, :pipeline:`$out` can output to a collection in
-a different database. In earlier versions, :pipeline:`$out` can output
-to a collection to the same database where the aggregation is run.
+Starting in MongoDB 4.4:
+
+- :pipeline:`$out` can output to a collection in
+  a different database. In earlier versions, :pipeline:`$out` can only 
+  output to a collection in the same database database where the 
+  aggregation is run.
+
+- :pipeline:`$out` can only run on replica set secondary nodes if
+  all the nodes in cluster have 
+  :ref:`featureCompatibilityVersion <view-fcv>` set to ``4.4`` or 
+  higher and the :doc:`/core/read-preference` allows secondary reads.
+  Check your :driver:`driver </>` documentation to see when your 
+  driver added support.
 
 ``$indexStats``
 ```````````````
@@ -416,6 +426,20 @@ Starting in MongoDB 4.4 (also available starting in 4.2.4),
 
 ``$merge``
 ``````````
+
+Starting in MongoDB 4.4:
+
+- :pipeline:`$merge` can output to a collection in
+  a different database. In earlier versions, :pipeline:`$merge` can 
+  only output to a collection in the same database where the aggregation 
+  is run.
+
+- :pipeline:`$merge` can only run on replica set secondary nodes if
+  all the nodes in cluster have 
+  :ref:`featureCompatibilityVersion <view-fcv>` set to ``4.4`` or 
+  higher and the :doc:`/core/read-preference` allows secondary reads.
+  Check your :driver:`driver </>` documentation to see 
+  when your driver added support.
 
 .. include:: /includes/fact-merge-same-collection-behavior.rst
 


### PR DESCRIPTION
FYI this was marked as a 5.1 but was actually implemented in 4.4, drivers implementation may lag hence the note "Check your driver documentation to see when your driver added support for :pipeline:`$merge` read operations running on 
secondary nodes".