### PR TITLE
WIP: Improve documentation about converting from MMAPv1 to WiredTiger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ examples:
 	curl -SfL https://raw.githubusercontent.com/mongodb/mongo-ruby-driver/master/spec/integration/versioned_api_examples_spec.rb -o ${DRIVERS_PATH}/versioned_api_examples_spec.rb
 
 # rust
-	curl -SfL https://raw.githubusercontent.com/mongodb/mongo-rust-driver/master/src/test/documentation_examples/mod.rs -o ${DRIVERS_PATH}/mod.rs
+	curl -SfL https://raw.githubusercontent.com/mongodb/mongo-rust-driver/main/src/test/documentation_examples/mod.rs -o ${DRIVERS_PATH}/mod.rs
 
 # scala
 	curl -SfL https://raw.githubusercontent.com/mongodb/mongo-scala-driver/master/driver/src/it/scala/org/mongodb/scala/DocumentationExampleSpec.scala -o ${DRIVERS_PATH}/DocumentationExampleSpec.scala

--- a/source/reference/database-references.txt
+++ b/source/reference/database-references.txt
@@ -13,57 +13,48 @@ Database References
    :class: singlecol
 
 For many use cases in MongoDB, the denormalized data model where
-related data is stored within a single :term:`document <document>` will
-be optimal. However, in some cases, it makes sense to store related
+related data is stored within a single :term:`document <document>` is optimal. 
+However, in some cases, it makes sense to store related
 information in separate documents, typically in different collections
 or databases.
 
 .. important::
 
-   MongoDB 3.2 introduces :pipeline:`$lookup` pipeline stage to perform
+   You can use the :pipeline:`$lookup` pipeline stage to perform
    a left outer join to an unsharded collection in the same database.
-   For more information and examples, see :pipeline:`$lookup`.
 
-   Starting in MongoDB 3.4, you can also use :pipeline:`$graphLookup`
-   pipeline stage to join an unsharded collection to perform recursive
-   search. For more information and examples, see
-   :pipeline:`$graphLookup`.
+   You can also use the :pipeline:`$graphLookup` pipeline stage to join an 
+   unsharded collection to perform recursive search.
 
 This page outlines alternative procedures that predate the
 :pipeline:`$lookup` and :pipeline:`$graphLookup` pipeline stages.
 
-MongoDB applications use one of two methods for relating documents:
+MongoDB applications use one of two methods to relate documents:
 
-- :ref:`Manual references <document-references>` where you save the
+- :ref:`Manual references <document-references>` save the
   ``_id`` field of one document in another document as a reference.
-  Then your application can run a second query to return the related
+  Your application runs a second query to return the related
   data. These references are simple and sufficient for most use
   cases.
 
 - :ref:`DBRefs <dbref-explanation>` are references from one document to another
   using the value of the first document's ``_id`` field, collection name,
-  and, optionally, its database name. By including these names, DBRefs
-  allow documents located in multiple collections to be more easily linked
-  with documents from a single collection.
+  and, optionally, its database name, as well as any other fields. DBRefs allow
+  you to more easily reference documents stored in multiple collections or 
+  databases.
 
