### PR TITLE
DOCSP-47081-modify-outdated-reference-to-wiredtiger-parameters

### DIFF
--- a/source/includes/dynamic-concurrent-transactions.rst
+++ b/source/includes/dynamic-concurrent-transactions.rst
@@ -1,0 +1,5 @@
+
+   .. note::
+
+      MongoDB dynamically adjusts the number of tickets to optimize 
+      performance, with a highest possible value of 128.

--- a/source/includes/dynamic-concurrent-transactions.rst
+++ b/source/includes/dynamic-concurrent-transactions.rst
@@ -1,4 +1,3 @@
-
    .. note::
 
       MongoDB dynamically adjusts the number of tickets to optimize 

--- a/source/reference/parameters.txt
+++ b/source/reference/parameters.txt
@@ -5496,63 +5496,45 @@ WiredTiger Parameters
 
 .. parameter:: wiredTigerConcurrentReadTransactions
 
-   .. versionchanged:: 7.0
-
    |mongod-only|
 
    *Type*: integer 
     
    *Default*: 128
 
+   Specify the maximum number of concurrent read transactions (read tickets)
+   allowed into the storage engine.
+
    Starting in MongoDB 7.0, this parameter is available for all storage 
    engines. In earlier versions, this parameter is available for the 
    WiredTiger storage engine only.
 
-   Specify the maximum number of concurrent read transactions (read tickets)
-   allowed into the storage engine.
-   
-   .. note::
-
-      MongoDB dynamically adjusts the number of tickets to optimize 
-      performance, with a highest possible value of 128.
+   .. include::  /includes/dynamic-concurrent-transactions
 
    .. versionchanged:: 6.0
       
       The ``wiredTigerConcurrentReadTransactions`` parameter was renamed to 
-      ``storageEngineConcurrentReadTransactions``.
-
-   .. seealso::
-
-      :parameter:`storageEngineConcurrentReadTransactions`
+      :parameter:`storageEngineConcurrentReadTransactions`.
 
 .. parameter:: wiredTigerConcurrentWriteTransactions
-
-   .. versionchanged:: 7.0
 
    |mongod-only|
 
    *Type*: integer 
 
+   Specify the maximum number of concurrent write transactions allowed
+   into the WiredTiger storage engine.
+
    Starting in MongoDB 7.0, this parameter is available for all storage 
    engines. In earlier versions, this parameter is available for the 
    WiredTiger storage engine only.
 
-   Specify the maximum number of concurrent write transactions allowed
-   into the WiredTiger storage engine.
-
-   .. note::
-
-      MongoDB dynamically adjusts the number of tickets to optimize 
-      performance, with a highest possible value of 128.
+   .. include::  /includes/dynamic-concurrent-transactions
 
    .. versionchanged:: 6.0
       
       The ``wiredTigerConcurrentWriteTransactions`` parameter was renamed to 
-      ``storageEngineConcurrentWriteTransactions``.
-
-   .. seealso::
-
-      :parameter:`storageEngineConcurrentWriteTransactions`
+      :parameter:`storageEngineConcurrentWriteTransactions`.
 
 .. parameter:: wiredTigerEngineRuntimeConfig
 

--- a/source/reference/parameters.txt
+++ b/source/reference/parameters.txt
@@ -5510,20 +5510,20 @@ WiredTiger Parameters
 
    Specify the maximum number of concurrent read transactions (read tickets)
    allowed into the storage engine.
+   
+   .. note::
 
-   .. |wtparam| replace:: ``wiredTigerConcurrentReadTransactions``
+      MongoDB dynamically adjusts the number of tickets to optimize 
+      performance, with a highest possible value of 128.
 
-   .. include:: /includes/fact-concurrent-read-write-dynamic-behavior.rst
-
-   .. include:: /includes/fact-runtime-startup-parameter
-
-   .. code-block:: javascript
-
-      db.adminCommand( { setParameter: 1, wiredTigerConcurrentReadTransactions: <int> } )
+   .. versionchanged:: 6.0
+      
+      The ``wiredTigerConcurrentReadTransactions`` parameter was renamed to 
+      ``storageEngineConcurrentReadTransactions``.
 
    .. seealso::
 
