### PR TITLE
DOCS-15292 fixed a typo

### DIFF
--- a/source/reference/command/setIndexCommitQuorum.txt
+++ b/source/reference/command/setIndexCommitQuorum.txt
@@ -78,7 +78,7 @@ The command takes the following fields:
        marks the ``indexes`` as ready.
        
        Starting in MongoDB v5.0, it's possible to resume some
-       :ref:`interupted index builds<index-operations-build-failure>`
+       :ref:`interrupted index builds<index-operations-build-failure>`
        when the commit quorum is set to ``"votingMembers"``. 
        
        Replica set nodes in a commit quorum must have :rsconf:`members[n].buildIndexes` 


### PR DESCRIPTION
## STAGING
https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/DOCS-15292-onboarding-typo-fix/reference/command/setIndexCommitQuorum/

## JIRA
https://jira.mongodb.org/browse/DOCS-15292

## Self-Review Checklist

- [] Is this free of any warnings or errors in the RST?
  There are warnings/errors in the worker output at https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=6310b431392ddab27020026c but not sure which are relevant to the change, please advise.
- [Y] Is this free of spelling errors?
- [Y] Is this free of grammatical errors?
- [Y] Is this free of staging / rendering issues?
- [Y] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
