### PR TITLE
changes insertOne to updateOne w/upsert

### DIFF
--- a/source/tutorial/modify-chunk-size-in-sharded-cluster.txt
+++ b/source/tutorial/modify-chunk-size-in-sharded-cluster.txt
@@ -34,7 +34,12 @@ To modify the chunk size, use the following procedure:
 
    .. code-block:: javascript
 
-      db.settings.insertOne( { _id:"chunksize", value: <sizeInMB> } )
+      db.settings.updateOne( 
+         { _id:"chunksize" }, 
+         { $set: { _id:"chunksize", value: <sizeInMB> } }, 
+         { upsert: true } )
+      )
+
 
 Modifying the chunk size has several limitations:
 


### PR DESCRIPTION
### SUMMARY

On [Modify Chunk Size in a Sharded Cluster](https://docs.mongodb.com/manual/tutorial/modify-chunk-size-in-sharded-cluster/#modify-chunk-size-in-a-sharded-cluster), we tell users to user ``insertOne`` to modify the max chunksize value. 

Instead, this operation ought to be ``updateOne`` with ``{ upsert : true}``.

### JIRA

[DOCS-15056](https://jira.mongodb.org/browse/DOCS-15056)

### STAGING

[Modify Chunk Size in a Sharded Cluster](https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/modify-max-chunksize-with-upsert/tutorial/modify-chunk-size-in-sharded-cluster/)