### PR TITLE
Add missing commas in log-messages.txt JSON example

### DIFF
--- a/source/reference/log-messages.txt
+++ b/source/reference/log-messages.txt
@@ -105,9 +105,9 @@ specification, and has the following layout and field order:
      "id": <Integer>, // unique identifier
      "ctx": <String>, // context
      "msg": <String>, // message body
-     "attr": <Object> // additional attributes (optional)
-     "tags": <Array of strings> // tags (optional)
-     "truncated": <Object> // truncation info (if truncated)
+     "attr": <Object>, // additional attributes (optional)
+     "tags": <Array of strings>, // tags (optional)
+     "truncated": <Object>, // truncation info (if truncated)
      "size": <Integer> // original size of entry (if truncated)
    }
 


### PR DESCRIPTION
Syntax highlighting is broken without them.

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
