### PR TITLE
MONGOCRYPT-580 Document libmongocrypt installation on Amazon Linux 2023

### DIFF
--- a/source/core/csfle/reference/libmongocrypt.txt
+++ b/source/core/csfle/reference/libmongocrypt.txt
@@ -156,6 +156,33 @@ RedHat
 
          sudo yum install -y libmongocrypt
 
+Amazon Linux 2023
+~~~~~~~~~~~~~~~~~
+
+.. procedure::
+   :style: connected
+
+   .. step::
+
+      Create a repository file for the ``libmongocrypt`` package:
+
+      .. code-block:: sh
+
+         [libmongocrypt]
+         name=libmongocrypt repository
+         baseurl=https://libmongocrypt.s3.amazonaws.com/yum/amazon/2023/libmongocrypt/{+libmongocrypt-version+}/x86_64
+         gpgcheck=1
+         enabled=1
+         gpgkey=https://www.mongodb.org/static/pgp/libmongocrypt.asc
+
+   .. step::
+
+      Install the ``libmongocrypt`` package:
+
+      .. code-block:: sh
+
+         sudo yum install -y libmongocrypt
+
 Amazon Linux 2
 ~~~~~~~~~~~~~~
 

--- a/source/core/queryable-encryption/reference/libmongocrypt.txt
+++ b/source/core/queryable-encryption/reference/libmongocrypt.txt
@@ -160,6 +160,33 @@ RedHat
 
          sudo yum install -y libmongocrypt
 
+Amazon Linux 2023
+~~~~~~~~~~~~~~~~~
+
+.. procedure::
+   :style: connected
+
+   .. step::
+
+      Create a repository file for the ``libmongocrypt`` package:
+
+      .. code-block:: sh
+
+         [libmongocrypt]
+         name=libmongocrypt repository
+         baseurl=https://libmongocrypt.s3.amazonaws.com/yum/amazon/2023/libmongocrypt/{+libmongocrypt-version+}/x86_64
+         gpgcheck=1
+         enabled=1
+         gpgkey=https://www.mongodb.org/static/pgp/libmongocrypt.asc
+
+   .. step::
+
+      Install the ``libmongocrypt`` package:
+
+      .. code-block:: sh
+
+         sudo yum install -y libmongocrypt
+
 Amazon Linux 2
 ~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This is a simple change that adds installation steps for libmongocrypt on Amazon Linux 2023. Please note that merging this PR should wait for the release of either libmongocrypt 1.9.0 or 1.8.3, as the packages are currently only going into a development PPA and will only show up in the release PPA (the one specified in the docs) after one of those releases.