### PR TITLE
Fix: Update ClientEncryption import from mongodb

### DIFF
--- a/source/includes/generated/in-use-encryption/queryable-encryption/node/local/reader/make_data_key.js
+++ b/source/includes/generated/in-use-encryption/queryable-encryption/node/local/reader/make_data_key.js
@@ -1,5 +1,4 @@
-const { MongoClient, Binary } = require("mongodb");
-const { ClientEncryption } = require("mongodb-client-encryption");
+const { MongoClient, ClientEncryption } = require("mongodb");
 
 const keyVaultDatabase = "encryption";
 const keyVaultCollection = "__keyVault";


### PR DESCRIPTION
## DESCRIPTION
Fixes the incorrect import of ClientEncryption. Previously, ClientEncryption was imported from "mongodb-client-encryption", but it is no longer available there. This update modifies the import to use "mongodb" instead.

## STAGING
N/A

## JIRA
N/A

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
