### PR TITLE
DOCSP-39857 changed configureQueryAnalyzer limitations

### DIFF
--- a/source/includes/analyzeShardKey-limitations.rst
+++ b/source/includes/analyzeShardKey-limitations.rst
@@ -1,7 +1,6 @@
 - You cannot run |analyzeShardKey| on Atlas
   :ref:`shared clusters <shared-tier-cluster>` and
   :ref:`serverless instances <atlas-choose-serverless>`.
-  configurations.
 - You cannot run |analyzeShardKey| on standalone deployments.
 - You cannot run |analyzeShardKey| directly against a
   :option:`--shardsvr <mongod --shardsvr>` replica set.

--- a/source/includes/analyzeShardKey-limitations.rst
+++ b/source/includes/analyzeShardKey-limitations.rst
@@ -1,5 +1,6 @@
 - You cannot run |analyzeShardKey| on Atlas
-  :atlas:`multi-tenant </build-multi-tenant-arch>`
+  :ref:`shared clusters <shared-tier-cluster>` and
+  :ref:`serverless instances <atlas-choose-serverless>`.
   configurations.
 - You cannot run |analyzeShardKey| on standalone deployments.
 - You cannot run |analyzeShardKey| directly against a

--- a/source/includes/cqa-limitations.rst
+++ b/source/includes/cqa-limitations.rst
@@ -1,5 +1,5 @@
 - You cannot run |CQA| on Atlas :ref:`shared clusters <shared-tier-cluster>` and
-  :ref:`serverless instances <atlas-choose-serverless>`
+  :ref:`serverless instances <atlas-choose-serverless>`.
 - You cannot run |CQA| on standalone deployments.
 - You cannot run |CQA| directly 
   against a :option:`--shardsvr <mongod --shardsvr>` replica set. 

--- a/source/includes/cqa-limitations.rst
+++ b/source/includes/cqa-limitations.rst
@@ -1,4 +1,5 @@
-- You cannot run |CQA| on Atlas :ref:`shared clusters <shared-tier-cluster>` and :ref:`serverless instances <atlas-choose-serverless>`
+- You cannot run |CQA| on Atlas :ref:`shared clusters <shared-tier-cluster>` and
+  :ref:`serverless instances <atlas-choose-serverless>`
 - You cannot run |CQA| on standalone deployments.
 - You cannot run |CQA| directly 
   against a :option:`--shardsvr <mongod --shardsvr>` replica set. 

--- a/source/includes/cqa-limitations.rst
+++ b/source/includes/cqa-limitations.rst
@@ -1,4 +1,4 @@
-- You cannot run |CQA| on Atlas :ref:'shared clusters <shared-tier-cluster>' and :ref:'serverless instances <atlas-choose-serverless>'
+- You cannot run |CQA| on Atlas :ref:`shared clusters <shared-tier-cluster>` and :ref:`serverless instances <atlas-choose-serverless>`
 - You cannot run |CQA| on standalone deployments.
 - You cannot run |CQA| directly 
   against a :option:`--shardsvr <mongod --shardsvr>` replica set. 

--- a/source/includes/cqa-limitations.rst
+++ b/source/includes/cqa-limitations.rst
@@ -1,8 +1,5 @@
-- You cannot run |CQA| on Atlas 
-  :atlas:`multi-tenant </build-multi-tenant-arch>`
-  configurations.
-- You cannot run |CQA| on 
-  standalone deployments.
+- You cannot run |CQA| on Atlas :ref:'shared clusters <shared-tier-cluster>' and :ref:'serverless instances <atlas-choose-serverless>'
+- You cannot run |CQA| on standalone deployments.
 - You cannot run |CQA| directly 
   against a :option:`--shardsvr <mongod --shardsvr>` replica set. 
   When running on a sharded cluster, 
@@ -12,3 +9,4 @@
   :ref:`time series <cmd-shard-collection-timeseries>` collections.
 - You cannot run |CQA| against 
   collections with :ref:`Queryable Encryption <qe-manual-feature-qe>`.
+


### PR DESCRIPTION
## DESCRIPTION
changed multi-tenant to shared tier and serverless, also added links 

## STAGING
https://preview-mongodbsonderdonkmdb.gatsbyjs.io/docs/DOCSP-39857/reference/command/configureQueryAnalyzer/

https://preview-mongodbsonderdonkmdb.gatsbyjs.io/docs/DOCSP-39857/reference/command/analyzeShardKey/ 

## JIRA
https://jira.mongodb.org/browse/DOCSP-39857

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=666c5c47ebce19f314e1cba0

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
