### PR TITLE
Separate documents using comma while inserting many ones

### DIFF
--- a/source/core/views/specify-collation.txt
+++ b/source/core/views/specify-collation.txt
@@ -19,8 +19,8 @@ Create a ``places`` collection with the following documents:
 .. code-block:: javascript
 
    db.places.insertMany([
-      { _id: 1, category: "café" }
-      { _id: 2, category: "cafe" }
+      { _id: 1, category: "café" },
+      { _id: 2, category: "cafe" },
       { _id: 3, category: "cafE" }
    ])
 


### PR DESCRIPTION
This PR is intended to add commas to `db.collectionName.insertMany([{<key>:<value>}, {<key>:<value>}])` operation to current MongoDB documentation.

When we want to insert many documents to any collection(s), it is required to add comma(s) in order to separate those documents. 
So, current documentation is missing to show the comma(s) on example.
Quick reading : [Create a View with Default Collation](https://www.mongodb.com/docs/manual/core/views/specify-collation/)