### PR TITLE
Add instructions for installing gpg key without use of apt-key as it has been deprecated

### DIFF
--- a/source/includes/steps-install-mongodb-on-ubuntu.yaml
+++ b/source/includes/steps-install-mongodb-on-ubuntu.yaml
@@ -27,8 +27,15 @@ content: |
 
           wget -qO - https://www.mongodb.org/static/pgp/server-{+pgp-version+}.asc | sudo apt-key add -
 
-       
-   
+    Lastly, apt-key is being deprecated. If you receive an error
+    indicating ``Warning: apt-key is deprecated. Manage keyring files
+    in trusted.gpg.d instead (see apt-key(8)).``, you can:
+
+    #. Use ``wget`` and ``tee`` to install the GPG Key directly.
+
+       .. code-block:: bash
+
+          wget -O - https://www.mongodb.org/static/pgp/server-6.0.asc | sudo tee /etc/apt/trusted.gpg.d/server-6.0.asc
 
 ---
 title: Create a list file for MongoDB.


### PR DESCRIPTION
Small fix for newer deb-based distros