### PR TITLE
DOCS-14980 updated lookup documentation

### DIFF
--- a/source/reference/database-references.txt
+++ b/source/reference/database-references.txt
@@ -21,7 +21,7 @@ or databases.
 .. important::
 
    MongoDB 3.2 introduces :pipeline:`$lookup` pipeline stage to perform
-   a left outer join to an unsharded collection in the same database.
+   a left outer join to a collection in the same database.
    For more information and examples, see :pipeline:`$lookup`.
 
    Starting in MongoDB 3.4, you can also use :pipeline:`$graphLookup`

--- a/source/reference/operator/aggregation/lookup.txt
+++ b/source/reference/operator/aggregation/lookup.txt
@@ -15,9 +15,9 @@ Definition
 
 .. pipeline:: $lookup
 
-   .. versionchanged:: 5.0
+   .. versionchanged:: 5.1
 
-   Performs a left outer join to an unsharded collection in the *same*
+   Performs a left outer join to a collection in the *same*
    database to filter in documents from the "joined" collection for
    processing. To each input document, the :pipeline:`$lookup` stage
    adds a new array field whose elements are the matching documents


### PR DESCRIPTION
Removed the unsharded qualifier for lookup collections. 
$graphlookup text would need to be verified. 