### PR TITLE
Fix Typo in multiple files in mongodb

### DIFF
--- a/source/core/sharding-reshard-a-collection.txt
+++ b/source/core/sharding-reshard-a-collection.txt
@@ -43,7 +43,7 @@ requirements:
   <shard-key-refine>` instead.
 - Your database meets these resource requirements:
 
-  -  Available storage space: Ensure that your cluster has sufficient availible
+  -  Available storage space: Ensure that your cluster has sufficient available
      disk space for resharding. If documents in the resharded collection are equally 
      distributed across the cluster, each shard requires disk space of 
      approximately 1.2 times the collection size on disk divided by the number of shards. 

--- a/source/includes/changelogs/releases/3.0.12.rst
+++ b/source/includes/changelogs/releases/3.0.12.rst
@@ -23,7 +23,7 @@ WiredTiger
 ``````````
 
 - :issue:`SERVER-22831` Low query rate with heavy cache pressure and an idle collection
-- :issue:`SERVER-22964` IX GlobalLock being held while wating for wt cache eviction
+- :issue:`SERVER-22964` IX GlobalLock being held while waiting for wt cache eviction
 - :issue:`SERVER-23457` WiredTiger changes for MongoDB 3.0.12
 
 Build and Packaging

--- a/source/includes/changelogs/releases/3.2.12.rst
+++ b/source/includes/changelogs/releases/3.2.12.rst
@@ -93,7 +93,7 @@ Build and Packaging
 - :issue:`SERVER-17368` Create windows SSL zip file with OpenSSL files
 - :issue:`SERVER-24245` Migrate sanitizer builds to Ubuntu 16.04 images
 - :issue:`SERVER-27063` Missing 'main/binary-i386/Packages' in Release file
-- :issue:`SERVER-27151` Hash sum mismach on Ubuntu 14.04 of 3.2.x community version
+- :issue:`SERVER-27151` Hash sum mismatch on Ubuntu 14.04 of 3.2.x community version
 
 Internals
 ~~~~~~~~~

--- a/source/includes/changelogs/releases/3.2.13.rst
+++ b/source/includes/changelogs/releases/3.2.13.rst
@@ -25,7 +25,7 @@ Replication
 - :issue:`SERVER-24811` replSetFreeze command can result in a crash if used during a dry-run election
 - :issue:`SERVER-25210` Deadlock in Master/Slave Startup on Windows 2008 R2
 - :issue:`SERVER-25519` repl::checkForCappedOplog will segfault if the local database doesn't exist
-- :issue:`SERVER-25714` Don't wait for db work in executor when upgrading protocol verison
+- :issue:`SERVER-25714` Don't wait for db work in executor when upgrading protocol version
 - :issue:`SERVER-25977` Increase default assert.soon timeout to 5 minutes
 - :issue:`SERVER-25995` raise timeout for priority takeover in replsets_priority1.js
 - :issue:`SERVER-26076` Increase default ReplSetTest awaitReplication() timeout to 5 minutes

--- a/source/includes/changelogs/releases/3.2.5.rst
+++ b/source/includes/changelogs/releases/3.2.5.rst
@@ -69,7 +69,7 @@ WiredTiger
 - :issue:`SERVER-22117` WiredTiger journal files not deleted/ Way too many journal files
 - :issue:`SERVER-22791` Invariant failure when creating WT collection with crafted configString
 - :issue:`SERVER-22831` Low query rate with heavy cache pressure and an idle collection
-- :issue:`SERVER-22964` IX GlobalLock being held while wating for wt cache eviction
+- :issue:`SERVER-22964` IX GlobalLock being held while waiting for wt cache eviction
 
 Operations
 ~~~~~~~~~~

--- a/source/includes/changelogs/releases/4.2.2.rst
+++ b/source/includes/changelogs/releases/4.2.2.rst
@@ -33,7 +33,7 @@ Replication
 - :issue:`SERVER-41513` Track the time the new term oplog entry was written by the primary and applied by secondary in replSetStatus on all nodes
 - :issue:`SERVER-42025` Prevent Oldest timestamp from advancing in prepare_transaction_read_at_cluster_time.js.
 - :issue:`SERVER-42366` When EMRC=false we may set the stable timestamp ahead during rollback after forcing it back to the common point
-- :issue:`SERVER-42925` idempotency tests have oplog visiblity issues
+- :issue:`SERVER-42925` idempotency tests have oplog visibility issues
 - :issue:`SERVER-43239` numCatchUpOps in repSetGetStatus is incorrect
 - :issue:`SERVER-43703` Race when disabling rsSyncApplyStop failpoint and stopping server
 - :issue:`SERVER-43729` replSetFreeze done part of RollbackTest.transitionToSyncSourceOperationsDuringRollback Should be resilient of errors.

--- a/source/includes/changelogs/releases/4.4.5.rst
+++ b/source/includes/changelogs/releases/4.4.5.rst
@@ -195,7 +195,7 @@ Internals
 - :issue:`WT-7224` Moved test_config.c to src/config 
 - :issue:`WT-7225` Restructure verify key function for the history store
 - :issue:`WT-7235` Enhance tiered API for object naming
-- :issue:`WT-7237` Creating component interface to improve class heirachy in the test framework
+- :issue:`WT-7237` Creating component interface to improve class hierachy in the test framework
 - :issue:`WT-7238` Use of constructor initialization list to avoid seg fault
 - :issue:`WT-7239` Embed compile step into macOS unit-test
 - :issue:`WT-7242` Fix example to correctly use API for system and no encryption

--- a/source/includes/changelogs/releases/5.3.0.rst
+++ b/source/includes/changelogs/releases/5.3.0.rst
@@ -241,7 +241,7 @@ Internals
 - :issue:`SERVER-60939` Fix disabled Query Opt tests failing due to changing latest release to 5.2
 - :issue:`SERVER-60944` Change interface for updateWithSuppliedFacet and update
 - :issue:`SERVER-60959` Insert to a Time-Series getting error collection ErrorCodes::TimeseriesBucketCleared
-- :issue:`SERVER-60974` Multiversion suites are overwritting receiveChunkWaitForRangeDeleterTimeoutMS
+- :issue:`SERVER-60974` Multiversion suites are overwrtting receiveChunkWaitForRangeDeleterTimeoutMS
 - :issue:`SERVER-61000` Coverity analysis defect 121043: Uninitialized pointer field
 - :issue:`SERVER-61005` rs.initiate() fails with "Invariant failure" under specific startup options
 - :issue:`SERVER-61009` Make createIndex a no-op on a cluster key if the collection exists
@@ -357,7 +357,7 @@ Internals
 - :issue:`SERVER-61939` Explore bounding clustered collection scans more tightly
 - :issue:`SERVER-61941` $sortArray comparator does not satisfy "Compare" requirement with -1 sort
 - :issue:`SERVER-61946` Remove requires_fcv_51 tag from internal sessions multiversion tests
-- :issue:`SERVER-61947` health check interval should be propery of the health observer
+- :issue:`SERVER-61947` health check interval should be properly of the health observer
 - :issue:`SERVER-61954` Improve decoding performance for BSONColumn
 - :issue:`SERVER-61955` Expose dbCheck as a generally available command
 - :issue:`SERVER-61956` fix data race when accessing the state machine's state

--- a/source/includes/changelogs/releases/6.0.4.rst
+++ b/source/includes/changelogs/releases/6.0.4.rst
@@ -137,7 +137,7 @@ Internals
 - :issue:`SERVER-71399` Jumbo chunk flag isn't automatically cleared
   after a chunk split
 - :issue:`SERVER-71424` Fix failures in lint_fuzzer_sanity
-- :issue:`SERVER-71435` Increse verbosity level for range-deleter in
+- :issue:`SERVER-71435` Increase verbosity level for range-deleter in
   resmoke
 - :issue:`SERVER-71436` Range deleter must not aggressively spam the log
   when shard key index not found

--- a/source/includes/changelogs/releases/6.0.7.rst
+++ b/source/includes/changelogs/releases/6.0.7.rst
@@ -96,7 +96,7 @@ Internals
 - :issue:`SERVER-74551` WriteConflictException unnecessarily logged as
   warning during findAndModify after upgrade to mongo 5.0
 - :issue:`SERVER-74645` integration_tests_standalone[_audit] should not
-  run a unqiue build
+  run a unique build
 - :issue:`SERVER-74716` Prevent "back-in-time" change stream resume
   token on MongoS
 - :issue:`SERVER-74806` Write size estimation logic does not account for

--- a/source/includes/extracts-wired-tiger.yaml
+++ b/source/includes/extracts-wired-tiger.yaml
@@ -244,7 +244,7 @@ content: |
 ref: wt-log-compression-limit
 content: |
 
-   If a log record less than or equal to 128 bytes (the mininum
+   If a log record less than or equal to 128 bytes (the minimum
    :ref:`log record size for WiredTiger <wt-jouraling-record>`),
    WiredTiger does not compress that record.
 ...

--- a/source/includes/fact-agg-memory-limit.rst
+++ b/source/includes/fact-agg-memory-limit.rst
@@ -35,7 +35,7 @@ Examples of stages that can write temporary files to disk when
 .. note::
 
    Pipeline stages operate on streams of documents with each pipeline
-   stage taking in documents, processing them, and then outputing the
+   stage taking in documents, processing them, and then outputting the
    resulting documents.
 
    Some stages can't output any documents until they have processed all

--- a/source/includes/fact-allowDiskUseByDefault.rst
+++ b/source/includes/fact-allowDiskUseByDefault.rst
@@ -1,6 +1,6 @@
 Starting in MongoDB 6.0, pipeline stages that require more than 100 
 megabytes of memory to execute write temporary files to disk by 
-default. In earlier verisons of MongoDB, you must pass 
+default. In earlier versions of MongoDB, you must pass 
 ``{ allowDiskUse: true }`` to individual ``find`` and ``aggregate``
 commands to enable this behavior.
 

--- a/source/includes/fact-read-concern-write-timeline.rst
+++ b/source/includes/fact-read-concern-write-timeline.rst
@@ -10,7 +10,7 @@ a three member replica set:
 
    - Write\ :sub:`prev` is the previous write before Write\ :sub:`0`.
 
-   - No other writes have occured after Write\ :sub:`0`. 
+   - No other writes have occurred after Write\ :sub:`0`. 
 
 .. figure:: /images/read-concern-write-timeline.svg
    :alt: Timeline of a write operation to a three member replica set.

--- a/source/includes/qe-tutorials/java/envrc_template
+++ b/source/includes/qe-tutorials/java/envrc_template
@@ -14,7 +14,7 @@ AWS_KEY_ARN="<Your AWS key ARN>"
 
 AZURE_TENANT_ID="<Your Azure tenant ID>"
 AZURE_CLIENT_ID="<Your Azure client ID>"
-AZURE_CLIENT_SECRET="<Your cleint secret>"
+AZURE_CLIENT_SECRET="<Your client secret>"
 AZURE_KEY_NAME="<Your key name>"
 AZURE_KEY_VERSION="<Your key version>"
 AZURE_KEY_VAULT_ENDPOINT="<Your key vault endpoint>"

--- a/source/includes/qe-tutorials/python/envrc_template
+++ b/source/includes/qe-tutorials/python/envrc_template
@@ -14,7 +14,7 @@ export AWS_KEY_ARN="<Your AWS key ARN>"
 
 export AZURE_TENANT_ID="<Your Azure tenant ID>"
 export AZURE_CLIENT_ID="<Your Azure client ID>"
-export AZURE_CLIENT_SECRET="<Your cleint secret>"
+export AZURE_CLIENT_SECRET="<Your client secret>"
 export AZURE_KEY_NAME="<Your key name>"
 export AZURE_KEY_VERSION="<Your key version>"
 export AZURE_KEY_VAULT_ENDPOINT="<Your key vault endpoint>"

--- a/source/includes/steps-deploy-replica-set-with-auth.yaml
+++ b/source/includes/steps-deploy-replica-set-with-auth.yaml
@@ -110,7 +110,7 @@ pre: |
 
 action:
   - pre: |
-      The following example initates a three member replica set.
+      The following example initiates a three member replica set.
       
       .. important::
 

--- a/source/includes/steps-modify-psa-replica-set-safely.yaml
+++ b/source/includes/steps-modify-psa-replica-set-safely.yaml
@@ -41,7 +41,7 @@ title: Reconfigure the secondary to have non-zero priority
 stepnum: 2
 ref: modify-psa-replica-set-reconfigure
 pre: |
-  Once the secondary is caught up, set the prority to the desired
+  Once the secondary is caught up, set the priority to the desired
   number. Before this reconfiguration succeeds, the secondary must
   replicate all the writes that were committed when it had zero votes.
   This is automatically checked when you issue the

--- a/source/includes/steps-upgrade-enterprise-sharded-cluster.yaml
+++ b/source/includes/steps-upgrade-enterprise-sharded-cluster.yaml
@@ -139,7 +139,7 @@ content: |-
 
    .. include:: /includes/extracts/4.2-changes-start-balancer-autosplit.rst
    
-   For more inforamtion on the balancer, see
+   For more information on the balancer, see
    :ref:`sharding-balancing-enable`.
 
 ...

--- a/source/release-notes/3.4-compatibility.txt
+++ b/source/release-notes/3.4-compatibility.txt
@@ -20,7 +20,7 @@ See also :doc:`/release-notes/3.4`.
 Sharded Cluster Changes
 -----------------------
 
-.. COMMENT to docs:  this section can be singlesourced since we refer to it in both rel notes and compatibility page (figured these changes are significant enought to place in both places)
+.. COMMENT to docs:  this section can be singlesourced since we refer to it in both rel notes and compatibility page (figured these changes are significant enough to place in both places)
 
 ``shardsvr`` Requirement
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/release-notes/3.4.txt
+++ b/source/release-notes/3.4.txt
@@ -855,7 +855,7 @@ New Aggregation Stages to Facilitate Reshaping Documents
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 3.4 introduces stages to the :ref:`aggregation pipeline
-<aggregation-pipeline>` that faciliate replacing documents as
+<aggregation-pipeline>` that facilitate replacing documents as
 well as adding new fields.
 
 .. list-table::

