### PR TITLE
DOCSP-51948-add-validate-component

### DIFF
--- a/config/changelog_conf.yaml
+++ b/config/changelog_conf.yaml
@@ -57,6 +57,7 @@ groups:
   "Storage":
     - Storage
     - Btree
+    - Validate
   "Catalog":
     - Catalog
   "TTL":


### PR DESCRIPTION
## Description

Adds new component "Validate" to the changelog script 

Reason: Getting `undefined component Validate. update configuration before continuing` error when running the Script
