### PR TITLE
DOCSP-62088 move Laravel key generation

### DIFF
--- a/content/laravel-mongodb/current/source/get-started.txt
+++ b/content/laravel-mongodb/current/source/get-started.txt
@@ -132,7 +132,7 @@ dependencies to a Laravel web application.
          New to Laravel? Check out our bootcamp and documentation.
          Build something amazing!
 
-   .. step:: Add a Laravel application encryption key
+   .. step:: Add {+odm-long+} to the dependencies
 
       Navigate to the application directory you created in the previous
       step:
@@ -140,15 +140,6 @@ dependencies to a Laravel web application.
       .. code-block:: bash
 
          cd {+quickstart-app-name+}
-
-      Run the following command to add the Laravel application encryption
-      key, which is required to encrypt cookies:
-
-      .. code-block:: bash
-
-         php artisan key:generate
-
-   .. step:: Add {+odm-long+} to the dependencies
 
       Run the following command to add the {+odm-long+} dependency to
       your application:
@@ -279,6 +270,13 @@ Configure Your MongoDB Connection
       .. code-block:: sh
 
          cp .env.example .env
+
+      Run the following command to add the Laravel application encryption
+      key, which is required to encrypt cookies:
+
+      .. code-block:: bash
+
+         php artisan key:generate
 
       Open the ``.env`` file and add or edit the following variables
       and values. Replace the ``<connection string>`` placeholder with

--- a/content/laravel-mongodb/upcoming/source/get-started.txt
+++ b/content/laravel-mongodb/upcoming/source/get-started.txt
@@ -132,7 +132,7 @@ dependencies to a Laravel web application.
          New to Laravel? Check out our bootcamp and documentation.
          Build something amazing!
 
-   .. step:: Add a Laravel application encryption key
+   .. step:: Add {+odm-long+} to the dependencies
 
       Navigate to the application directory you created in the previous
       step:
@@ -140,15 +140,6 @@ dependencies to a Laravel web application.
       .. code-block:: bash
 
          cd {+quickstart-app-name+}
-
-      Run the following command to add the Laravel application encryption
-      key, which is required to encrypt cookies:
-
-      .. code-block:: bash
-
-         php artisan key:generate
-
-   .. step:: Add {+odm-long+} to the dependencies
 
       Run the following command to add the {+odm-long+} dependency to
       your application:
@@ -279,6 +270,13 @@ Configure Your MongoDB Connection
       .. code-block:: sh
 
          cp .env.example .env
+
+      Run the following command to add the Laravel application encryption
+      key, which is required to encrypt cookies:
+
+      .. code-block:: bash
+
+         php artisan key:generate
 
       Open the ``.env`` file and add or edit the following variables
       and values. Replace the ``<connection string>`` placeholder with


### PR DESCRIPTION
Move `php artisan key:generate` step after `cp .env.example .env` in [Get Started with Laravel MongoDB](https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/get-started/#create-a-laravel-application) to avoid overwriting the generated key.

See DOCSP-62088 for details.