### PR TITLE
DOCSP-47296-fix-typo-in-rolling-index-replica-set

### DIFF
--- a/source/includes/rolling-index-build-cases.rst
+++ b/source/includes/rolling-index-build-cases.rst
@@ -3,7 +3,7 @@ deployment matches one of the following cases:
 
 - If your average CPU utilization exceeds (N-1)/N-10% where where N is
   the number of CPU threads available to mongod
-- If your WiredTiger cache fill ratio regularly exceeds 90&
+- If your WiredTiger cache fill ratio regularly exceeds 90%
 
 .. note::
 


### PR DESCRIPTION
## DESCRIPTION

Fixes typo in "Rolling Index Build Cases":

https://www.mongodb.com/docs/manual/tutorial/build-indexes-on-replica-sets/#about-this-task

On the rolling index build [page](https://www.mongodb.com/docs/manual/tutorial/build-indexes-on-replica-sets/#about-this-task) for replica sets, in the second bullet of the recommendation, **where reads:
"If your WiredTiger cache fill ratio regularly exceeds 90&" should read: "If your WiredTiger cache fill ratio regularly exceeds 90%"**

## STAGING

Link to staging: https://deploy-preview-6290--mongodb-docs.netlify.app/tutorial/build-indexes-on-replica-sets/

## JIRA

https://jira.mongodb.org/browse/DOCSP-47296

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
