### PR TITLE
fix typo

### DIFF
--- a/content/manual/manual/source/reference/operator/aggregation/currentOp.txt
+++ b/content/manual/manual/source/reference/operator/aggregation/currentOp.txt
@@ -163,7 +163,7 @@ Syntax
 
        Boolean.  If set to ``true``, ``$currentOp`` outputs a document 
        for each data-bearing node for all shards.  If set to ``false``,
-       ``$curentOp`` outputs a document for each shard.
+       ``$currentOp`` outputs a document for each shard.
 
        For example, in a sharded cluster with three shards where each shard
        is a replica set with three nodes: 
@@ -1530,7 +1530,7 @@ relevant for the operation:
    -1 when a new resharding operation starts.
 
    Only present when a resharding operation is taking place. This 
-   field may not be present if an estimate cannot not be computed.
+   field may not be present if an estimate cannot be computed.
 
    .. versionadded:: 5.0
 
@@ -1554,7 +1554,7 @@ relevant for the operation:
 
 .. data:: $currentOp.documentsCopied
 
-   The number of documents copied form donor shards to recipient shards
+   The number of documents copied from donor shards to recipient shards
    during the :ref:`resharding operation <sharding-resharding>`. The
    number is set to 0 when a new resharding operation starts.
 


### PR DESCRIPTION
### what i have done

- $curentOp → $currentOp
- “cannot not be computed” → “cannot be computed”
- “copied form donor shards” → “from”