### PR TITLE
Revert "DOCSP-18626 release note for snippets. (#6145)"

### DIFF
--- a/source/release-notes/5.0.txt
+++ b/source/release-notes/5.0.txt
@@ -714,12 +714,6 @@ of :doc:`replica set </replication>`
 :term:`capped collections <capped collection>` are processed by 
 the :doc:`secondary members </core/replica-set-secondary/>`.
 
-Snippets Package Manager for ``mongosh``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:binary:`~bin.mongosh` provides the :ref:`snippets <snip-overview>`
-tool to facilitate running and sharing scripts.
-
 Execution Plan Statistics for Query with ``$lookup`` Pipeline Stage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This reverts commit a50431b2d914514bdd139c36b7a9e8c619e5ff94.