### PR TITLE
DOCS - pass default_language as an option to the createIndex method

### DIFF
--- a/source/core/indexes/index-types/index-text/specify-language-text-index/create-text-index-multiple-languages.txt
+++ b/source/core/indexes/index-types/index-text/specify-language-text-index/create-text-index-multiple-languages.txt
@@ -93,7 +93,7 @@ The following operation creates a text index on the ``original`` and
 
 .. code-block:: javascript
 
-   db.quotes.createIndex({ original: "text", "translation.quote": "text", "default_language" : "fr" })
+   db.quotes.createIndex({ original: "text", "translation.quote": "text"}, {"default_language" : "fr" })
 
 .. note::
 


### PR DESCRIPTION
## DESCRIPTION

The `default_language` option should be specified as an option to the `createIndex` method, not as part of the index specification. This PR add correction to procedure command `db.quotes.createIndex()`. 

## RESOURCE
[change default language mongodb docs](https://www.mongodb.com/docs/manual/core/indexes/index-types/index-text/specify-text-index-language/)

## SELF-REVIEW CHECKLIST
 
- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