-  To resolve DBRefs, your application
-  must perform additional queries to return the referenced
-  documents. Many :driver:`Drivers </>` have helper
-  methods that form the query for the DBRef automatically. The
-  drivers [#official-driver]_ do not *automatically* resolve DBRefs
-  into documents.
+To resolve DBRefs, your application must perform additional queries to return
+the referenced documents. Some :driver:`MongoDB drivers </>` provide helper 
+methods to enable DBRefs to be resolved into documents, but it doesn't happen 
+automatically.
 
-  DBRefs provide a common format and type to represent relationships among
-  documents. The DBRef format also provides common semantics for representing
-  links between documents if your database must interact with
-  multiple frameworks and tools.
+DBRefs provide a common format and type to represent relationships among
+documents. The DBRef format also provides common semantics for representing
+links between documents if your database must interact with
+multiple frameworks and tools.
 
 Unless you have a compelling reason to use DBRefs, use manual
 references instead.
-
-.. [#official-driver] Some community supported drivers may have
-   alternate behavior and may resolve a DBRef into a document
-   automatically.
 
 .. _document-references:
 
@@ -73,7 +64,7 @@ Manual References
 Background
 ~~~~~~~~~~
 
-Using manual references is the practice of including one
+A manual reference is the practice of including one
 :term:`document's <document>` ``_id`` field in another document. The
 application can then issue a second query to resolve the referenced
 fields as needed.
@@ -129,7 +120,11 @@ Background
 DBRefs are a convention for representing a :term:`document`, rather
 than a specific reference type. They include the name of the
 collection, and in some cases the database name, in addition to the
-value from the ``_id`` field.
+value from the ``_id`` field. 
+
+Optionally, DBRefs can include any number of other fields. Extra field names 
+must follow any :ref:`rules for field names <limit-restrictions-on-field-names>` 
+imposed by the server version.
 
 Format
 ~~~~~~
@@ -153,8 +148,6 @@ DBRefs have the following fields:
    Contains the name of the database where the referenced document
    resides.
 
-   Only some drivers support ``$db`` references.
-
 .. example::
 
    DBRef documents resemble the following document:
@@ -174,13 +167,15 @@ DBRefs have the following fields:
         "creator" : {
                         "$ref" : "creators",
                         "$id" : ObjectId("5126bc054aed4daf9e2ab772"),
-                        "$db" : "users"
+                        "$db" : "users",
+                        "extraField" : "anything"
                      }
       }
 
    The DBRef in this example points to a document in the ``creators``
    collection of the ``users`` database that has
-   ``ObjectId("5126bc054aed4daf9e2ab772")`` in its ``_id`` field.
+   ``ObjectId("5126bc054aed4daf9e2ab772")`` in its ``_id`` field. It also contains
+   an optional field.
 
 .. note::
 

--- a/source/reference/explain-results.txt
+++ b/source/reference/explain-results.txt
@@ -718,14 +718,20 @@ representative. Your output may differ significantly.
             * - ``spilledBytesApprox``
               - The approximate number of in-memory bytes spilled to disk in 
                 the stage.
+
+                .. versionadded:: 5.3
               - ``GROUP``
 
             * - ``spilledRecords``
               - The number of produced records spilled to disk in the stage.
+                
+                .. versionadded:: 5.3
               - ``GROUP``
 
             * - ``usedDisk``
               - Whether the stage wrote to disk.
+
+                .. versionadded:: 5.3
               - ``GROUP``
 
    .. data:: explain.executionStats.allPlansExecution

--- a/source/reference/operator/aggregation/geoNear.txt
+++ b/source/reference/operator/aggregation/geoNear.txt
@@ -206,6 +206,9 @@ When using :pipeline:`$geoNear`, consider that:
   :ref:`let option <geoNear_let_example>` and
   :ref:`bound let option <geoNear_bounded_let_example>`.
 
+- Starting in MongoDB 5.3, you can use :pipeline:`$geoNear` on any field
+  in a :ref:`time series collection <manual-timeseries-collection>`.
+
 Examples
 --------
 

--- a/source/release-notes/5.0.txt
+++ b/source/release-notes/5.0.txt
@@ -19,8 +19,8 @@ Patch Releases
 
 .. _5.0.7-release-notes:
 
-5.0.7 - Upcoming
-~~~~~~~~~~~~~~~~
+5.0.7 - April 11, 2022
+~~~~~~~~~~~~~~~~~~~~~~
 
 Issues fixed:
 

--- a/source/release-notes/5.3.txt
+++ b/source/release-notes/5.3.txt
@@ -149,6 +149,13 @@ Starting in MongoDB 5.3, the :parameter:`fassertOnLockTimeoutForStepUpDown`
 parameter allows a server that receives a request to step up or down to 
 terminate if it is unable to comply within the timeout.
 
+Time Series Collection Improvements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Starting in MongoDB 5.3, you can use the :pipeline:`$geoNear` pipeline
+operator on any field in a :ref:`time series collection
+<manual-timeseries-collection>`.
+
 Report an Issue
 ---------------
 

--- a/source/release-notes/5.3.txt
+++ b/source/release-notes/5.3.txt
@@ -142,6 +142,23 @@ can use ``getParameter`` to report :ref:`details on all parameters
 <getParameter-showdetails-all-params>` by passing 
 ``{ showDetails: true, allParameters: true }``. 
 
+``explain`` Output Can Includes Fields for Disk Usage on ``inputStage``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Starting in MongoDB 5.3, :dbcommand:`explain` output can include the 
+following disk usage metrics for a ``GROUP`` 
+:data:`explain.executionStats.executionStages.inputStage` that uses the 
+:ref:`slot-based execution query engine <5.1-rel-notes-sbe>`:
+
+- ``spilledBytesApprox``, the approximate number of in-memory bytes 
+  spilled to disk in the stage
+- ``spilledRecords``, the number of produced records spilled to disk in 
+  the stage
+- ``usedDisk``, whether the stage wrote to disk
+
+For details, see
+:data:`explain.executionStats.executionStages.inputStage`.
+
 Specify a Timeout for Step Up and Step Down Operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
A story about upgrading:

I just learned that I needed to upgrade MongoDB for a different program to be able to update. No big deal, I'll just go read the steps to upgrade Mongo from v4.0.something.

Ok, gotta add a new apt-source for v... and it wasn't self updating to 4.2... weird. Whatever.

Hmmm, what is this mmapv1 thing? Oh, it's just the default storage type. I just used defaults. Find by me if it gets upgraded to the latest.

`apt upgrade` installs new version...

`mongod` service is still running... weird. Usually apt takes care of that. `sudo systemctl restart mongod`... Wait, it's not coming back up...

No error in syslog... oh right, mongo does it's own logs. Hmmm, mmapv1 support was removed so now it can't start. Weird. Ok, find the migration instructions, basically: `mongodump --out=mongo.dump && ...` Wait, mongo needs to be running for the dump to work. Now I need to downgrade and I don't remember exactly which version was running before...

Now I'm frustrated. Clearly I've done this to myself but it sure feels like the docs could have had a simple yet clear warning on the migration page that you can't miss: "Export/Dump before stopping the dameon/upgrading!"

So, here I am making a request to change the docs to save others from the trouble I went through in the hopes that someone will see this and agree.

Ps, Unfortunately, this repo doesn't allow "Issues", so I've had to create a bogus "Pull Request" as I don't see *any* other way to give feedback.

Alternatively, I don't see how mongod can't just automatically do the right thing here. Refusing to write/update a mmapv1 database is reasonable to get users to upgrade but now it can't even read it?!?