### PR TITLE
Update ulimit.txt

### DIFF
--- a/source/reference/ulimit.txt
+++ b/source/reference/ulimit.txt
@@ -343,9 +343,9 @@ object for a process or processes with a given name:
    return-limits(){
 
         for process in $@; do
-             process_pids=`ps -C $process -o pid --no-headers | cut -d " " -f 2`
+             process_pids=`ps -C $process -o pid --no-headers | grep -oP "[[:digit:]]*"`
 
-             if [ -z $@ ]; then
+             if [ -z $process_pids ]; then
                 echo "[no $process running]"
              else
                 for pid in $process_pids; do


### PR DESCRIPTION
## STAGING

### Fix `process_pids` empty

Command `ps -C $process -o pid --no-headers` output prefix has 4 spaces on ubuntu 20.04 (older version had only 1 spaces), so the argument `process_pids` will empty in shell script.

Modify `cut -d " " -f 2` to `grep -oP "[[:digit:]]*"`, can solve this problem, and makes both versions compatible.

### Fix operator expected

If using multiple arguments, will cause problem and shows following error message: 

```
$ return-limits mongod mongos
-bash: [: mongod: binary operator expected
-bash: [: mongod: binary operator expected
```
The argument `$@` should be changed to `process_pids` In the `if` conditional expressions, which can solve the problem and be more actual.

## JIRA


## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
