### PR TITLE
DOCSP-43405-msg-oplogReplay-find-command

### DIFF
--- a/source/reference/command/find.txt
+++ b/source/reference/command/find.txt
@@ -75,7 +75,7 @@ The :dbcommand:`find` command has the following syntax:
    )
 
 .. note::
-  Since MongoDB 4.4, the :dbcommand:`find` command ignores the
+  Since MongoDB 4.4, the ``find`` command ignores the
   ``oplogReplay`` flag. If the ``oplogReplay`` flag is set, 
   the server accepts it for backwards compatibility, but has no effect.
   

--- a/source/reference/command/find.txt
+++ b/source/reference/command/find.txt
@@ -76,7 +76,7 @@ The :dbcommand:`find` command has the following syntax:
 
 .. note::
   Since MongoDB 4.4, the :dbcommand:`find` command ignores the
-  ``oplogReplay`` flag. However, if the ``oplogReplay`` flag is set, 
+  ``oplogReplay`` flag. If the ``oplogReplay`` flag is set, 
   the server accepts it for backwards compatibility, but has no effect.
   
 .. _find-cmd-fields:

--- a/source/reference/command/find.txt
+++ b/source/reference/command/find.txt
@@ -74,6 +74,11 @@ The :dbcommand:`find` command has the following syntax:
       }
    )
 
+.. note::
+  Since MongoDB 4.4, the :dbcommand:`find` command ignores the
+  ``oplogReplay`` flag. However, if the ``oplogReplay`` flag is set, 
+  the server accepts it for backwards compatibility, but has no effect.
+  
 .. _find-cmd-fields:
 
 Command Fields
@@ -421,7 +426,6 @@ When using :ref:`Stable API <stable-api>` V1, the following
 - ``max``
 - ``min``
 - ``noCursorTimeout``
-- ``oplogReplay``
 - ``returnKey``
 - ``showRecordId``
 - ``tailable``


### PR DESCRIPTION
## DESCRIPTION
The current docs for the find command still documents oplogReplay, but since version 4.4 it is ignored. However, the flag can still be defined for backwards compatibility, without any effect. 

- Added admonition to describe the behavior of the oplogReplay with versions 4.4 and above
- Deleted the oplogReplay option from unsupported find command fields with Stable API

## STAGING
https://deploy-preview-6295--mongodb-docs.netlify.app/reference/command/find/

## JIRA
https://jira.mongodb.org/projects/DOCSP/issues/DOCSP-43405

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?]
- Review that oplogReplay behavior description 
(https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
