### PR TITLE
docs(create-index): align createIndex output with ascending index definition

### DIFF
--- a/content/manual/manual/source/core/indexes/create-index.txt
+++ b/content/manual/manual/source/core/indexes/create-index.txt
@@ -85,7 +85,7 @@ are currently being built, run the
 
       [
          { v: 2, key: { _id: 1 }, name: '_id_' },
-         { v: 2, key: { name: -1 }, name: 'name_-1' }
+         { v: 2, key: { name: 1 }, name: 'name_1' }
       ]    
 
 To check whether your index is building, use :pipeline:`$currentOp`


### PR DESCRIPTION
The existing example in the docs creates an ascending index with `{ name: 1 }`, 
```
collection.createIndex( { name : 1 }, function(err, result) {
  console.log(result);
  callback(result);
} )
```
But the resulting index list shows `{ name: -1 }`.

```
[
  { v: 2, key: { _id: 1 }, name: '_id_' },
  { v: 2, key: { name: -1 }, name: 'name_-1' }
]
```

This change updates the output example to `{ name: 1 }` so that it
matches the index definition and avoids confusion for readers.

**Updated**
```
[
  { v: 2, key: { _id: 1 }, name: '_id_' },
  { v: 2, key: { name: 1 }, name: 'name_1' }
]
```

