### PR TITLE
Clarify limitation for encrypted storage sync

### DIFF
--- a/source/core/replica-set-sync.txt
+++ b/source/core/replica-set-sync.txt
@@ -116,8 +116,8 @@ Limitations
 
 - You can only run an initial sync from one given member at a time. 
 
-- You cannot use file copy based initial sync with encrypted storage
-  engine to re-key the data.
+- When using encrypted storage engine, the destination will be encrypted with
+  the same key as the source.
 
 .. _init-sync-retry:
 


### PR DESCRIPTION
As currently phrased it leads people to think that you cannot use file copy sync with encrypted storage engine.
(feel free to tweak my rewording if not consistent with our terminology)

## STAGING


## JIRA


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
