### PR TITLE
DOCs cursor.noCursorTimeout.txt

### DIFF
--- a/source/reference/method/cursor.noCursorTimeout.txt
+++ b/source/reference/method/cursor.noCursorTimeout.txt
@@ -51,7 +51,7 @@ session using the :dbcommand:`refreshSessions` command. For example:
 .. code-block:: shell
 
    var session = db.getMongo().startSession()
-   var sessionId = session.getSessionId().id
+   var sessionId = session.id
 
    var cursor = session.getDatabase("examples").getCollection("data").find().noCursorTimeout()
    var refreshTimestamp = new Date() // take note of time at operation start


### PR DESCRIPTION
There is no such method as `session.getSessionId`

"TypeError: session.getSessionId is not a function"

Though there you can get the session id directly with `session.id`

Tested on mongosh 1.1.9 and 1.0.5 and Mongodb 4.2.6-18-g6cdb6ab