### PR TITLE
Update limits.txt

### DIFF
--- a/source/reference/limits.txt
+++ b/source/reference/limits.txt
@@ -516,6 +516,8 @@ Naming Restrictions
 
    - begin with the ``system.`` prefix. (Reserved for internal use.)
 
+   - be the name of a method on db, e.g. "hello".
+
    If your collection name includes special characters, such as the
    underscore character, or begins with numbers, then to access the
    collection use the :method:`db.getCollection()` method in


### PR DESCRIPTION
See detailed statement of the issue [here](https://3willows.github.io/2024-06-10-db.hello.find/).

## DESCRIPTION

Add an additional limit to how one can name collections in MongoDB.

## STAGING


## JIRA


## BUILD LOG


## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
