### PR TITLE
fix: replace broken collation comparison level link

### DIFF
--- a/source/reference/collation.txt
+++ b/source/reference/collation.txt
@@ -69,7 +69,7 @@ parameters and the locales they are associated with, see
 
      - Optional. The level of comparison to perform.
        Corresponds to `ICU Comparison Levels
-       <http://userguide.icu-project.org/collation/concepts#TOC-Comparison-Levels>`_.
+       <https://unicode-org.github.io/icu/userguide/collation/concepts.html#comparison-levels>`_.
        Possible values are:
        
        .. list-table::
@@ -118,7 +118,7 @@ parameters and the locales they are associated with, see
               breaker.
        
        See `ICU Collation: Comparison Levels
-       <http://userguide.icu-project.org/collation/concepts#TOC-Comparison-Levels>`_
+       <https://unicode-org.github.io/icu/userguide/collation/concepts.html#comparison-levels>`_
        for details.
        
        
@@ -222,7 +222,7 @@ parameters and the locales they are associated with, see
               and are only distinguished at strength levels greater than 3.
        
        See `ICU Collation: Comparison Levels
-       <http://userguide.icu-project.org/collation/concepts#TOC-Comparison-Levels>`_
+       <https://unicode-org.github.io/icu/userguide/collation/concepts.html#comparison-levels>`_
        for more information.
        
        Default is ``"non-ignorable"``.

--- a/source/reference/method/Bulk.find.collation.txt
+++ b/source/reference/method/Bulk.find.collation.txt
@@ -53,7 +53,7 @@ Description
    
         - Optional. The level of comparison to perform.
           Corresponds to `ICU Comparison Levels
-          <http://userguide.icu-project.org/collation/concepts#TOC-Comparison-Levels>`_.
+          <https://unicode-org.github.io/icu/userguide/collation/concepts.html#comparison-levels>`_.
           Possible values are:
           
           .. list-table::
@@ -102,7 +102,7 @@ Description
                  breaker.
           
           See `ICU Collation: Comparison Levels
-          <http://userguide.icu-project.org/collation/concepts#TOC-Comparison-Levels>`_
+          <https://unicode-org.github.io/icu/userguide/collation/concepts.html#comparison-levels>`_
           for details.
           
           
@@ -203,7 +203,7 @@ Description
                  and are only distinguished at strength levels greater than 3.
           
           See `ICU Collation: Comparison Levels
-          <http://userguide.icu-project.org/collation/concepts#TOC-Comparison-Levels>`_
+          <https://unicode-org.github.io/icu/userguide/collation/concepts.html#comparison-levels>`_
           for more information.
           
           Default is ``"non-ignorable"``.

--- a/source/reference/method/cursor.collation.txt
+++ b/source/reference/method/cursor.collation.txt
@@ -58,7 +58,7 @@ Definition
    
         - Optional. The level of comparison to perform.
           Corresponds to `ICU Comparison Levels
-          <http://userguide.icu-project.org/collation/concepts#TOC-Comparison-Levels>`_.
+          <https://unicode-org.github.io/icu/userguide/collation/concepts.html#comparison-levels>`_.
           Possible values are:
           
           .. list-table::
@@ -107,7 +107,7 @@ Definition
                  breaker.
           
           See `ICU Collation: Comparison Levels
-          <http://userguide.icu-project.org/collation/concepts#TOC-Comparison-Levels>`_
+          <https://unicode-org.github.io/icu/userguide/collation/concepts.html#comparison-levels>`_
           for details.
           
           
@@ -208,7 +208,7 @@ Definition
                  and are only distinguished at strength levels greater than 3.
           
           See `ICU Collation: Comparison Levels
-          <http://userguide.icu-project.org/collation/concepts#TOC-Comparison-Levels>`_
+          <https://unicode-org.github.io/icu/userguide/collation/concepts.html#comparison-levels>`_
           for more information.
           
           Default is ``"non-ignorable"``.


### PR DESCRIPTION
## DESCRIPTION
Update "ICU Comparison Levels" hyperlink to the correct, non-broken link


## STAGING
N/A I assume as not a MongoDB employee?

## JIRA
N/A I assume as not a MongoDB employee?

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
