### PR TITLE
Clarify type of operators removed

### DIFF
--- a/source/release-notes/6.0-compatibility.txt
+++ b/source/release-notes/6.0-compatibility.txt
@@ -109,7 +109,7 @@ Regular Expressions
 Removed Operators
 -----------------
 
-Starting in MongoDB 5.1, these operators are removed:
+Starting in MongoDB 5.1, these legacy query operators are removed:
 
 .. list-table::
    :header-rows: 1


### PR DESCRIPTION
Without context people are confused into thinking we removed regular $min/$max aggregation operators due to same naming.

## STAGING


## JIRA


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
