### PR TITLE
DOCSP-49963-Fixed-headings-query-plan

### DIFF
--- a/source/core/query-plans.txt
+++ b/source/core/query-plans.txt
@@ -43,7 +43,7 @@ The following diagram illustrates the query planner logic:
 .. _cache-entry-state:
 
 Plan Cache Entry State
-~~~~~~~~~~~~~~~~~~~~~~
+-------------------
 
 Each plan cache query shape is associated with one of three states in 
 the cache:
@@ -128,7 +128,7 @@ changes to the plan cache.
 
 
 Query Plan and Cache Information
---------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To view the query plan information for a given query, you can use
 :method:`db.collection.explain()` or the :method:`cursor.explain()` .
@@ -141,7 +141,7 @@ To view plan cache information for a collection, you can use the
 .. _query-plans-plan-cache-flushes:
 
 Plan Cache Flushes
-------------------
+''''''''''''''''''''
 
 The query plan cache does not persist if a :binary:`~bin.mongod`
 restarts or shuts down. In addition:
@@ -165,7 +165,7 @@ Users can also:
    :ref:`query-hash-plan-cache-key`
 
 Plan Cache Debug Info Size Limit
---------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Starting in MongoDB 5.0, the
 :ref:`plan cache <query-plans-query-optimization>` will save full 
@@ -228,7 +228,7 @@ If one of the indexes were dropped, or if a new index ``{ x: 1, a: 1
 change.
 
 Availability
-~~~~~~~~~~~~
+''''''''''''''
 
 The ``planCacheShapeHash`` and ``planCacheKey`` are available in:
 

--- a/source/reference/command/find.txt
+++ b/source/reference/command/find.txt
@@ -74,6 +74,11 @@ The :dbcommand:`find` command has the following syntax:
       }
    )
 
+.. note::
+  Since MongoDB 4.4, the :dbcommand:`find` command ignores the
+  ``oplogReplay`` flag. However, if the ``oplogReplay`` flag is set, 
+  the server accepts it for backwards compatibility, but has no effect.
+  
 .. _find-cmd-fields:
 
 Command Fields
@@ -421,7 +426,6 @@ When using :ref:`Stable API <stable-api>` V1, the following
 - ``max``
 - ``min``
 - ``noCursorTimeout``
-- ``oplogReplay``
 - ``returnKey``
 - ``showRecordId``
 - ``tailable``


### PR DESCRIPTION
## DESCRIPTION
Some headings within the Query Plan doc where rendering with the incorrect hierarchy. Fixed the headings levels to render the real structure of the doc.  

## STAGING


## JIRA
https://jira.mongodb.org/browse/DOCSP-49963

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