-      :serverstatus:`queues.execution`
+      :parameter:`storageEngineConcurrentReadTransactions`
 
 .. parameter:: wiredTigerConcurrentWriteTransactions
 
@@ -5540,25 +5540,19 @@ WiredTiger Parameters
    Specify the maximum number of concurrent write transactions allowed
    into the WiredTiger storage engine.
 
-   By default, MongoDB sets ``wiredTigerConcurrentWriteTransactions`` to 
-   whichever value is higher: 
-   
-   - Number of cores on the machine running MongoDB
-   - 4
+   .. note::
 
-   .. |wtparam| replace:: ``wiredTigerConcurrentWriteTransactions``
+      MongoDB dynamically adjusts the number of tickets to optimize 
+      performance, with a highest possible value of 128.
 
-   .. include:: /includes/fact-concurrent-read-write-dynamic-behavior.rst
-
-   .. include:: /includes/fact-runtime-startup-parameter
-
-   .. code-block:: javascript
-
-      db.adminCommand( { setParameter: 1, wiredTigerConcurrentWriteTransactions: <int> } )
+   .. versionchanged:: 6.0
+      
+      The ``wiredTigerConcurrentWriteTransactions`` parameter was renamed to 
+      ``storageEngineConcurrentWriteTransactions``.
 
    .. seealso::
 
-      :serverstatus:`queues.execution`
+      :parameter:`storageEngineConcurrentWriteTransactions`
 
 .. parameter:: wiredTigerEngineRuntimeConfig
 

--- a/source/reference/parameters.txt
+++ b/source/reference/parameters.txt
@@ -5325,12 +5325,12 @@ Storage Parameters
     
    *Default*: 128
 
+   Specify the maximum number of concurrent read transactions (read tickets)
+   allowed into the storage engine.
+
    Starting in MongoDB 7.0, this parameter is available for all storage 
    engines. In earlier versions, this parameter is available for the 
    WiredTiger storage engine only.
-
-   Specify the maximum number of concurrent read transactions (read tickets)
-   allowed into the storage engine.
 
    .. |wtparam| replace:: ``storageEngineConcurrentReadTransactions``
 
@@ -5359,12 +5359,12 @@ Storage Parameters
 
    *Type*: integer 
 
+   Specify the maximum number of concurrent write transactions allowed
+   into the WiredTiger storage engine.
+
    Starting in MongoDB 7.0, this parameter is available for all storage 
    engines. In earlier versions, this parameter is available for the 
    WiredTiger storage engine only.
-
-   Specify the maximum number of concurrent write transactions allowed
-   into the WiredTiger storage engine.
 
    By default, MongoDB sets ``storageEngineConcurrentWriteTransactions`` to 
    whichever value is higher: 


### PR DESCRIPTION
## DESCRIPTION

Updates description of [WiredTiger](https://www.mongodb.com/docs/manual/reference/parameters/#wiredtiger-parameters) parameters `wiredTigerConcurrentWriteTransactions` and `wiredTigerConcurrentReadTransactions` to reflect change made in version 6 (said parameters were renamed to `storageEngineConcurrentWriteTransactions` and `storageEngineConcurrentReadTransactions` respectively.

It also modifies the description to state the current behavior (MongoDB dynamically adjusts number of transactions and removes outdated examples where users could modify the number of transactions.

## STAGING

- https://deploy-preview-6289--mongodb-docs.netlify.app/reference/parameters/#mongodb-parameter-param.wiredTigerConcurrentReadTransactions
- https://deploy-preview-6289--mongodb-docs.netlify.app/reference/parameters/#mongodb-parameter-param.wiredTigerConcurrentWriteTransactions

## JIRA

Jira ticket: https://jira.mongodb.org/browse/DOCSP-47081

## SELF-REVIEW CHECKLIST

- [X] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [X] Is this free of any warnings or errors in the RST?
- [X] Is this free of spelling errors?
- [X] Is this free of grammatical errors?
- [X] Is this free of staging / rendering issues?
- [X] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)

