### PR TITLE
Update redirects base for subdomain consolidation

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1,8 +1,5 @@
-define: base https://docs.mongodb.com
+define: base https://www.mongodb.com/docs
 define: versions v2.2 v2.4 v2.6 v3.0 v3.2 v3.4 v3.6 v4.0 v4.2 v4.4 v5.0 v5.1 v5.2 master
-symlink: manual -> v5.0
-symlink: upcoming -> v5.0
-symlink: master -> v5.0
 
 [v2.2]: /${version}/core/read-operations-introduction -> ${base}/${version}/core/read-operations/
 [v2.2]: /${version}/core/write-operations-introduction -> ${base}/${version}/core/write-operations/
@@ -648,7 +645,7 @@ symlink: master -> v5.0
 [*-v3.0]: /${version}/reference/operator/query/bitsAnyClear -> ${base}/${version}/reference/operator/query/
 [*-v3.0]: /${version}/reference/operator/query/bitsAnySet -> ${base}/${version}/reference/operator/query/
 [*-v3.0]: /${version}/reference/method/db.collection.bulkWrite -> ${base}/${version}/reference/method/Bulk/
-[*]: /${version}/use-cases/storing-comments -> https://docs.mongodb.com/ecosystem/use-cases/storing-comments/
+[*]: /${version}/use-cases/storing-comments -> https://www.mongodb.com/developer/
 (v3.0-*]: /${version}/core/aggregation-mechanics -> ${base}/${version}/aggregation/
 (v3.0-*]: /${version}/core/aggregation-introduction -> ${base}/${version}/aggregation/
 (v3.0-*]: /${version}/core/aggregation -> ${base}/${version}/aggregation/
@@ -1076,7 +1073,7 @@ raw: /master/release-notes/3.3-dev-series-reference -> ${base}/master/release-no
 [v2.2]: /${version}/MongoDB-reference-manual-v2.2.pdf -> ${base}/${version}/meta/pdfs/
 [v2.2]: /${version}/MongoDB-crud-guide-v2.2.pdf -> ${base}/${version}/meta/pdfs/
 (v3.0-*]: /${version}/products/bi-connector -> https://docs.mongodb.com/bi-connector/
-(v3.0-*]: /${version}/reference/business-intelligence-programs -> https://docs.mongodb.com/bi-connector/
+(v3.0-*]: /${version}/reference/business-intelligence-programs -> ${base}/bi-connector/
 (v3.0-*]: /${version}/products/faq-bi-connector -> https://docs.mongodb.com/bi-connector/faq/
 (v3.0-*]: /${version}/products/components-bi-connector -> https://docs.mongodb.com/bi-connector/components/
 (v3.0-*]: /${version}/products/release-notes/bi-connector -> https://docs.mongodb.com/bi-connector/release-notes/
@@ -1577,7 +1574,7 @@ raw: /v2.8/release-notes/2.8-changes -> ${base}/v3.0/release-notes/3.0/
 [*]: /${version}/core/operational-segregation -> ${base}/${version}/core/workload-isolation/
 
 # DOCSP-3769
-[*]: /${version}/applications/drivers -> https://docs.mongodb.com/drivers/
+[*]: /${version}/applications/drivers -> ${base}/drivers/
 
 # Redirects for 4.2 and greater
 
@@ -1967,14 +1964,14 @@ raw: /manual/core/wildcard -> ${base}/manual/core/index-wildcard/
 # Redirecting DB Tools program pages to DB Tools repo directly
 #
 
-[v5.0-*]: /${version}/reference/program/mongodump -> https://docs.mongodb.com/database-tools/mongodump/
-[v5.0-*]: /${version}/reference/program/mongorestore -> https://docs.mongodb.com/database-tools/mongorestore/
-[v5.0-*]: /${version}/reference/program/bsondump -> https://docs.mongodb.com/database-tools/bsondump/
-[v5.0-*]: /${version}/reference/program/mongoimport -> https://docs.mongodb.com/database-tools/mongoimport/
-[v5.0-*]: /${version}/reference/program/mongoexport -> https://docs.mongodb.com/database-tools/mongoexport/
-[v5.0-*]: /${version}/reference/program/mongostat -> https://docs.mongodb.com/database-tools/mongostat/
-[v5.0-*]: /${version}/reference/program/mongotop -> https://docs.mongodb.com/database-tools/mongotop/
-[v5.0-*]: /${version}/reference/program/mongofiles -> https://docs.mongodb.com/database-tools/mongofiles/
+[v5.0-*]: /${version}/reference/program/mongodump -> ${base}/database-tools/mongodump/
+[v5.0-*]: /${version}/reference/program/mongorestore -> ${base}/database-tools/mongorestore/
+[v5.0-*]: /${version}/reference/program/bsondump -> ${base}/database-tools/bsondump/
+[v5.0-*]: /${version}/reference/program/mongoimport -> ${base}/database-tools/mongoimport/
+[v5.0-*]: /${version}/reference/program/mongoexport -> ${base}/database-tools/mongoexport/
+[v5.0-*]: /${version}/reference/program/mongostat -> ${base}/database-tools/mongostat/
+[v5.0-*]: /${version}/reference/program/mongotop -> ${base}/database-tools/mongotop/
+[v5.0-*]: /${version}/reference/program/mongofiles -> ${base}/database-tools/mongofiles/
 
 # Redirect of Long-Running Queries page (must be removed as part of the work for DOCS-15065)
 


### PR DESCRIPTION
Also: the "symlinks" don't do anything as of Snooty, so removing that cruft to avoid introducing tech debt / confusion.