### PR TITLE
corrected a spelling

### DIFF
--- a/source/reference/operator/aggregation/sort.txt
+++ b/source/reference/operator/aggregation/sort.txt
@@ -222,7 +222,7 @@ able to write temporary files to disk if additional space is required.
 ----------------------------------
 
 The :pipeline:`$sort` operator can take advantage of an index if it's
-used in the first stage of a pipeline or if it's only preceeded by a
+used in the first stage of a pipeline or if it's only preceded by a
 :pipeline:`$match` stage.
 
 When you use the :pipeline:`$sort` on a sharded cluster, each shard


### PR DESCRIPTION
Corrected the spelling from "preceeded" to "preceded".