### PR TITLE
Updating AlmaLinux references

### DIFF
--- a/source/administration/production-notes.txt
+++ b/source/administration/production-notes.txt
@@ -109,7 +109,7 @@ systems are recommended for production use on ``x86_64`` architecture:
 
 - Amazon Linux 2
 - Debian 10
-- :abbr:`RHEL (Red Hat Enterprise Linux)` / CentOS 7 and 8 [#rocky-alma]_
+- :abbr:`RHEL (Red Hat Enterprise Linux)` / CentOS 7 and 8 [#rocky-almalinux]_
 - SLES 12 and 15
 - Ubuntu LTS 18.04 and 20.04
 - Windows Server 2016 and 2019
@@ -126,7 +126,7 @@ systems are recommended for production use on ``x86_64`` architecture:
    `select Intel and AMD processors
    <https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#CPUs_with_AVX>`__.
 
-.. [#rocky-alma]
+.. [#rocky-almalinux]
 
    MongoDB on-premises products released for RHEL version 8.0+ are 
    compatible with and supported on Rocky Linux version 8.0+ and 

--- a/source/includes/fact-platform-support-enterprise-red-hat.rst
+++ b/source/includes/fact-platform-support-enterprise-red-hat.rst
@@ -12,7 +12,7 @@
 
 MongoDB {+version+} Enterprise Edition supports the following
 :red:`64-bit` versions of Red Hat Enterprise Linux (RHEL), CentOS Linux,
-Oracle Linux [#oracle-linux]_, Rocky Linux, and AlmaLinux [#rocky-alma]_ 
+Oracle Linux [#oracle-linux]_, Rocky Linux, and AlmaLinux [#rocky-almalinux]_ 
 on :ref:`x86_64 <prod-notes-supported-platforms-x86_64>` architecture:
 
 - :abbr:`RHEL (Red Hat Enterprise Linux)` / CentOS / Oracle / Rocky / Alma 8
@@ -35,7 +35,7 @@ See :ref:`prod-notes-supported-platforms` for more information.
    Kernel (RHCK). MongoDB does **not** support the Unbreakable
    Enterprise Kernel (UEK).
 
-.. [#rocky-alma]
+.. [#rocky-almalinux]
 
    MongoDB on-premises products released for RHEL version 8.0+ are 
    compatible with and supported on Rocky Linux version 8.0+ and 

--- a/source/includes/fact-platform-support-red-hat.rst
+++ b/source/includes/fact-platform-support-red-hat.rst
@@ -11,10 +11,10 @@
 MongoDB {+version+} Community Edition supports the following
 :red:`64-bit` versions of Red Hat Enterprise Linux (RHEL), CentOS Linux,
 Oracle Linux [#oracle-linux]_, Rocky Linux, and AlmaLinux 
-[#rocky-alma-note]_
+[#rocky-almalinux-note]_
 on :ref:`x86_64 <prod-notes-supported-platforms-x86_64>` architecture:
 
-- :abbr:`RHEL (Red Hat Enterprise Linux)` / CentOS / Oracle / Rocky / Alma 8
+- :abbr:`RHEL (Red Hat Enterprise Linux)` / CentOS / Oracle / Rocky / AlmaLinux 8
 
 - :abbr:`RHEL (Red Hat Enterprise Linux)` / CentOS / Oracle 7
 
@@ -23,7 +23,7 @@ on :ref:`x86_64 <prod-notes-supported-platforms-x86_64>` architecture:
 MongoDB only supports the 64-bit versions of these platforms.
 
 MongoDB {+version+} Community Edition on
-:abbr:`RHEL (Red Hat Enterprise Linux)` / CentOS / Oracle / Rocky / Alma  
+:abbr:`RHEL (Red Hat Enterprise Linux)` / CentOS / Oracle / Rocky / AlmaLinux  
 also supports the :ref:`ARM64 <prod-notes-supported-platforms-ARM64>` architecture on
 select platforms.
 
@@ -35,7 +35,7 @@ See :ref:`prod-notes-supported-platforms` for more information.
    Kernel (RHCK). MongoDB does **not** support the Unbreakable
    Enterprise Kernel (UEK).
 
-.. [#rocky-alma-note]
+.. [#rocky-almalinux-note]
 
    MongoDB on-premises products released for RHEL version 8.0+ are 
    compatible with and supported on Rocky Linux version 8.0+ and 

--- a/source/installation.txt
+++ b/source/installation.txt
@@ -109,7 +109,7 @@ Supported Platforms
    Kernel (RHCK). MongoDB does **not** support the Unbreakable
    Enterprise Kernel (UEK).
 
-.. [#RockyAlma-support-install]
+.. [#RockyAlmaLinux-support-install]
 
    MongoDB on-premises products released for RHEL version 8.0+ are 
    compatible with and supported on Rocky Linux version 8.0+ and 


### PR DESCRIPTION
Switching the references to AlmaLinux from 'alma' to 'almalinux' for accuracy and branding consistency.

Signed-off-by: benny Vasquez <benny@almalinux.org>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?
