### PR TITLE
Typo fix in substrCP example

### DIFF
--- a/source/reference/operator/aggregation/substrCP.txt
+++ b/source/reference/operator/aggregation/substrCP.txt
@@ -90,7 +90,7 @@ Definition
         - ``"cafét"``
    
       * - ``{ $substrCP: [ "cafétéria", 5, 4 ] }``
-        - ``"tér"``
+        - ``"éria"``
    
       * - ``{ $substrCP: [ "cafétéria", 7, 3 ] }``
         - ``"ia"``


### PR DESCRIPTION
Micro typo fix in example return value.