### PR TITLE
Add Middleware in Hosted Monitoring Tools List

### DIFF
--- a/source/administration/monitoring.txt
+++ b/source/administration/monitoring.txt
@@ -323,6 +323,10 @@ a paid subscription.
      - `Monitoring, Anomaly Detection and Alerting
        <https://sematext.com/spm/integrations/mongodb-monitoring/>`_ SPM monitors all key MongoDB metrics together with infrastructure incl. Docker and other application metrics, e.g. Node.js, Java, NGINX, Apache, HAProxy or Elasticsearch. SPM provides correlation of metrics and logs. 
 
+* - `Middleware <https://middleware.io/>`_
+
+     - `Track MongoDB instances <https://docs.middleware.io/integrations/mongodb-integration>`_ health and performance with real-time metrics, query insights and proactive alerts. 
+
 .. _stdout:
 .. _standard-output:
 .. _monitoring-standard-loggging:


### PR DESCRIPTION
Adds Middleware under the Hosted (SaaS) Monitoring Tools because it also provides MongoDB integrations for users to monitor their instances.