### PR TITLE
ci: declare workflow-level `contents: read` on lint-docs and openapi-tests

### DIFF
--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -8,6 +8,9 @@ on:
       - 'content/**/*.md'
       - 'content/**/*.mdx'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/openapi-tests.yml
+++ b/.github/workflows/openapi-tests.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - "code-example-tests/openapi/tests/**"
 
+permissions:
+  contents: read
+
 jobs:
   run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Both workflows do read-only validation (markdown lint, openapi spec tests). No GitHub API writes, so a workflow-level `contents: read` is the appropriate cap for the default `GITHUB_TOKEN`.

Other workflows in this repo that use `cache: pnpm` or have write-needing paths are intentionally untouched, since adding `contents: read` there would break the cache save without `actions: write` and that scope decision belongs to maintainers.

Same hardening shape as the post-CVE-2025-30066 response (`tj-actions/changed-files` compromise). YAML validated locally.