--- a/source/release-notes/4.0.txt
+++ b/source/release-notes/4.0.txt
@@ -750,7 +750,7 @@ Parameters
 
 - :parameter:`maxTransactionLockRequestTimeoutMillis` to specify how
   long :ref:`multi-document transactions <transactions>` should
-  wait to aquire locks required by the operations in the transaction.
+  wait to acquire locks required by the operations in the transaction.
 
 Aggregation
 -----------

--- a/source/sharding.txt
+++ b/source/sharding.txt
@@ -239,7 +239,7 @@ careful planning, execution, and maintenance.
 
 While you can :ref:`reshard your collection <sharding-resharding>`
 later, it is important to carefully consider your shard key choice to
-avoid scalability and perfomance issues.
+avoid scalability and performance issues.
 
 .. seealso::
 

--- a/source/tutorial/rotate-key-sharded-cluster.txt
+++ b/source/tutorial/rotate-key-sharded-cluster.txt
@@ -18,7 +18,7 @@ downtime, the key for a sharded cluster. [#exclude-encryption-keyfile]_
 .. warning::
 
    The example keys in this tutorial are for illustrative purposes
-   only. Do :red:`NOT` use for your deployement. Instead, generate a
+   only. Do :red:`NOT` use for your deployment. Instead, generate a
    keyfile using any method you choose (e.g. ``openssl rand -base64
    756``, etc.).
 
@@ -55,7 +55,7 @@ Modify each member's keyfile to include both the old and new keys.
 .. warning::
 
    The example keys in this tutorial are for illustrative purposes
-   only. Do :red:`NOT` use for your deployement. Instead, generate a
+   only. Do :red:`NOT` use for your deployment. Instead, generate a
    keyfile using any method you choose (e.g. ``openssl rand -base64
    756``, etc.).
 
@@ -164,7 +164,7 @@ old or new key for membership authentication.
 .. warning::
 
    The example keys in this tutorial are for illustrative purposes
-   only. Do :red:`NOT` use for your deployement. Instead, generate a
+   only. Do :red:`NOT` use for your deployment. Instead, generate a
    keyfile using any method you choose (e.g. ``openssl rand -base64
    756``, etc.).
 


### PR DESCRIPTION
## DESCRIPTION

This PR fix the multiple typo as seen in various files

```pseduo
wating > waiting
mismach > mismatch
verison > version
visiblity > visibility
heirachy > hierachy
and many more
```

## Self-Review Checklist

- [X] Is this free of any warnings or errors in the RST?
- [X] Is this free of spelling errors?
- [X] Is this free of grammatical errors?
- [X] Is this free of staging / rendering issues?
- [X] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
