### PR TITLE
Fix `maximum page size at eviction` to `maximum page size seen at eviction`

### DIFF
--- a/source/reference/command/serverStatus.txt
+++ b/source/reference/command/serverStatus.txt
@@ -6590,7 +6590,7 @@ wiredTiger
          internal pages split during eviction : <num>,
          leaf pages split during eviction : <num>,
          maximum bytes configured : <num>,
-         maximum page size at eviction : <num>,
+         maximum page size seen at eviction : <num>,
          modified pages evicted : <num>,
          modified pages evicted by application threads : <num>,
          operations timed out waiting for space in cache : <num>,


### PR DESCRIPTION
In this commit https://github.com/mongodb/mongo/commit/838d3648a66bc46f10e6fcad9d0294df5331d090 the wording of this property on `wiredtiger.cache` changed. This PR adds the `seen` to the docs as it is the current wording:

```js
test> db.version()
7.0.14
test> db.runCommand( { serverStatus: 1 } ).wiredTiger.cache['maximum page size at eviction']

test> db.runCommand( { serverStatus: 1 } ).wiredTiger.cache['maximum page size seen at eviction']
0
```

