### PR TITLE
TlsInsecure effective only when tls=true

### DIFF
--- a/source/reference/connection-string.txt
+++ b/source/reference/connection-string.txt
@@ -553,8 +553,8 @@ Alternatively, you can also use the equivalent :urioption:`ssl=true
 
      - Disables various certificate validations. 
      
-       Set to ``true`` to disable certificate validations. The exact
-       validatations disabled vary by drivers. Refer to the
+       Set `tlsInsecure` and `tls` to ``true`` to disable certificate validations. The exact
+       validations disabled vary by drivers. Refer to the
        :driver:`Drivers </>` documentation.
 
        .. include:: /includes/fact-uri-option-availability.rst


### PR DESCRIPTION
TlsInsecure is not considered when tls is not set to true. Maybe more connection string options are also effected.